### PR TITLE
harden eval: prevent the calc tool from accessing globals and locals

### DIFF
--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -37,7 +37,7 @@ def eval_with_timeout(formula, max_time=3):
         with timeout(max_time, formula):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", SyntaxWarning)
-                return eval(formula)
+                return eval(formula, {"__builtins__": {}}, {})
     except Exception as e:
         signal.alarm(0)
         # print(f"Warning: Failed to eval {formula}, exception: {e}") # it's ok ignore wrong calculator usage


### PR DESCRIPTION
By passing empty `globals` and `locals` dicts to `eval()` we can prevent simple malicious cases where the user gets the model to output something like

```<|python_start|><global variable/func> or 'dummy'.count('a')<|python_end|>```
e.g.
```<|python_start|>signal.raise_signal(9) or 'dummy'.count('a')<|python_end|>``` 
which would kill the process or one could maybe get it to output secrets etc. 
Because without this change the `eval()` does not set `globals` namespace which means it gets set to the value returned by `globals()` which is not what we want - the calculator tool can access all python function/builtins/imported modules...

I think to make it 100% secure one would need to parse the AST and only execute secure nodes but this should make it much more robust.