### PR TITLE
Fix a memory leak and incorrect sort in rustbpe

### DIFF
--- a/rustbpe/src/lib.rs
+++ b/rustbpe/src/lib.rs
@@ -116,7 +116,7 @@ impl Ord for MergeJob {
             self.count.cmp(&other.count)
         } else {
             // ascending order on the pair when counts tie
-            other.pair.cmp(&self.pair)
+            self.pair.cmp(&other.pair)
         }
     }
 }
@@ -292,8 +292,7 @@ impl Tokenizer {
 
         // Prepare a true Python iterator object
         let py_iter: pyo3::Py<pyo3::PyAny> = unsafe {
-            pyo3::Bound::from_borrowed_ptr_or_err(py, pyo3::ffi::PyObject_GetIter(iterator.as_ptr()))?
-                .into()
+            pyo3::Py::from_owned_ptr_or_err(py, pyo3::ffi::PyObject_GetIter(iterator.as_ptr()))?
         };
 
         // Global chunk counts


### PR DESCRIPTION
I came across this while reading the rustbpe sources.

This fixes a memory leak on the iterator (`PyObject_GetIter` returns an owned references) and what I believe to be a bug in the tie-braker sort.  At least the comment implies that it would work the other way round.