### PR TITLE
Fix comment: rotary embeddings final dimension size

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -244,7 +244,7 @@ class GPT(nn.Module):
     def forward(self, idx, targets=None, kv_cache=None, loss_reduction='mean'):
         B, T = idx.size()
 
-        # Grab the rotary embeddings for the current sequence length (they are of shape (1, seq_len, 1, head_dim))
+        # Grab the rotary embeddings for the current sequence length (they are of shape (1, seq_len, 1, head_dim/2))
         assert T <= self.cos.size(1), f"Sequence length grew beyond the rotary embeddings cache: {T} > {self.cos.size(1)}"
         assert idx.device == self.cos.device, f"Rotary embeddings and idx are on different devices: {idx.device} != {self.cos.device}"
         assert self.cos.dtype == torch.bfloat16, "Rotary embeddings must be in bfloat16"


### PR DESCRIPTION
While taking some time to review RoPE internals and implementations, I noticed that there was a small typo/error in one of the comments here. The comment says the cos/sin rotary embeddings are `head_dim` in length for their final dimension, but they're half that size. This can be quickly verified in a repl:

```
>>> from nanochat.gpt import GPT, GPTConfig
>>> gpt = GPT(GPTConfig())
>>> print(gpt.transformer.h[0].attn.head_dim)
128
>>> print(gpt.cos.shape, gpt.sin.shape)
torch.Size([1, 10240, 1, 64]) torch.Size([1, 10240, 1, 64])
```

<img width="782" height="235" alt="Screenshot 2025-11-17 112500" src="https://github.com/user-attachments/assets/2b8bfa65-20a3-43c5-9fa2-7017eb125b15" />

This is a lil' patch to correct.

Separately: thanks for putting this repository together!