### PR TITLE
make mid_train script work even with a tiny number of iterations

### DIFF
--- a/scripts/mid_train.py
+++ b/scripts/mid_train.py
@@ -139,7 +139,7 @@ def mid_data_generator(split):
                     last_step = True # toggle last_step to True, which will terminate the training loop
         # Stopping condition to respect num_iterations, if given
         it += 1
-        if num_iterations > 0 and it >= num_iterations and split == "train":
+        if 0 < num_iterations <= it and split == "train":
             last_step = True # toggle last_step to True, which will terminate the training loop
         # Build up inputs/targets and yield
         for i in range(needed_tokens):


### PR DESCRIPTION
This fixes the mid_train training loop exiting before it does any steps.

I noticed the problem when doing tiny tests such as:

`python -m scripts.mid_train --num_iterations=10 --model_tag=d4 --max_seq_len=128 --device_batch_size=1 --total_batch_size=128 --eval_tokens=1280`

When num_iterations is small, this condition becomes true for the val_loader:

`if num_iterations > 0 and it >= num_iterations`

This change fixes it. Running the above command before:

```
...
Step 00000 | Validation bpb: 2.1492
2025-11-19 15:49:34,346 - nanochat.checkpoint_manager - INFO ...
```

After:
```
...
Step 00000 | Validation bpb: 2.1492
step 00001 (20.00%) | loss: 4.377713 | lrm: 1.00 | dt: 5856.08ms | tok/sec: 21 | mfu: 0.00 | total time: 0.00m
step 00002 (30.00%) | loss: 5.784154 | lrm: 1.00 | dt: 26.68ms | tok/sec: 4,797 | mfu: 0.06 | total time: 0.00m
...
```

