### PR TITLE
Fix Rust linter warnings (9 LoC)

### DIFF
--- a/rustbpe/src/lib.rs
+++ b/rustbpe/src/lib.rs
@@ -449,10 +449,10 @@ impl Tokenizer {
 
                 for i in 0..ids.len() - 1 {
                     let pair: Pair = (ids[i], ids[i + 1]);
-                    if let Some(&new_id) = self.merges.get(&pair) {
-                        if best_pair.is_none() || new_id < best_pair.unwrap().2 {
-                            best_pair = Some((i, pair, new_id));
-                        }
+                    if let Some(&new_id) = self.merges.get(&pair)
+                        && (best_pair.is_none() || new_id < best_pair.unwrap().2)
+                    {
+                        best_pair = Some((i, pair, new_id));
                     }
                 }
 


### PR DESCRIPTION
## Problem
Running `cargo clippy` produces 3 warnings. [Clippy](https://github.com/rust-lang/rust-clippy) is the most popular linting tool for Rust.

```
$ cd rustbpe && cargo clippy

warning: you should consider adding a `Default` implementation for `Tokenizer`
   --> src/lib.rs:264:5
 
warning: redundant closure
   --> src/lib.rs:359:25

warning: this `if` statement can be collapsed
   --> src/lib.rs:446:21
```
Note: above output is trimmed for brevity. See "Appendix: full linter warnings" section for the full output, or run above command.

## Solution
Fixed all warnings through 3 commits (one commit per warning):

1. [Add Default impl for Tokenizer](https://github.com/karpathy/nanochat/commit/015ce712d76bbe8239cb04968d88a4f74889ebfb) - Implements `Default` trait for `Tokenizer`
2. [Remove redundant closure in reduce](https://github.com/karpathy/nanochat/commit/bdd2e4e47090c9d58425ec7dca58c37b9db00f89) - `|| AHashMap::new()` → `AHashMap::new`
3. [Collapse nested if in encode()](https://github.com/karpathy/nanochat/commit/809824a07cca82efdadceac36a0529a1d867276f) - Combines `if let` with inner condition using `&&`

Commits are prepared based on suggestions of clippy (see appendix), and then verified by me and AI review (Claude Code)

See "Appendix: why each commit is safe and makes sense" section for more details.

## Verification
No linter warnings anymore. I ran clippy again after all changes and it didn't throw any warnings. Below is its output:
```bash
$ cd rustbpe && cargo clippy

Checking rustbpe v0.1.0 (~/dev/github/barisozmen/nanochat/rustbpe)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.71s
```

## Testing
All existing tests pass. Zero breaking changes. I ran pytest (after the changes) and copy-pasted the result below:
```
$ PYTHONPATH=. uv run pytest

======================= test session starts ========================
platform darwin -- Python 3.10.18, pytest-8.4.2, pluggy-1.6.0
rootdir: ~/dev/github/barisozmen/nanochat
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.10.0
collected 7 items                                                  

tests/test_engine.py ..                                      [ 28%]
tests/test_rustbpe.py .....                                  [100%]

======================== 7 passed in 9.25s =========================
```


## Appendix: full linter warnings
You can run below command to get the same output (before applying changes in this PR):
```
$ cd rustbpe && cargo clippy

warning: you should consider adding a `Default` implementation for `Tokenizer`
   --> src/lib.rs:264:5
    |
264 | /     pub fn new() -> Self {
265 | |         Self {
266 | |             merges: StdHashMap::new(),
267 | |             pattern: String::new(),
...   |
270 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#new_without_default
    = note: `#[warn(clippy::new_without_default)]` on by default
help: try adding this
    |
261 + impl Default for Tokenizer {
262 +     fn default() -> Self {
263 +         Self::new()
264 +     }
265 + }
    |

warning: redundant closure
   --> src/lib.rs:359:25
    |
359 |                         || AHashMap::new(),
    |                         ^^^^^^^^^^^^^^^^^^ help: replace the closure with the associated function itself: `AHashMap::new`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#redundant_closure
    = note: `#[warn(clippy::redundant_closure)]` on by default

warning: this `if` statement can be collapsed
   --> src/lib.rs:446:21
    |
446 | / ...   if let Some(&new_id) = self.merges.get(&pair) {
447 | | ...       if best_pair.is_none() || new_id < best_pair.un...
448 | | ...           best_pair = Some((i, pair, new_id));
449 | | ...       }
450 | | ...   }
    | |_______^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#collapsible_if
    = note: `#[warn(clippy::collapsible_if)]` on by default
help: collapse nested if block
    |
446 ~                     if let Some(&new_id) = self.merges.get(&pair)
447 ~                         && (best_pair.is_none() || new_id < best_pair.unwrap().2) {
448 |                             best_pair = Some((i, pair, new_id));
449 ~                         }
    |

warning: `rustbpe` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p rustbpe` to apply 3 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
```

## Appendix: Why each commit is safe and makes sense

#### 1. [Add Default impl for Tokenizer](https://github.com/karpathy/nanochat/commit/015ce712d76bbe8239cb04968d88a4f74889ebfb)

```rust
// Added
impl Default for Tokenizer {
    fn default() -> Self {
        Self::new()
    }
}
```

Why this is safe and makes sense:
- The impl simply delegates to new(), so behavior is identical
- The Default trait is Rust's idiomatic way to create a type with default values
- When a struct has a new() that takes no arguments, Rust convention (and Clippy) expects a Default implementation
- This enables usage like Tokenizer::default() and Option::unwrap_or_default(), improving ergonomics for downstream users
- No breaking change: existing code calling Tokenizer::new() continues to work exactly as before


#### 2. [Remove redundant closure in reduce](https://github.com/karpathy/nanochat/commit/bdd2e4e47090c9d58425ec7dca58c37b9db00f89)

```rust
// Before
  .reduce(|| AHashMap::new(), ...)
  
// After
  .reduce(AHashMap::new, ...)
```

Why this is safe and makes sense:
- || AHashMap::new() creates a closure that calls AHashMap::new()
- AHashMap::new is already a function pointer with the same signature fn() -> AHashMap
- Passing the function directly avoids an unnecessary indirection
- The compiled code is likely identical (the compiler may optimize it away), but this is cleaner source code
- Zero behavioral change: both produce a new empty AHashMap when called

#### 3. [Collapse nested if in encode()](https://github.com/karpathy/nanochat/commit/809824a07cca82efdadceac36a0529a1d867276f)

```rust
// Before
if let Some(&new_id) = self.merges.get(&pair) {
    if best_pair.is_none() || new_id < best_pair.unwrap().2 {
        best_pair = Some((i, pair, new_id));
    }
}

// After
if let Some(&new_id) = self.merges.get(&pair)
    && (best_pair.is_none() || new_id < best_pair.unwrap().2)
{
    best_pair = Some((i, pair, new_id));
}
```

Why this is safe and makes sense:
- Uses Rust's let-chains feature (stabilized in Rust 1.65)
- The && combines the pattern match with the boolean condition into a single if expression
- Logic is semantically identical:
  a. First, check if pair exists in merges (pattern match)
    b. If yes, check if we should update best_pair (boolean condition)
    c. If both pass, update best_pair
- Short-circuit evaluation is preserved: the boolean condition only evaluates when the pattern matches
- Reduces nesting depth by one level, improving readability
- Zero behavioral change: the same conditions must pass to execute the same assignment



## Appendix: AI usage

I used Claude Code to help identify potential improvements and bug fixes in rustbpe/. Its first suggestion was to address linter warnings (it recommended to use `cargo clippy` which I learned that it's the most popular Rust linter).

I reviewed Clippy’s output and gave to Claude Code to apply the clippy suggestions on lib.rs. I then asked Claude Code to split the changes into individual commits, with one commit per warning, and then git push. The changes are straightforward and directly reflect what Clippy recommended. I reviewed all commits myself too and explained why each of them makes sense above in Solution section.

The "Appendix: Why each commit is safe and makes sense" section is prepared by Claude Code. I reviewed the explanations and verified myself that they're correct.