### PR TITLE
remove unnecessary check to make the logic in CausalSelfAttention.forward() clearer

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -98,8 +98,7 @@ class CausalSelfAttention(nn.Module):
             # First, each query attends to all the cached keys/values (i.e. full prefix)
             attn_mask = torch.zeros((Tq, Tk), dtype=torch.bool, device=q.device) # True = keep, False = mask
             prefix_len = Tk - Tq
-            if prefix_len > 0: # can't be negative but could be zero
-                attn_mask[:, :prefix_len] = True
+            attn_mask[:, :prefix_len] = True
             # Then, causal attention within this chunk
             attn_mask[:, prefix_len:] = torch.tril(torch.ones((Tq, Tq), dtype=torch.bool, device=q.device))
             y = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, enable_gqa=enable_gqa)


### PR DESCRIPTION
I'm pretty sure `prefix_len` must be positive and the comment that it could be zero confused me when I was hand reimplementing.

If we're just starting on say "engine-driven generation" so there is a kv cache but it's empty, then Tq == Tk and that gets handled by the first if condition. By the time we get to this line, say because the kv cache contains stuff and multiple new tokens have been forced, Tk must be greater than Tq.

Or even without thinking that hard, assuming that the "can't be negative" comment is right, they also can't be equal because that's handled above.