### PR TITLE
fix(eval): use UTF-8 when reading CORE JSONL and writing CSV

### DIFF
--- a/scripts/base_eval.py
+++ b/scripts/base_eval.py
@@ -88,7 +88,7 @@ def evaluate_model(model, tokenizer, device, max_per_task=-1):
 
         # Load data for this task
         data_path = os.path.join(data_base_path, task_meta['dataset_uri'])
-        with open(data_path, 'r') as f:
+        with open(data_path, 'r', encoding='utf-8') as f:
             data = [json.loads(line.strip()) for line in f]
 
         # shuffle the data because in many cases it appears ordered but we want
@@ -184,7 +184,7 @@ def main():
         results = out["results"]
         centered_results = out["centered_results"]
         core_metric = out["core_metric"]
-        with open(output_csv_path, 'w') as f:
+        with open(output_csv_path, 'w', encoding='utf-8', newline='') as f:
             f.write(f"{'Task':<35}, {'Accuracy':<10}, {'Centered':<10}\n")
             for label in results:
                 f.write(f"{label:<35}, {results[label]:<10.6f}, {centered_results[label]:<10.6f}\n")


### PR DESCRIPTION
This PR makes scripts/base_eval.py deterministic across platforms by opening the CORE JSONL with encoding='utf-8' (JSON defaults to UTF-8). On Windows/macOS, locale defaults (e.g., cp1252) can cause UnicodeDecodeError or silent mis-decoding.

Optional addition: write the output CSV with encoding='utf-8' and newline='' for consistent output.