### PR TITLE
[TOML] cpu only install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,14 @@ python_functions = ["test_*"]
 # target torch to cuda 12.8
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cu128", marker = "platform_system == 'linux'"},
+  { index = "pytorch-cpu", marker = "sys_platform != 'linux'" },
+  { index = "pytorch-cu128", marker = "sys_platform == 'linux'" },
 ]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [[tool.uv.index]]
 name = "pytorch-cu128"


### PR DESCRIPTION
This PR updtes the TOML to check for linux then expose the cu128 index. This is based on [uv docs](https://docs.astral.sh/uv/guides/integration/pytorch/#configuring-accelerators-with-environment-markers) and does not require any declaration, just `uv sync`.

The intended result it:
- defaults to cu128
- installs on torch-cpu on mac

This doesn't specify for cpu on linux, but I uv's index manager will solve that. 