### PR TITLE
fuse qkv linear, qk rotary + norm

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -23,7 +23,6 @@ from nanochat.common import get_dist_info
 from nanochat.muon import Muon, DistMuon
 from nanochat.adamw import DistAdamW
 
-
 @dataclass
 class GPTConfig:
     sequence_len: int = 1024
@@ -48,7 +47,6 @@ def apply_rotary_emb(x, cos, sin):
     out = torch.cat([y1, y2], 3) # re-assemble
     out = out.to(x.dtype) # ensure input/output dtypes match
     return out
-
 
 class CausalSelfAttention(nn.Module):
     def __init__(self, config, layer_idx):


### PR DESCRIPTION
fewer kernel launches over larger data inputs --> improve MFU & TPS

Evaluate over shrunken model setup (1xA100, bs=4, depth=8, max_seq_len=128)

Baseline
```
Step 00000 | Validation bpb: 3.3018
step 00000/21400 (0.00%) | loss: 11.090355 | lrm: 1.00 | dt: 73663.02ms | tok/sec: 6 | mfu: 2.09 | total time: 0.00m
step 00001/21400 (0.00%) | loss: 10.850858 | lrm: 1.00 | dt: 23142.06ms | tok/sec: 22 | mfu: 6.65 | total time: 0.00m
step 00002/21400 (0.01%) | loss: 10.362000 | lrm: 1.00 | dt: 23166.57ms | tok/sec: 22 | mfu: 6.64 | total time: 0.00m
step 00003/21400 (0.01%) | loss: 9.586880 | lrm: 1.00 | dt: 23746.88ms | tok/sec: 21 | mfu: 6.48 | total time: 0.00m
step 00004/21400 (0.02%) | loss: 8.999461 | lrm: 1.00 | dt: 23136.88ms | tok/sec: 22 | mfu: 6.65 | total time: 0.00m
step 00005/21400 (0.02%) | loss: 8.439834 | lrm: 1.00 | dt: 23135.50ms | tok/sec: 22 | mfu: 6.65 | total time: 0.00m
step 00006/21400 (0.03%) | loss: 8.383724 | lrm: 1.00 | dt: 23128.97ms | tok/sec: 22 | mfu: 6.65 | total time: 0.00m
step 00007/21400 (0.03%) | loss: 8.218992 | lrm: 1.00 | dt: 23558.79ms | tok/sec: 21 | mfu: 6.53 | total time: 0.00m
step 00008/21400 (0.04%) | loss: 8.068848 | lrm: 1.00 | dt: 23096.62ms | tok/sec: 22 | mfu: 6.66 | total time: 0.00m
step 00009/21400 (0.04%) | loss: 7.858495 | lrm: 1.00 | dt: 23147.27ms | tok/sec: 22 | mfu: 6.65 | total time: 0.00m
step 00010/21400 (0.05%) | loss: 7.647767 | lrm: 1.00 | dt: 23138.90ms | tok/sec: 22 | mfu: 6.65 | total time: 0.00m
step 00011/21400 (0.05%) | loss: 7.520364 | lrm: 1.00 | dt: 23471.63ms | tok/sec: 21 | mfu: 6.55 | total time: 0.39m
step 00012/21400 (0.06%) | loss: 7.313815 | lrm: 1.00 | dt: 23137.73ms | tok/sec: 22 | mfu: 6.65 | total time: 0.78m
step 00013/21400 (0.06%) | loss: 7.209348 | lrm: 1.00 | dt: 23131.34ms | tok/sec: 22 | mfu: 6.65 | total time: 1.16m
step 00014/21400 (0.07%) | loss: 7.077872 | lrm: 1.00 | dt: 23137.14ms | tok/sec: 22 | mfu: 6.65 | total time: 1.55m
step 00015/21400 (0.07%) | loss: 6.972244 | lrm: 1.00 | dt: 23493.17ms | tok/sec: 21 | mfu: 6.55 | total time: 1.94m
step 00016/21400 (0.07%) | loss: 6.877245 | lrm: 1.00 | dt: 23103.08ms | tok/sec: 22 | mfu: 6.66 | total time: 2.32m
step 00017/21400 (0.08%) | loss: 6.790990 | lrm: 1.00 | dt: 23154.66ms | tok/sec: 22 | mfu: 6.64 | total time: 2.71m
step 00018/21400 (0.08%) | loss: 6.719249 | lrm: 1.00 | dt: 23125.35ms | tok/sec: 22 | mfu: 6.65 | total time: 3.10m
step 00019/21400 (0.09%) | loss: 6.646377 | lrm: 1.00 | dt: 23550.10ms | tok/sec: 21 | mfu: 6.53 | total time: 3.49m
step 00020/21400 (0.09%) | loss: 6.697980 | lrm: 1.00 | dt: 23114.26ms | tok/sec: 22 | mfu: 6.66 | total time: 3.87m
```

