### PR TITLE
change test/train split approach to fix bug in spelling bee task

### DIFF
--- a/tasks/spellingbee.py
+++ b/tasks/spellingbee.py
@@ -35,6 +35,8 @@ from nanochat.common import download_file_with_lock
 LETTERS = "abcdefghijklmnopqrstuvwxyz"
 # A list of 370K English words of large variety
 WORD_LIST_URL = "https://raw.githubusercontent.com/dwyl/english-words/refs/heads/master/words_alpha.txt"
+# A number bigger than 370K to separate train and test random seeds
+TEST_RANDOM_SEED_OFFSET = 10_000_000
 
 # Identical to gsm8k's answer extraction
 ANSWER_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
@@ -131,7 +133,7 @@ class SpellingBee(Task):
         return self.size
 
     def get_example(self, index):
-        seed = index if self.split == "train" else -(index + 1) # avoid collision at 0
+        seed = index if self.split == 'train' else TEST_RANDOM_SEED_OFFSET + index
         rng = random.Random(seed)
 
         # pick a random word
@@ -252,7 +254,7 @@ class SimpleSpelling(Task):
         return self.size
 
     def get_example(self, index):
-        seed = index if self.split == "train" else -(index + 1) # avoid collision at 0
+        seed = index if self.split == 'train' else TEST_RANDOM_SEED_OFFSET + index
         rng = random.Random(seed)
         # pick a random word
         word = rng.choice(self.words)


### PR DESCRIPTION
I noticed seeing the same words for the train and test splits for the SpellingBee and SimpleSpelling tasks, just offset by 1. The cause seems to be this line:

```
seed = index if self.split == 'train' else -(index + 1)
```

but 

```
>>> import random
>>> random.seed(5)
>>> random.random()
0.6229016948897019
>>> random.seed(-5)
>>> random.random()
0.6229016948897019
```

Proposing the fix in this PR.

Noticed the issue while investigating chat eval after midtraining d20 [here](https://github.com/ericsilberstein1/learn-nanochat/blob/master/challenge-28-midtrain-d20/investigate-questions.ipynb).