### PR TITLE
Export the cache directory so that users can use their own cache location

### DIFF
--- a/speedrun.sh
+++ b/speedrun.sh
@@ -12,7 +12,7 @@
 
 # Default intermediate artifacts directory is in ~/.cache/nanochat
 export OMP_NUM_THREADS=1
-NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
+export NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
 mkdir -p $NANOCHAT_BASE_DIR
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Thanks so much for making this! I run a nonstandard data setup so I need my data in a custom `/mnt` folder. When I tried changing the cache dir I found it didn't propagate unless we did `export` first which is what I've done here. 

Thanks for considering!