### PR TITLE
FEAT: Allow CPU-only execution in compute_init

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -100,14 +100,21 @@ def autodetect_device_type():
     print0(f"Autodetected device type: {device_type}")
     return device_type
 
-def compute_init(device_type="cuda"): # cuda|cpu|mps
+def compute_init(device_type=None): # cuda|cpu|mps
     """Basic initialization that we keep doing over and over, so make common."""
+
+    # Determine device
+    if os.environ.get("NANOCHAT_DEVICE"):
+        device_type = os.environ.get("NANOCHAT_DEVICE")
+    elif device_type is None:
+        device_type = autodetect_device_type()
 
     assert device_type in ["cuda", "mps", "cpu"], "Invalid device type atm"
     if device_type == "cuda":
         assert torch.cuda.is_available(), "Your PyTorch installation is not configured for CUDA but device_type is 'cuda'"
     if device_type == "mps":
         assert torch.backends.mps.is_available(), "Your PyTorch installation is not configured for MPS but device_type is 'mps'"
+    device = torch.device(device_type)
 
     # Reproducibility
     torch.manual_seed(42)


### PR DESCRIPTION
Modified compute_init in nanochat/common.py to allow for CPU-only execution by checking the NANOCHAT_DEVICE environment variable. This enhances flexibility and hackability, aligning with the project's goals of accessibility.