### PR TITLE
Added tinyrun for minimal configuration

### DIFF
--- a/tinyrun.sh
+++ b/tinyrun.sh
@@ -50,16 +50,6 @@ DATASET_DOWNLOAD_PID=$!
 python -m scripts.tok_train --max_chars=2000000000
 python -m scripts.tok_eval
 
-# Download the eval_bundle from s3 to evaluate CORE metric during training (~162MB)
-EVAL_BUNDLE_URL=https://karpathy-public.s3.us-west-2.amazonaws.com/eval_bundle.zip
-if [ ! -d "$NANOCHAT_BASE_DIR/eval_bundle" ]; then
-    curl -L -o eval_bundle.zip $EVAL_BUNDLE_URL
-    unzip -q eval_bundle.zip
-    rm eval_bundle.zip
-    mv eval_bundle $NANOCHAT_BASE_DIR
-fi
-
-
 echo "Waiting for dataset download to complete..."
 wait $DATASET_DOWNLOAD_PID
 


### PR DESCRIPTION
I have seen many people discuss and try to run it on single GPUs. I myself have a 3080 GPU with 10GB VRAM workstation at home and was not able to run the speedrun.sh. Therefore, I have created tinyrun.sh, which is the same as speedrun.sh and run1000, but with adjusted parameters. I was able to run the whole pipeline end-to-end in roughly one hour.

I think it brings it a bit closer to people who do not have the budget of 100$ or are hesitating to rent a cluster for 25$ an hour or having a simple GPU setup at home.

@karpathy, what do you think?