### PR TITLE
add modular imports to the init

### DIFF
--- a/nanochat/__init__.py
+++ b/nanochat/__init__.py
@@ -1,0 +1,33 @@
+# Import all submodules used by scripts
+from . import common
+from . import tokenizer
+from . import checkpoint_manager
+from . import core_eval
+from . import gpt
+from . import dataloader
+from . import loss_eval
+from . import engine
+from . import dataset
+from . import report
+from . import adamw
+from . import muon
+from . import configurator
+from . import execution
+
+# Make submodules available
+__all__ = [
+    "common",
+    "tokenizer",
+    "checkpoint_manager",
+    "core_eval",
+    "gpt",
+    "dataloader",
+    "loss_eval",
+    "engine",
+    "dataset",
+    "report",
+    "adamw",
+    "muon",
+    "configurator",
+    "execution",
+]


### PR DESCRIPTION
This PR add modular imports to nanochat's `__init__` this will allow users to use nanochat code without relative imports. For example:

```python
from nanochat.tokenizer import RustBPETokenizer

tokenizer = RustBPETokenizer.from_directory(tokenizer_dir="tokenizer")
```

I have copied the same usage as `scripts` to avoid having to change any further code. 