### PR TITLE
Fix: Add colorama for cross-platform colored output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "torch>=2.8.0",
     "uvicorn>=0.36.0",
     "wandb>=0.21.3",
+    "colorama>=0.4.6",
 ]
 
 [build-system]

--- a/scripts/tok_eval.py
+++ b/scripts/tok_eval.py
@@ -2,6 +2,9 @@
 Evaluate compression ratio of the tokenizer.
 """
 
+import colorama
+colorama.init()
+
 from nanochat.tokenizer import get_tokenizer, RustBPETokenizer
 from nanochat.dataset import parquets_iter_batched
 
@@ -263,3 +266,5 @@ report_markdown = "\n".join(lines)
 get_report().log(section="Tokenizer evaluation", data=[
     report_markdown,
 ])
+
+colorama.deinit()


### PR DESCRIPTION
The script uses ANSI escape sequences for color, which are not natively supported by all terminals, particularly on Windows. This can result in a poor user experience, with escape characters being displayed instead of colored text.

To address this, this PR introduces the colorama library, a standard solution for cross-platform colored terminal text in Python.

The changes in this pull request include:
 * Adding colorama as a dependency in pyproject.toml.
 * Initializing colorama at the beginning of the tok_eval.py script.
 * De-initializing colorama at the end of the tok_eval.py script.

These changes ensure that the script's output is correctly displayed on all platforms, improving the user experience and cross-platform compatibility of the project.