### PR TITLE
Remove explicit numpy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "datasets>=4.0.0",
     "fastapi>=0.117.1",
     "files-to-prompt>=0.6",
-    "numpy==1.26.4",
     "psutil>=7.1.0",
     "regex>=2025.9.1",
     "setuptools>=80.9.0",


### PR DESCRIPTION
The numpy library `numpy==1.26.4` is currently listed as a dependency for `nanochat`, but it isn’t being directly used in the project.    

* NumPy is not a direct dependency of `nanochat` — no module within the codebase imports or relies on it.
* Keeping it in `pyproject.toml` can lead to unnecessary dependency conflicts, especially since it pins `numpy==1.26.4`.
* Removing it is helping to reduce dependency footprint and avoid potential version conflicts for users or forks.

## Proposed Change:

Remove the numpy entry from the dependency list.

## Impact:

* No functional change to NanoChat’s behavior.
* Cleaner dependency management for developers and users forking or extending the repo.