### PR TITLE
remove unused initialization of rotary embeddings

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -180,10 +180,6 @@ class GPT(nn.Module):
         for block in self.transformer.h:
             torch.nn.init.zeros_(block.mlp.c_proj.weight)
             torch.nn.init.zeros_(block.attn.c_proj.weight)
-        # init the rotary embeddings
-        head_dim = self.config.n_embd // self.config.n_head
-        cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
-        self.cos, self.sin = cos, sin
 
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):


### PR DESCRIPTION
Fixed redundant reinitialization of `cos ` and `sin `buffers in `init_weights()`.
These buffers are already registered during model setup, so the extra initialization call was removed for cleaner weight initialization.