### PR TITLE
export NANOCHAT_BASE_DIR so child processes get it too

### DIFF
--- a/run1000.sh
+++ b/run1000.sh
@@ -4,7 +4,7 @@
 
 # all the setup stuff
 export OMP_NUM_THREADS=1
-NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
+export NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
 mkdir -p $NANOCHAT_BASE_DIR
 command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
 [ -d ".venv" ] || uv venv


### PR DESCRIPTION
Similar to #48 but for the run1000.sh script.