### PR TITLE
Add hf-transfer dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "torch>=2.8.0",
     "uvicorn>=0.36.0",
     "wandb>=0.21.3",
+    "hf-transfer>=0.1.9",
 ]
 
 [build-system]


### PR DESCRIPTION
to fix error after pre-training stage

```bash
[rank0]: ValueError: Fast download using 'hf_transfer' is enabled (HF_HUB_ENABLE_HF_TRANSFER=1) but 'hf_transfer' package is not available in your environment. Try `pip install hf_transfer`.
```
originating from [tasks/smoltalk.py](https://github.com/karpathy/nanochat/blob/67aaca98f53a6db9f1f5a2a62893f98d443a090a/tasks/smoltalk.py#L16)
```python
self.ds = load_dataset("HuggingFaceTB/smol-smoltalk", split=split).shuffle(seed=42)
```