### PR TITLE
Remove redundant exception handling in chdir

### DIFF
--- a/nanochat/execution.py
+++ b/nanochat/execution.py
@@ -127,8 +127,6 @@ def chdir(root):
     os.chdir(root)
     try:
         yield
-    except BaseException as exc:
-        raise exc
     finally:
         os.chdir(cwd)
 


### PR DESCRIPTION
Catching and raising has no effect here. If an exception is raised, the `finally` will be executed and the exception will propagate upwards automatically.