### PR TITLE
Fix tok/sec metrics for base_train and mid_train when gradient accumulation is not 1

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -294,7 +294,7 @@ for step in range(num_iterations + 1):
     smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss.item() # EMA the training loss
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1)) # debias the EMA
     pct_done = 100 * step / num_iterations
-    tok_per_sec = int(world_tokens_per_fwdbwd / dt)
+    tok_per_sec = int(total_batch_size / dt)
     flops_per_sec = num_flops_per_token * total_batch_size / dt
     promised_flops_per_sec_h100 = 989e12 * ddp_world_size # bfloat16 H100 SXM and without 2:4 sparsity
     mfu = 100 * flops_per_sec / promised_flops_per_sec_h100 # in %

--- a/scripts/mid_train.py
+++ b/scripts/mid_train.py
@@ -268,7 +268,7 @@ while True:
     smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss.item() # EMA the training loss
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1)) # debias the EMA
     pct_done = 100 * progress
-    tok_per_sec = int(world_tokens_per_fwdbwd / dt)
+    tok_per_sec = int(total_batch_size / dt)
     flops_per_sec = num_flops_per_token * total_batch_size / dt
     promised_flops_per_sec_h100 = 989e12 * ddp_world_size # bfloat16 H100 SXM and without 2:4 sparsity
     mfu = 100 * flops_per_sec / promised_flops_per_sec_h100 # in %


### PR DESCRIPTION
Currently, when`grad_accum_steps` is not 1, the reported tokens-per-second (tok/sec) metric is incorrect. The issue arises because `world_tokens_per_fwdbwd` represents the number of tokens per step, while `dt `measures the total time for all gradient accumulation steps. As a result, the reported tok/sec value is underestimated by a factor of `1/grad_accum_steps`.

The fix is to replace `world_tokens_per_fwdbwd` with `total_batch_size` when computing tok/sec. Notably, the subsequent line
```python
flops_per_sec = num_flops_per_token * total_batch_size / dt
```
already uses total_batch_size correctly.