### PR TITLE
Fix epsilon scaling in DistAdamW to match standard AdamW

### DIFF
--- a/nanochat/adamw.py
+++ b/nanochat/adamw.py
@@ -66,9 +66,10 @@ class DistAdamW(torch.optim.Optimizer):
                 # bias corrections
                 bias1 = 1 - beta1 ** t
                 bias2 = 1 - beta2 ** t
-                # compute step
-                denom = exp_avg_sq.sqrt().add_(eps)
-                step_size = lr * (torch.sqrt(bias2) / bias1)
+                # compute step (standard AdamW: apply eps after bias correction)
+                bias_correction2_sqrt = torch.sqrt(bias2)
+                denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)
+                step_size = lr / bias1
                 update = exp_avg.div(denom).mul_(step_size)
                 p_slice.add_(other=update, alpha=-1.0)
                 idx += 1


### PR DESCRIPTION
## Summary
- Fixes epsilon scaling in `DistAdamW` optimizer to match standard AdamW (PyTorch)
- The epsilon term was being added before bias correction of the second moment
- Now applies epsilon after bias correction, matching [PyTorch's implementation](https://github.com/pytorch/pytorch/blob/main/torch/optim/adam.py)

## Mathematical Change
| Before | After |
|--------|-------|
| `denom = sqrt(exp_avg_sq) + eps` | `denom = sqrt(exp_avg_sq) / sqrt(bias2) + eps` |

At early training steps (e.g., step 1 with β2=0.999), the standard formula has epsilon effectively scaled down by ~31x. Both converge to equivalent behavior as training progresses.

Fixes #304

## Test plan
- [ ] Run existing tests
- [ ] Verify training convergence is maintained on a small model

🤖 Generated with [Claude Code](https://claude.com/claude-code)