### PR TITLE
Fix: Handle missing d<number> model tags in find_largest_model

### DIFF
--- a/nanochat/checkpoint_manager.py
+++ b/nanochat/checkpoint_manager.py
@@ -104,8 +104,8 @@ def find_largest_model(checkpoint_dir):
         candidates.sort(key=lambda x: x[0], reverse=True)
         return candidates[0][1]
     # 2) if that failed, take the most recently updated model:
-    candidates.sort(key=lambda x: os.path.getmtime(os.path.join(checkpoint_dir, x[1])), reverse=True)
-    return candidates[0][1]
+    model_tags.sort(key=lambda x: os.path.getmtime(os.path.join(checkpoint_dir, x)), reverse=True)
+    return model_tags[0]
 
 
 def find_last_step(checkpoint_dir):


### PR DESCRIPTION
What does this PR do?
This PR fixes a bug in the find_largest_model function in nanochat/checkpoint_manager.py. The bug caused an IndexError when attempting to load a model from a checkpoint directory that did not contain any models using the d<number> naming convention (e.g., d20, d26).

Why is this change needed?
The find_largest_model function is intended to have a fallback mechanism:
If no models with the d<number> naming scheme are found, it should fall back to selecting the most recently modified model checkpoint.

However, the fallback logic was broken and caused the program to crash instead. As a result, users couldn't load models that used custom naming schemes, significantly reducing the flexibility and usability of the application.

How was this change implemented?
The fallback logic was corrected by updating the way the function handles an empty list of d<number>-style models.
Instead of attempting to sort an empty list (which led to a crash), the code now correctly sorts the available model_tags list by modification time and returns the most recently modified one. This ensures compatibility with both conventionally and custom-named model checkpoints.