### PR TITLE
Refactor apply_rotary_emb function to clarify dimension handling

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -40,7 +40,7 @@ def norm(x):
 
 def apply_rotary_emb(x, cos, sin):
     assert x.ndim == 4  # multihead attention
-    d = x.shape[3] // 2
+    d = x.shape[-1] // 2 #always refers to the last dimension.
     x1, x2 = x[..., :d], x[..., d:] # split up last time into two halves
     y1 = x1 * cos + x2 * sin # rotate pairs of dims
     y2 = x1 * (-sin) + x2 * cos


### PR DESCRIPTION
Updated the calculation of the split dimension in apply_rotary_emb to always refer to the last dimension of the input tensor.

x.shape[3] explicitly assumes the tensor always has exactly 4 dimensions, and the last one is at index 3. Using x.shape[-1] always refers to the last dimension, regardless of how many dimensions come before it.