### PR TITLE
Fix kv cache, given resize will destroys the logical structure

### DIFF
--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -139,6 +139,7 @@ class KVCache:
             additional_shape[4] = t_needed - self.kv_cache.size(4)
             additional_cache = torch.empty(additional_shape, dtype=k.dtype, device=k.device)
             self.kv_cache = torch.cat([self.kv_cache, additional_cache], dim=4).contiguous()
+            self.kv_shape = self.kv_cache.shape
         # Insert k, v into the cache
         self.kv_cache[layer_idx, 0, :, :, t0:t1] = k
         self.kv_cache[layer_idx, 1, :, :, t0:t1] = v


### PR DESCRIPTION
observed when growing the cache, the higher layer's cache will be cleared when using `self.kv_cache.resize_`

original code:
```python
        # Dynamically grow the cache if needed
        if t1 > self.kv_cache.size(4):
            t_needed = t1 + 1024 # as much as we need plus buffer of 1024
            t_needed = (t_needed + 1023) & ~1023 # then round up to the nearest multiple of 1024
            current_shape = list(self.kv_cache.shape)
            current_shape[4] = t_needed
            self.kv_cache.resize_(current_shape)
```

the `resize_` does not keep the logical structure of the tensor, see the following example:
```python
kv_cache_internal = torch.rand(2, 2, 1, 1, 2, 2, dtype=torch.float32, device='cuda')
```
```
tensor([[[[[[0.5962, 0.3126],
            [0.6887, 0.8604]]]],

         [[[[0.6763, 0.1150],
            [0.6101, 0.8032]]]]],

        [[[[[0.2981, 0.0287],
            [0.3910, 0.3979]]]],

         [[[[0.0843, 0.1437],
            [0.4670, 0.8548]]]]]], device='cuda:0')
```
resize from sequence of 2 to sequence of 4:
```python
kv_cache_internal.resize_(2, 2, 1, 1, 4, 2)
```
```
tensor([[[[[[ 0.5962,  0.3126],
            [ 0.6887,  0.8604],
            [ 0.6763,  0.1150],
            [ 0.6101,  0.8032]]]],

         [[[[ 0.2981,  0.0287],
            [ 0.3910,  0.3979],
            [ 0.0843,  0.1437],
            [ 0.4670,  0.8548]]]]],

        [[[[[ 0.0116, -0.0144],
            [ 0.0227,  0.0281],
            [-0.0155,  0.0046],
            [-0.0109,  0.0133]]]],

         [[[[-0.0147, -0.0249],
            [-0.0022,  0.0162],
            [-0.0121, -0.0166],
            [ 0.0230,  0.0247]]]]]], device='cuda:0')
```
the previous 2 layers of cache value will be moved to the 1 layer due to resize_

So instead of using `resize_`, I am thinking to use `torch.cat([previous, new_allocated], dim=-2)` to grow cache

test the code:
```python
batch_size = 1
num_heads = 2
seq_len = 2
head_dim = 4
num_layers = 2
test_kv_cache = KVCache(batch_size, num_heads, seq_len, head_dim, num_layers)
key_size_2 = torch.rand(batch_size, num_heads, seq_len, head_dim, dtype=torch.float32, device='cuda')
value_size_2 = torch.rand(batch_size, num_heads, seq_len, head_dim, dtype=torch.float32, device='cuda')
[test_kv_cache.insert_kv(layer_idx, key_size_2, value_size_2) for layer_idx in range(num_layers)] 
```
```
[(tensor([[[[0.5142, 0.1259, 0.1527, 0.3710],
            [0.8059, 0.7397, 0.9953, 0.3557]],
  
           [[0.4287, 0.4321, 0.7932, 0.5813],
            [0.3779, 0.4701, 0.1192, 0.4625]]]], device='cuda:0'),
  tensor([[[[0.8371, 0.2664, 0.2173, 0.4084],
            [0.8637, 0.2964, 0.4995, 0.8014]],
  
           [[0.6989, 0.4583, 0.1503, 0.1996],
            [0.4704, 0.9786, 0.0212, 0.8056]]]], device='cuda:0')),
 (tensor([[[[0.5142, 0.1259, 0.1527, 0.3710],
            [0.8059, 0.7397, 0.9953, 0.3557]],
  
           [[0.4287, 0.4321, 0.7932, 0.5813],
            [0.3779, 0.4701, 0.1192, 0.4625]]]], device='cuda:0'),
  tensor([[[[0.8371, 0.2664, 0.2173, 0.4084],
            [0.8637, 0.2964, 0.4995, 0.8014]],
  
           [[0.6989, 0.4583, 0.1503, 0.1996],
            [0.4704, 0.9786, 0.0212, 0.8056]]]], device='cuda:0'))]
```

```python
# insert again, the internal cache size will grow
[test_kv_cache.insert_kv(layer_idx, key_size_2, value_size_2) for layer_idx in range(num_layers)] 
```
result expected:
```
[(tensor([[[[0.5142, 0.1259, 0.1527, 0.3710],
            [0.8059, 0.7397, 0.9953, 0.3557],
            [0.5142, 0.1259, 0.1527, 0.3710],
            [0.8059, 0.7397, 0.9953, 0.3557]],
  
           [[0.4287, 0.4321, 0.7932, 0.5813],
            [0.3779, 0.4701, 0.1192, 0.4625],
            [0.4287, 0.4321, 0.7932, 0.5813],
            [0.3779, 0.4701, 0.1192, 0.4625]]]], device='cuda:0'),
  tensor([[[[0.8371, 0.2664, 0.2173, 0.4084],
            [0.8637, 0.2964, 0.4995, 0.8014],
            [0.8371, 0.2664, 0.2173, 0.4084],
            [0.8637, 0.2964, 0.4995, 0.8014]],
  
           [[0.6989, 0.4583, 0.1503, 0.1996],
            [0.4704, 0.9786, 0.0212, 0.8056],
            [0.6989, 0.4583, 0.1503, 0.1996],
            [0.4704, 0.9786, 0.0212, 0.8056]]]], device='cuda:0')),
 (tensor([[[[0.5142, 0.1259, 0.1527, 0.3710],
            [0.8059, 0.7397, 0.9953, 0.3557],
            [0.5142, 0.1259, 0.1527, 0.3710],
            [0.8059, 0.7397, 0.9953, 0.3557]],
  
           [[0.4287, 0.4321, 0.7932, 0.5813],
            [0.3779, 0.4701, 0.1192, 0.4625],
            [0.4287, 0.4321, 0.7932, 0.5813],
            [0.3779, 0.4701, 0.1192, 0.4625]]]], device='cuda:0'),
  tensor([[[[0.8371, 0.2664, 0.2173, 0.4084],
            [0.8637, 0.2964, 0.4995, 0.8014],
            [0.8371, 0.2664, 0.2173, 0.4084],
            [0.8637, 0.2964, 0.4995, 0.8014]],
  
           [[0.6989, 0.4583, 0.1503, 0.1996],
            [0.4704, 0.9786, 0.0212, 0.8056],
            [0.6989, 0.4583, 0.1503, 0.1996],
            [0.4704, 0.9786, 0.0212, 0.8056]]]], device='cuda:0'))]
```