### PR TITLE
Add pyproject for rustbpe standalone

### DIFF
--- a/rustbpe/pyproject.toml
+++ b/rustbpe/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "rustbpe"
+version = "0.1.0"
+description = "Rust BPE tokenizer from nanochat as standalone package"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+dependencies = []
+
+[build-system]
+requires = ["maturin>=1.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+module-name = "rustbpe"
+bindings = "pyo3"
+python-source = "."
+features = ["pyo3/extension-module"]


### PR DESCRIPTION
## Motivation:
Allow `rustbpe` as standalone dependency. 
E.g. my training code already uses `tiktoken` with a custom implementation to train compatible tokenizers, so `rustbpe` would be a drop-in replacement with minor changes and it makes more sense to contribute to something public.

This PR just adds a `pyproject.toml` to the rustbpe subdir and any third party would need to add dependencies to their own `pyproject.toml` and implement the bindings

```toml
...
[tool.hatch.metadata]
"allow-direct-references" = true

dependencies = [  
  "maturin>=1.9.4",
  "rustbpe @ git+https://github.com/karpathy/nanochat.git@rustbpe-standalone#subdirectory=rustbpe"  
]
```