### PR TITLE
Clean up CPU script

### DIFF
--- a/dev/runcpu.sh
+++ b/dev/runcpu.sh
@@ -19,9 +19,6 @@ source .venv/bin/activate
 if [ -z "$WANDB_RUN" ]; then
     WANDB_RUN=dummy
 fi
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-source "$HOME/.cargo/env"
-uv run maturin develop --release --manifest-path rustbpe/Cargo.toml
 
 # wipe the report
 python -m nanochat.report reset


### PR DESCRIPTION
After [deleting](https://github.com/karpathy/nanochat/commit/aa42f40e66ecb62c5649f57a6123c04977f44622#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) the inline rustbpe project, we don't need these commands in `runcpu.sh` anymore.