### PR TITLE
remove unneeded iter() in chat_sft.py

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -167,17 +167,16 @@ def get_lr_multiplier(it):
 
 # Go!
 step = 0
-train_iter = iter(train_loader)
 for step in range(num_iterations):
     last_step = step == num_iterations - 1
 
     # evaluate the validation loss
     if last_step or step % eval_every == 0:
         model.eval()
-        val_iter = iter(build_val_loader())
+        val_loader = build_val_loader()
         losses = []
         for _ in range(eval_steps):
-            val_inputs, val_targets = next(val_iter)
+            val_inputs, val_targets = next(val_loader)
             with torch.no_grad(), autocast_ctx:
                 loss = model(val_inputs, val_targets)
             losses.append(loss)
@@ -214,7 +213,7 @@ for step in range(num_iterations):
     # evaluate the gradient
     num_tokens = torch.tensor(0, device=device) # the number of "active" tokens of supervision seen
     for micro_step in range(grad_accum_steps):
-        train_inputs, train_targets = next(train_iter)
+        train_inputs, train_targets = next(train_loader)
         with autocast_ctx:
             loss = model(train_inputs, train_targets)
         train_loss = loss.detach() # for logging


### PR DESCRIPTION
This very minor change makes `chat_sft.py` more consistent with `mid_train.py` and `base_train.py`.

I recognize this could just be a style thing, but when I was hand copying, I was thrown for a second and wondered if I was missing something about the loader vs what I saw earlier in the mid and base training loops.

Example command to run  a quick test:

```
python -m scripts.chat_sft --model_tag=d4 --num_iterations=10 --device_batch_size=1 --target_examples_per_step=4  --eval_every=5 --eval_steps=10 --eval_metrics_every=5 --eval_metrics_max_problems=2
```