### PR TITLE
fix: fix last_step computation bug

### DIFF
--- a/nanochat/checkpoint_manager.py
+++ b/nanochat/checkpoint_manager.py
@@ -118,7 +118,7 @@ def find_last_step(checkpoint_dir):
     checkpoint_files = glob.glob(os.path.join(checkpoint_dir, "model_*.pt"))
     if not checkpoint_files:
         raise FileNotFoundError(f"No checkpoints found in {checkpoint_dir}")
-    last_step = int(max(os.path.basename(f).split("_")[-1].split(".")[0] for f in checkpoint_files))
+    last_step = max(int(os.path.basename(f).split("_")[-1].split(".")[0]) for f in checkpoint_files)
     return last_step
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Since the model in checkpoint_dir has name like model_<step>.pt, so we should compare step as int, right ?