### PR TITLE
small change to doc string at top of tok_train.py

### DIFF
--- a/scripts/tok_train.py
+++ b/scripts/tok_train.py
@@ -1,5 +1,5 @@
 """
-Train a tokenizer using the HuggingFace Tokenizers library.
+Train a tokenizer using our own BPE Tokenizer library.
 In the style of GPT-4 tokenizer.
 """
 import os


### PR DESCRIPTION
At top of `tok_train.py` we say that we're training a HF tokenizer, when we're training our own BPE tokenizer written in rust. 