### PR TITLE
fix(ui): prevent iOS Safari toolbar from covering input on initial load

### DIFF
--- a/nanochat/ui.html
+++ b/nanochat/ui.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>NanoChat</title>
     <link rel="icon" type="image/svg+xml" href="/logo.svg">
     <style>
@@ -18,7 +18,7 @@
             font-family: ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
             background-color: #ffffff;
             color: #111827;
-            min-height: 100vh;
+            min-height: 100dvh;
             margin: 0;
             display: flex;
             flex-direction: column;
@@ -144,6 +144,7 @@
         .input-container {
             background-color: #ffffff;
             padding: 1rem;
+            padding-bottom: calc(1rem + env(safe-area-inset-bottom))
         }
 
         .input-wrapper {


### PR DESCRIPTION
**Problem**  

On ios safari, the bottom toolbar overlapped the chat input on initial page load. Part of the input was hidden until you scrolled down a bit. A small but annoying quirk thats fixable with just a few css tweaks. 

**Before**  

![90F4BBF3-3791-4A1C-A6F0-9F75398AB08B_1_201_a](https://github.com/user-attachments/assets/ede9d06d-5ead-40c9-ae08-b970db73fc1d)

**After**  

![B50F4E1B-023E-44D9-9582-DA4344112070_1_201_a](https://github.com/user-attachments/assets/43179236-6fa0-44e5-a1a1-b34892a9a04d)

**Fix**  

- add `viewport-fit=cover` to let the layout extend into the ios safe area  
- switch `min-height: 100vh` → `100dvh` to use the dynamic viewport height, which updates correctly when safari shows or hides its ui  
- add `padding-bottom: calc(1rem + env(safe-area-inset-bottom))` so the input container always sits above the toolbar and respects the safe-area inset  

**Result**  

Input stays above above the toolbar on load.