### PR TITLE
Enable Proxy/Gateway Compatibility via Uvicorn's --root-path

### DIFF
--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -70,7 +70,7 @@ parser.add_argument('-g', '--model-tag', type=str, default=None, help='Model tag
 parser.add_argument('-s', '--step', type=int, default=None, help='Step to load')
 parser.add_argument('-p', '--port', type=int, default=8000, help='Port to run the server on')
 parser.add_argument('--host', type=str, default='0.0.0.0', help='Host to bind the server to')
-parser.add_argument('--root-path', type=str, default='', help='ASGI root path for proxy/gateway configurations.')
+parser.add_argument('--root-path', type=str, default='', help='ASGI root path for proxy/gateway configurations')
 args = parser.parse_args()
 
 # Configure logging for conversation traffic
@@ -226,25 +226,18 @@ app.add_middleware(
 
 @app.get("/")
 async def root(request: Request):
-    """
-    Serve the chat UI, dynamically injecting the proxy path.
-    """
+    """Serve the chat UI, dynamically injecting the proxy path."""
     ui_html_path = os.path.join("nanochat", "ui.html")
     with open(ui_html_path, "r") as f:
         html_content = f.read()
 
     # Get the prefix provided by the proxy/ASGI server.
-    proxy_prefix = request.scope.get('root_path', '') 
-
-    # Strip trailing slash if present
-    if proxy_prefix.endswith('/'):
-        proxy_prefix = proxy_prefix.rstrip('/')
+    proxy_prefix = request.scope.get('root_path', '').rstrip('/')
 
     html_content = html_content.replace(
         "const API_URL = '';",
         f"const API_URL = '{proxy_prefix}';"
     )
-
     return HTMLResponse(content=html_content)
 
 @app.get("/logo.svg")
@@ -406,8 +399,4 @@ if __name__ == "__main__":
     import uvicorn
     print(f"Starting NanoChat Web Server")
     print(f"Temperature: {args.temperature}, Top-k: {args.top_k}, Max tokens: {args.max_tokens}")
-    uvicorn.run(app, 
-        host=args.host, 
-        port=args.port,
-        root_path=args.root_path
-    )
+    uvicorn.run(app, host=args.host, port=args.port, root_path=args.root_path)


### PR DESCRIPTION
Description:

This PR implements the standard solution for deploying FastAPI behind proxies (like Jupyter tunnels, Nginx, etc.) where the public access URL contains a path prefix that is not part of the application itself.

Problem:

When deployed to an environment that forwards requests (e.g., from /notebook/user/proxy/8000/chat/completions to /chat/completions), the client-side API calls were failing with a 404 Not Found. This occurred because the browser didn't know the proxy prefix and was incorrectly calling /chat/completions relative to the domain root. The server was unable to determine the necessary prefix automatically.

Solution:

Configuration: Added the standard --root-path argument to argparse and passed it to uvicorn.run(). This allows users to launch the server with the required public prefix (e.g., python chat_web.py --root-path "/my/proxy/path").

ASGI Compliance: When --root-path is provided, Uvicorn correctly sets the request.scope['root_path'] variable for every incoming request, making the proxy prefix available to the application.

Dynamic UI Fix: The @app.get("/") endpoint now reads this root_path and injects it into the client's API_URL variable, ensuring all subsequent API calls are correctly prefixed and routed through the gateway.