### PR TITLE
Fix subtle model-loading bug

### DIFF
--- a/nanochat/checkpoint_manager.py
+++ b/nanochat/checkpoint_manager.py
@@ -72,7 +72,7 @@ def build_model(checkpoint_dir, step, device, phase):
             for k, v in model_data.items()
         }
     # Hack: fix torch compile issue, which prepends all keys with _orig_mod.
-    model_data = {k.lstrip("_orig_mod."): v for k, v in model_data.items()}
+    model_data = {k.removeprefix("_orig_mod."): v for k, v in model_data.items()}
     model_config_kwargs = meta_data["model_config"]
     log0(f"Building model with config: {model_config_kwargs}")
     model_config = GPTConfig(**model_config_kwargs)


### PR DESCRIPTION
lstrip will strip out more than just `_orig_mod.` . I encountered this bug on my own fork when trying to add a layer named `output_projection`, and the 'o' got stripped to `utput_projection`.