### PR TITLE
Fix maturin build failure when conda environment is active

### DIFF
--- a/dev/runcpu.sh
+++ b/dev/runcpu.sh
@@ -21,6 +21,7 @@ if [ -z "$WANDB_RUN" ]; then
 fi
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
+unset CONDA_PREFIX
 uv run maturin develop --release --manifest-path rustbpe/Cargo.toml
 
 # wipe the report

--- a/run1000.sh
+++ b/run1000.sh
@@ -18,6 +18,7 @@ fi
 python -m nanochat.report reset
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
+unset CONDA_PREFIX
 uv run maturin develop --release --manifest-path rustbpe/Cargo.toml
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 

--- a/speedrun.sh
+++ b/speedrun.sh
@@ -53,6 +53,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
 
 # Build the rustbpe Tokenizer
+unset CONDA_PREFIX
 uv run maturin develop --release --manifest-path rustbpe/Cargo.toml
 
 # Download the first ~2B characters of pretraining dataset


### PR DESCRIPTION
## Summary
- Unset CONDA_PREFIX before maturin build to fix compatibility on systems with conda installed