### PR TITLE
Fix script comment to reference correct file

### DIFF
--- a/speedrun.sh
+++ b/speedrun.sh
@@ -96,7 +96,7 @@ torchrun --standalone --nproc_per_node=$NPROC_PER_NODE -m scripts.base_eval
 # Midtraining (teach the model conversation special tokens, tool use, multiple choice)
 
 # download 2.3MB of synthetic identity conversations to impart a personality to nanochat
-# see dev/gen_sft_data.py for details on how this data was prepared and to get a sense of how you can easily tune it
+# see dev/gen_synthetic_data.py for details on how this data was prepared and to get a sense of how you can easily tune it
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 
 # run midtraining and eval the model


### PR DESCRIPTION
In the speedrun.sh script, the comment references a file named gen_sft_data.py for details on generating the synthetic identity conversation dataset.
However, the actual file in the repository is named differently. I updated the comment to point to the correct filename so contributors can locate the referenced script without confusion.

This change fixes a broken reference and improves developer navigation.