### PR TITLE
fix: missing val_bpb on resume

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -205,6 +205,7 @@ if not resuming:
 else:
     step = meta_data["step"]
     loop_state = meta_data["loop_state"]
+    val_bpb = meta_data["val_bpb"]
     min_val_bpb = loop_state["min_val_bpb"]
     smooth_train_loss = loop_state["smooth_train_loss"]
     total_training_time = loop_state["total_training_time"]


### PR DESCRIPTION
## Summary

This PR fixes a bug where resuming training from a checkpoint can trigger a `NameError: name 'val_bpb' is not defined` when `save_every` is small and no evaluation has occurred yet.

## Background

In `base_train.py`, the variable `val_bpb` is created only during validation
steps:

```python
if step % eval_every == 0:
    val_bpb = evaluate_bpb(...)
```

However, the checkpoint-saving logic runs independently of evaluation:

```python
save_checkpoint(..., {"val_bpb": val_bpb, ...})
```


When resuming training (e.g., resume_from_step=100) with:
- save_every = 100
- eval_every = 250

the next save happens at step 200 — before any validation has run.
Because val_bpb has not been initialized in the resumed process, saving the checkpoint raises a NameError.

This issue does not appear when training starts from scratch, because step=0 always triggers an initial validation, ensuring `val_bpb` is defined.
