### PR TITLE
Fix relative difference sign in  scripts/tok_eval.py

### DIFF
--- a/scripts/tok_eval.py
+++ b/scripts/tok_eval.py
@@ -212,9 +212,9 @@ def print_comparison(baseline_name, baseline_results, ours_results, all_text):
         baseline_data = baseline_results[name]
         ours_data = ours_results[name]
 
-        # Calculate relative difference (positive means ours is better, negative means worse)
-        # Using tokens: fewer tokens is better, so we calculate (baseline_tokens - ours_tokens) / baseline_tokens
-        relative_diff = ((baseline_data['tokens'] - ours_data['tokens']) / baseline_data['tokens']) * 100
+        # Calculate relative difference in total tokens (negative means ours is better, positive means worse)
+        # We calculate (ours_tokens - baseline_tokens) / baseline_tokens
+        relative_diff = ((ours_data['tokens'] - baseline_data['tokens']) / baseline_data['tokens']) * 100
 
         # Determine which has better compression (higher ratio = better)
         if baseline_data['ratio'] > ours_data['ratio']:
@@ -256,7 +256,7 @@ for baseline_name in ["GPT-2", "GPT-4"]:
     for name, text in all_text:
         baseline_data = baseline_results[name]
         ours_data = ours_results[name]
-        relative_diff = ((baseline_data['tokens'] - ours_data['tokens']) / baseline_data['tokens']) * 100
+        relative_diff = ((ours_data['tokens'] - baseline_data['tokens']) / baseline_data['tokens']) * 100
         lines.append(f"| {name} | {baseline_data['bytes']} | {baseline_data['tokens']} | {baseline_data['ratio']:.2f} | {ours_data['tokens']} | {ours_data['ratio']:.2f} | {relative_diff:+.1f}% |")
     lines.append("")
 report_markdown = "\n".join(lines)


### PR DESCRIPTION
Current code has the sign flipped in the numerator, so e.g. if "ours" tokens count is 3X value of the "base" it will report -200%, which does not make sense.

Before the fix 
```
uv run -m scripts.tok_eval

Vocab sizes:
GPT-2: 50257
GPT-4: 100277
Ours: 65536

Comparison with GPT-2:
===============================================================================================
Text Type  Bytes    GPT-2           Ours            Relative     Better    
                    Tokens  Ratio   Tokens  Ratio   Diff %      
-----------------------------------------------------------------------------------------------
news       1819     404     4.50    375     4.85       +7.2%     Ours      
korean     893      745     1.20    721     1.24       +3.2%     Ours      
code       1259     576     2.19    493     2.55      +14.4%     Ours      
math       1834     936     1.96    966     1.90       -3.2%     GPT-2     
science    1112     260     4.28    225     4.94      +13.5%     Ours      
fwe-train  4208518  900364  4.67    856901  4.91       +4.8%     Ours      
fwe-val    4908443  1059062 4.63    1010356 4.86       +4.6%     Ours      

Comparison with GPT-4:
===============================================================================================
Text Type  Bytes    GPT-4           Ours            Relative     Better    
                    Tokens  Ratio   Tokens  Ratio   Diff %      
-----------------------------------------------------------------------------------------------
news       1819     387     4.70    375     4.85       +3.1%     Ours      
korean     893      364     2.45    721     1.24      -98.1%     GPT-4     
code       1259     309     4.07    493     2.55      -59.5%     GPT-4     
math       1834     832     2.20    966     1.90      -16.1%     GPT-4     
science    1112     249     4.47    225     4.94       +9.6%     Ours      
fwe-train  4208518  874799  4.81    856901  4.91       +2.0%     Ours  
```

After the fix:
```
uv run -m scripts.tok_eval

Vocab sizes:
GPT-2: 50257
GPT-4: 100277
Ours: 65536

Comparison with GPT-2:
===============================================================================================
Text Type  Bytes    GPT-2           Ours            Relative     Better    
                    Tokens  Ratio   Tokens  Ratio   Diff %      
-----------------------------------------------------------------------------------------------
news       1819     404     4.50    375     4.85       -7.2%     Ours      
korean     893      745     1.20    721     1.24       -3.2%     Ours      
code       1259     576     2.19    493     2.55      -14.4%     Ours      
math       1834     936     1.96    966     1.90       +3.2%     GPT-2     
science    1112     260     4.28    225     4.94      -13.5%     Ours      
fwe-train  4208518  900364  4.67    856901  4.91       -4.8%     Ours      
fwe-val    4908443  1059062 4.63    1010356 4.86       -4.6%     Ours      

Comparison with GPT-4:
===============================================================================================
Text Type  Bytes    GPT-4           Ours            Relative     Better    
                    Tokens  Ratio   Tokens  Ratio   Diff %      
-----------------------------------------------------------------------------------------------
news       1819     387     4.70    375     4.85       -3.1%     Ours      
korean     893      364     2.45    721     1.24      +98.1%     GPT-4     
code       1259     309     4.07    493     2.55      +59.5%     GPT-4     
math       1834     832     2.20    966     1.90      +16.1%     GPT-4     
science    1112     249     4.47    225     4.94       -9.6%     Ours      
fwe-train  4208518  874799  4.81    856901  4.91       -2.0%     Ours      
fwe-val    4908443  1029691 4.77    1010356 4.86       -1.9%     Ours 
```

```
cat ~/.cache/nanochat/report/tokenizer-evaluation.md 
## Tokenizer evaluation
timestamp: 2025-11-23 17:55:47

### Comparison with GPT-2

| Text Type | Bytes | GPT-2 Tokens | GPT-2 Ratio | Ours Tokens | Ours Ratio | Relative Diff % |
|-----------|-------|--------------|--------------|-------------|------------|-----------------|
| news | 1819 | 404 | 4.50 | 375 | 4.85 | -7.2% |
| korean | 893 | 745 | 1.20 | 721 | 1.24 | -3.2% |
| code | 1259 | 576 | 2.19 | 493 | 2.55 | -14.4% |
| math | 1834 | 936 | 1.96 | 966 | 1.90 | +3.2% |
| science | 1112 | 260 | 4.28 | 225 | 4.94 | -13.5% |
| fwe-train | 4208518 | 900364 | 4.67 | 856901 | 4.91 | -4.8% |
| fwe-val | 4908443 | 1059062 | 4.63 | 1010356 | 4.86 | -4.6% |

### Comparison with GPT-4

| Text Type | Bytes | GPT-4 Tokens | GPT-4 Ratio | Ours Tokens | Ours Ratio | Relative Diff % |
|-----------|-------|--------------|--------------|-------------|------------|-----------------|
| news | 1819 | 387 | 4.70 | 375 | 4.85 | -3.1% |
| korean | 893 | 364 | 2.45 | 721 | 1.24 | +98.1% |
| code | 1259 | 309 | 4.07 | 493 | 2.55 | +59.5% |
| math | 1834 | 832 | 2.20 | 966 | 1.90 | +16.1% |
| science | 1112 | 249 | 4.47 | 225 | 4.94 | -9.6% |
| fwe-train | 4208518 | 874799 | 4.81 | 856901 | 4.91 | -2.0% |
| fwe-val | 4908443 | 1029691 | 4.77 | 1010356 | 4.86 | -1.9% |
```