### PR TITLE
Small rewrite of base cache dir helper

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -52,9 +52,7 @@ def get_base_dir():
     if os.environ.get("NANOCHAT_BASE_DIR"):
         nanochat_dir = os.environ.get("NANOCHAT_BASE_DIR")
     else:
-        home_dir = os.path.expanduser("~")
-        cache_dir = os.path.join(home_dir, ".cache")
-        nanochat_dir = os.path.join(cache_dir, "nanochat")
+        nanochat_dir = os.path.join(os.path.expanduser("~"), ".cache", "nanochat")
     os.makedirs(nanochat_dir, exist_ok=True)
     return nanochat_dir
 


### PR DESCRIPTION
**Description:** Small cleanup in `get_base_dir()` in `common.py`


Simplify construction of nanochat_dir from three lines to a single os.path.join(...) expression.
Preserve existing behavior (still uses `~/.cache/nanochat `by default, or `NANOCHAT_BASE_DIR `when set).
No functional changes expected. This is just a minor readability refactor.