### PR TITLE
Reduce token waste in BOS bestfit by cropping shortest doc

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -178,8 +178,9 @@ def tokenizing_distributed_data_loader_with_state_bos_bestfit(
                     doc = doc_buffer.pop(best_idx)
                     row.extend(doc)
                 else:
-                    # No doc fits - crop first doc to fill remaining
-                    doc = doc_buffer.pop(0)
+                    # No doc fits - crop shortest in buffer to fill remaining and minimize waste
+                    shortest_idx = min(range(len(doc_buffer)), key=lambda i: len(doc_buffer[i]))
+                    doc = doc_buffer.pop(shortest_idx)
                     row.extend(doc[:remaining])
 
             rows.append(row[:row_capacity])


### PR DESCRIPTION
When no document fits the remaining row space, the bestfit dataloader currently
crops the first document in the buffer. This adjustment crops the shortest document
instead, minimizing discarded tokens.

Example: if remaining=50 tokens and the buffer contains docs of lengths
[500, 200, 100, 300], cropping the 100-token doc wastes 50 tokens vs 450 for
the first doc.

Same O(n) complexity as the existing best-fit search.

---

LLM disclosure: Used Claude for implementation. The optimization
concept and code are straightforward and fully understood.