### PR TITLE
Add GitHub Workflow for Dependency Installation and Pytest Execution

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -36,6 +36,7 @@ jobs:
 
     - name: Install dependencies with uv
       run: |
+        uv pip install transformers>=4.0.0
         uv pip install . --system
 
     - name: Add nanochat to PYTHONPATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "tiktoken>=0.11.0",
     "tokenizers>=0.22.0",
     "torch>=2.8.0",
-    "transformers>=4.0.0",
     "uvicorn>=0.36.0",
     "wandb>=0.21.3",
 ]


### PR DESCRIPTION
Summary:
This pull request introduces the following improvements to the nanochat project:
1- GitHub Actions Workflow:
- Added a workflow to automate testing. [I needed to add `dev` in addition to  `master` to be able to see if it is running ]
- Ensures all required dependencies, including pytest, are installed using uv and pip.
- tests with pytest
- Added caching while building with pip since it takes a while otherwise to optimize workflow execution time.

2 - CPU Fallback in compute_init:
- Updated the compute_init function to allow fallback to CPU when CUDA is not available.
This hopefully will ensure compatibility in environments without GPU support, such as GitHub Actions runners.
I wanted to provide a minimal GH workflow that will test any issues during installation process and while testing with pytest (so far for ubuntu only)
