### PR TITLE
fix(checkpoint): handle bf16 on MPS by casting to fp32 during load

### DIFF
--- a/nanochat/checkpoint_manager.py
+++ b/nanochat/checkpoint_manager.py
@@ -65,7 +65,7 @@ def build_model(checkpoint_dir, step, device, phase):
     """
     assert phase in ["train", "eval"], f"Invalid phase: {phase}"
     model_data, optimizer_data, meta_data = load_checkpoint(checkpoint_dir, step, device, load_optimizer=False)
-    if device.type == "cpu":
+    if device.type in {"cpu", "mps"}:
         # Convert bfloat16 tensors to float for CPU inference
         model_data = {
             k: v.float() if v.dtype == torch.bfloat16 else v


### PR DESCRIPTION
Apple MPS lacks full bfloat16 support. If checkpoints were saved with bf16
weights, loading on MPS can error or upcast unpredictably. Mirror the existing
CPU behavior by casting bf16 tensors to float32 when device.type == "mps".

Scope: checkpoint loading only. CUDA paths unchanged. No metric/logic changes.