### PR TITLE
Use optimal tokenization for minimum token count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "psutil>=7.1.0",
     "regex>=2025.9.1",
     "setuptools>=80.9.0",
-    "tiktoken>=0.11.0",
+    "tiktoken",
     "tokenizers>=0.22.0",
     "torch>=2.8.0",
     "uvicorn>=0.36.0",
@@ -49,6 +49,7 @@ torch = [
     { index = "pytorch-cpu", extra = "cpu" },  
     { index = "pytorch-cu128", extra = "gpu" },  
 ]
+tiktoken = { git = "https://github.com/Majdoddin/tiktoken", rev = "d51dde13f91c5fa0957f1312f7521a9f1906338f" }
 
 [[tool.uv.index]]  
 name = "pytorch-cpu"  


### PR DESCRIPTION
Uses a [tiktoken fork](https://github.com/Majdoddin/tiktoken/tree/optimal_byte_pair_encode) that improves the piece-to-tokens encoding step.

### How tokenization works
1. Regex splits text into pieces (unchanged)
2. Each piece is encoded to tokens using the vocab ← **This step is improved**

Tiktoken uses a greedy approach for step 2 that can produce suboptimal tokenizations. This fork uses dynamic programming to guarantee the optimal solution (fewest tokens) for each piece, thus _improved byte/token ratio (and LLM throughput)_.
This works with any vocabulary.
### Compression improvement
Tested on diverse text types from `tok_eval.py`:

```
  Text Type  Bytes   Tiktoken  Ratio  Fork    Diff%    Better
  -----------------------------------------------------------------------
  news       1819    375       4.85   374     0.27%    Fork
  korean     893     712       1.25   712     0.00%    Same
  code       1259    492       2.56   490     0.41%    Fork
  math       1834    966       1.90   964     0.21%    Fork
  science    1112    228       4.88   225     1.32%    Fork
```
### Runtime improvement
Tested on `enwik8`, the runtime is improved by 3.75%.

### Why not in upstream tiktoken?
A [PR was submitted to tiktoken](https://github.com/openai/tiktoken/pull/316) but not merged because changing the tokenization algorithm would break compatibility with existing trained models. Models learn token distributions during training, so the tokenization must remain identical between training and inference.

**This makes it a perfect match for nanochat** - we use the optimized tokenizer for both training and inference, so our models learn the optimal token distributions from the start.

A [PR was also submitted to minbpe](https://github.com/karpathy/minbpe/pull/84).

### What changed
Pinned `tiktoken` to the optimal tokenization fork at commit d51dde13
