### PR TITLE
[FIX] export env variable in speedrun.sh

### DIFF
--- a/speedrun.sh
+++ b/speedrun.sh
@@ -12,7 +12,7 @@
 
 # Default intermediate artifacts directory is in ~/.cache/nanochat
 export OMP_NUM_THREADS=1
-NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
+export NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
 mkdir -p $NANOCHAT_BASE_DIR
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
turbo nit, but `dataset.py` will use the incorrect location if this bash variable is not exported beyond the script. 