### PR TITLE
[FIX] run cpu when num_fewshot is greater than data

### DIFF
--- a/nanochat/core_eval.py
+++ b/nanochat/core_eval.py
@@ -174,7 +174,7 @@ def evaluate_example(idx, model, tokenizer, data, device, task_meta):
 
     # Sample few-shot examples (excluding current item)
     fewshot_examples = []
-    if num_fewshot > 0:
+    if num_fewshot > 0 and len(data) > num_fewshot:
         rng = random.Random(1234 + idx)
         available_indices = [i for i in range(len(data)) if i != idx]
         fewshot_indices = rng.sample(available_indices, num_fewshot)


### PR DESCRIPTION
When running `bash dev/runcpu.sh` I get this error. This is because `num_fewshot > len(data)`

```sh
Evaluating: hellaswag_zeroshot (0-shot, type: multiple_choice)... accuracy: 0.2000 | centered: -0.0667 | time: 0.26s
Traceback (most recent call last):
  File "/Users/ben/.local/share/uv/python/cpython-3.10.15-macos-aarch64-none/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/ben/.local/share/uv/python/cpython-3.10.15-macos-aarch64-none/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/ben/code/nanochat/scripts/base_eval.py", line 186, in <module>
    main()
  File "/Users/ben/code/nanochat/scripts/base_eval.py", line 149, in main
    out = evaluate_model(model, tokenizer, device, max_per_task=args.max_per_task)
  File "/Users/ben/code/nanochat/scripts/base_eval.py", line 75, in evaluate_model
    accuracy = evaluate_task(model, tokenizer, data, device, task_meta)
  File "/Users/ben/code/nanochat/nanochat/core_eval.py", line 254, in evaluate_task
    is_correct = evaluate_example(idx, model, tokenizer, data, device, task_meta)
  File "/Users/ben/code/nanochat/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/Users/ben/code/nanochat/nanochat/core_eval.py", line 180, in evaluate_example
    fewshot_indices = rng.sample(available_indices, num_fewshot)
  File "/Users/ben/.local/share/uv/python/cpython-3.10.15-macos-aarch64-none/lib/python3.10/random.py", line 482, in sample
    raise ValueError("Sample larger than population or is negative")
ValueError: Sample larger than population or is negative

```

