### PR TITLE
Fix race condition in save_checkpoint for non-zero ranks

### DIFF
--- a/nanochat/checkpoint_manager.py
+++ b/nanochat/checkpoint_manager.py
@@ -21,8 +21,8 @@ def log0(message):
         logger.info(message)
 
 def save_checkpoint(checkpoint_dir, step, model_data, optimizer_data, meta_data, rank=0):
+    os.makedirs(checkpoint_dir, exist_ok=True)
     if rank == 0:
-        os.makedirs(checkpoint_dir, exist_ok=True)
         # Save the model state parameters
         model_path = os.path.join(checkpoint_dir, f"model_{step:06d}.pt")
         torch.save(model_data, model_path)


### PR DESCRIPTION
When running `scripts/base_train.py` with multiple ranks, I hit the following error at the very end of training:

```text
RuntimeError: Parent directory /data/home/zizhuofu/.cache/nanochat/base_checkpoints/d20 does not exist.
  File "nanochat/checkpoint_manager.py", line 38, in save_checkpoint
    torch.save(optimizer_data, optimizer_path)
````

This happens because in `save_checkpoint` only `rank == 0` calls `os.makedirs(checkpoint_dir, exist_ok=True)`, while **all** ranks always call `torch.save` for their optimizer shard. If a non-zero rank reaches `torch.save` before rank 0 has created the directory, `torch.save` fails with the “Parent directory does not exist” error.

At the end of `base_train`, this can also corrupt the last checkpoint. Subsequent scripts that try to load that checkpoint (e.g. `scripts/base_loss.py`, `scripts/base_eval.py`, `scripts/mid_train.py`) then fail with:

```text
RuntimeError: PytorchStreamReader failed reading zip archive: failed finding central directory
```

## Fix

This PR removes the race condition by:

* Moving `os.makedirs(checkpoint_dir, exist_ok=True)` **outside** of the `rank == 0` branch so that every rank ensures the directory exists before saving.

This way, all ranks see a valid `checkpoint_dir`, and only rank 0 writes the shared model/metadata files, avoiding concurrent writes and checkpoint corruption.