### PR TITLE
Fix relative_diff calculation

### DIFF
--- a/scripts/tok_eval.py
+++ b/scripts/tok_eval.py
@@ -213,8 +213,8 @@ def print_comparison(baseline_name, baseline_results, ours_results, all_text):
         ours_data = ours_results[name]
 
         # Calculate relative difference (positive means ours is better, negative means worse)
-        # Using tokens: fewer tokens is better, so we calculate (baseline_tokens - ours_tokens) / baseline_tokens
-        relative_diff = ((baseline_data['tokens'] - ours_data['tokens']) / baseline_data['tokens']) * 100
+        # Using ratios: higher ratio is better, so we calculate (ours_ratio - baseline_ratio) / baseline_ratio
+        relative_diff = ((ours_data['ratio'] - baseline_data['ratio']) / baseline_data['ratio']) * 100
 
         # Determine which has better compression (higher ratio = better)
         if baseline_data['ratio'] > ours_data['ratio']:
@@ -256,7 +256,7 @@ for baseline_name in ["GPT-2", "GPT-4"]:
     for name, text in all_text:
         baseline_data = baseline_results[name]
         ours_data = ours_results[name]
-        relative_diff = ((baseline_data['tokens'] - ours_data['tokens']) / baseline_data['tokens']) * 100
+        relative_diff = ((ours_data['ratio'] - baseline_data['ratio']) / baseline_data['ratio']) * 100
         lines.append(f"| {name} | {baseline_data['bytes']} | {baseline_data['tokens']} | {baseline_data['ratio']:.2f} | {ours_data['tokens']} | {ours_data['ratio']:.2f} | {relative_diff:+.1f}% |")
     lines.append("")
 report_markdown = "\n".join(lines)


### PR DESCRIPTION
Follow-up of https://github.com/karpathy/nanochat/pull/328.

Basically I think @waiwnf was correct in pointing out an issue with the relative difference calculation. However, in contrast to #328 we do still want "better compression is positive" to also be in line with the green colors showing better compressed token ratios.

So when total bytes is 1112, and GPT2 tokens 260 (ratio 4.28), and nanochat has 225 tokens (ratio 4.94). Currently on `master` this is shown as an 13.5% increase, because 260*0.865 is 225. 

However to me it makes more sense to look at the ratios, where an increase is in fact a good thing, and here we have 4.28 * 1.155 = 4.94. So from this standpoint, it's a 15.5% increase instead of 13.5% one. And from @waiwnf's perspective it would have been a 13.5% decrease (in tokens). See also https://github.com/karpathy/nanochat/pull/328#issuecomment-3572090358.

I think basically the confusion started when using the tokens for the calculation, but wanting to flip the sign as less tokens is better.

## Master
```
Comparison with GPT-2:
===============================================================================================
Text Type  Bytes    GPT-2           Ours            Relative     Better    
                    Tokens  Ratio   Tokens  Ratio   Diff %      
-----------------------------------------------------------------------------------------------
news       1819     404     4.50    375     4.85       +7.2%     Ours      
korean     893      745     1.20    721     1.24       +3.2%     Ours      
code       1259     576     2.19    493     2.55      +14.4%     Ours      
math       1834     936     1.96    966     1.90       -3.2%     GPT-2     
science    1112     260     4.28    225     4.94      +13.5%     Ours      
fwe-train  4208518  900364  4.67    856901  4.91       +4.8%     Ours      
fwe-val    4908443  1059062 4.63    1010356 4.86       +4.6%     Ours      
```

## This PR
```
Comparison with GPT-2:
===============================================================================================
Text Type  Bytes    GPT-2           Ours            Relative     Better
                    Tokens  Ratio   Tokens  Ratio   Diff %
-----------------------------------------------------------------------------------------------
news       1819     404     4.50    375     4.85       +7.7%     Ours
korean     893      745     1.20    721     1.24       +3.3%     Ours
code       1259     576     2.19    493     2.55      +16.8%     Ours
math       1834     936     1.96    966     1.90       -3.1%     GPT-2
science    1112     260     4.28    225     4.94      +15.6%     Ours
fwe-train  4208518  900364  4.67    856901  4.91       +5.1%     Ours
fwe-val    4642360  1000660 4.64    956855  4.85       +4.6%     Ours
```


## PR 328

```
Comparison with GPT-2:
===============================================================================================
Text Type  Bytes    GPT-2           Ours            Relative     Better    
                    Tokens  Ratio   Tokens  Ratio   Diff %      
-----------------------------------------------------------------------------------------------
news       1819     404     4.50    375     4.85       -7.2%     Ours      
korean     893      745     1.20    721     1.24       -3.2%     Ours      
code       1259     576     2.19    493     2.55      -14.4%     Ours      
math       1834     936     1.96    966     1.90       +3.2%     GPT-2     
science    1112     260     4.28    225     4.94      -13.5%     Ours      
fwe-train  4208518  900364  4.67    856901  4.91       -4.8%     Ours      
fwe-val    4908443  1059062 4.63    1010356 4.86       -4.6%     Ours      
```