With PR
```
Step 00000 | Validation bpb: 3.3018
step 00000/21400 (0.00%) | loss: 11.090355 | lrm: 1.00 | dt: 68833.55ms | tok/sec: 7 | mfu: 2.23 | total time: 0.00m
step 00001/21400 (0.00%) | loss: 10.850858 | lrm: 1.00 | dt: 22158.20ms | tok/sec: 23 | mfu: 6.94 | total time: 0.00m
step 00002/21400 (0.01%) | loss: 10.362043 | lrm: 1.00 | dt: 22153.80ms | tok/sec: 23 | mfu: 6.94 | total time: 0.00m
step 00003/21400 (0.01%) | loss: 9.586792 | lrm: 1.00 | dt: 22094.94ms | tok/sec: 23 | mfu: 6.96 | total time: 0.00m
step 00004/21400 (0.02%) | loss: 9.001559 | lrm: 1.00 | dt: 22130.74ms | tok/sec: 23 | mfu: 6.95 | total time: 0.00m
step 00005/21400 (0.02%) | loss: 8.443194 | lrm: 1.00 | dt: 22124.07ms | tok/sec: 23 | mfu: 6.95 | total time: 0.00m
step 00006/21400 (0.03%) | loss: 8.387075 | lrm: 1.00 | dt: 22102.40ms | tok/sec: 23 | mfu: 6.96 | total time: 0.00m
step 00007/21400 (0.03%) | loss: 8.226027 | lrm: 1.00 | dt: 22119.10ms | tok/sec: 23 | mfu: 6.95 | total time: 0.00m
step 00008/21400 (0.04%) | loss: 8.078289 | lrm: 1.00 | dt: 22144.72ms | tok/sec: 23 | mfu: 6.95 | total time: 0.00m
step 00009/21400 (0.04%) | loss: 7.866694 | lrm: 1.00 | dt: 22137.93ms | tok/sec: 23 | mfu: 6.95 | total time: 0.00m
step 00010/21400 (0.05%) | loss: 7.656322 | lrm: 1.00 | dt: 22161.74ms | tok/sec: 23 | mfu: 6.94 | total time: 0.00m
step 00011/21400 (0.05%) | loss: 7.530898 | lrm: 1.00 | dt: 22141.65ms | tok/sec: 23 | mfu: 6.95 | total time: 0.37m
step 00012/21400 (0.06%) | loss: 7.326664 | lrm: 1.00 | dt: 22148.05ms | tok/sec: 23 | mfu: 6.95 | total time: 0.74m
step 00013/21400 (0.06%) | loss: 7.241962 | lrm: 1.00 | dt: 22130.97ms | tok/sec: 23 | mfu: 6.95 | total time: 1.11m
step 00014/21400 (0.07%) | loss: 7.113908 | lrm: 1.00 | dt: 22088.70ms | tok/sec: 23 | mfu: 6.96 | total time: 1.48m
step 00015/21400 (0.07%) | loss: 7.006810 | lrm: 1.00 | dt: 22090.82ms | tok/sec: 23 | mfu: 6.96 | total time: 1.84m
step 00016/21400 (0.07%) | loss: 6.912732 | lrm: 1.00 | dt: 22170.08ms | tok/sec: 23 | mfu: 6.94 | total time: 2.21m
step 00017/21400 (0.08%) | loss: 6.823814 | lrm: 1.00 | dt: 22627.94ms | tok/sec: 22 | mfu: 6.80 | total time: 2.59m
step 00018/21400 (0.08%) | loss: 6.755755 | lrm: 1.00 | dt: 22030.29ms | tok/sec: 23 | mfu: 6.98 | total time: 2.96m
step 00019/21400 (0.09%) | loss: 6.672474 | lrm: 1.00 | dt: 22158.33ms | tok/sec: 23 | mfu: 6.94 | total time: 3.33m
step 00020/21400 (0.09%) | loss: 6.719924 | lrm: 1.00 | dt: 22172.56ms | tok/sec: 23 | mfu: 6.94 | total time: 3.70m
```
