### PR TITLE
add support for mps (Metal Performance Shaders) in web and cli to enable GPU accelerated inference on Macs

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -98,7 +98,7 @@ def compute_init(device_type="cuda"):
     # Reproducibility
     torch.manual_seed(42)
     if device_type == "cuda":
-    torch.cuda.manual_seed(42)
+        torch.cuda.manual_seed(42)
     elif device_type == "mps":
         torch.mps.manual_seed(42)
     # skipping full reproducibility for now, possibly investigate slowdown later

--- a/scripts/chat_cli.py
+++ b/scripts/chat_cli.py
@@ -17,7 +17,7 @@ parser.add_argument('-s', '--step', type=int, default=None, help='Step to load')
 parser.add_argument('-p', '--prompt', type=str, default='', help='Prompt the model, get a single response back')
 parser.add_argument('-t', '--temperature', type=float, default=0.6, help='Temperature for generation')
 parser.add_argument('-k', '--top-k', type=int, default=50, help='Top-k sampling parameter')
-parser.add_argument('-d', '--device', type=str, default='cuda', help='Device to run the model on: cuda|mps')
+parser.add_argument('-d', '--device', type=str, default='cuda', choices=['mps', 'cuda'], help='Device to run the model on: cuda|mps')
 
 args = parser.parse_args()
 

--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -29,7 +29,7 @@ parser.add_argument('-g', '--model-tag', type=str, default=None, help='Model tag
 parser.add_argument('-s', '--step', type=int, default=None, help='Step to load')
 parser.add_argument('-p', '--port', type=int, default=8000, help='Port to run the server on')
 parser.add_argument('--host', type=str, default='0.0.0.0', help='Host to bind the server to')
-parser.add_argument('-d', '--device', type=str, default='cuda', help='Device to run the model on: cuda|mps')
+parser.add_argument('-d', '--device', type=str, default='cuda', choices=['mps', 'cuda'], help='Device to run the model on: cuda|mps')
 args = parser.parse_args()
 
 ddp, ddp_rank, ddp_local_rank, ddp_world_size, device = compute_init(args.device)


### PR DESCRIPTION
Hi ! nice project.
I made some small changes so you can instruct torch to use MPS ( https://docs.pytorch.org/docs/stable/notes/mps.html ) instead of Cuda to enable accelerated inference on Macs
I added an extra argument (-d) to the web and cli script to support device selection.