### PR TITLE
Fix escape character in README bibtex entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ If you find nanochat helpful in your research cite simply as:
 ```bibtex
 @misc{nanochat,
   author = {Andrej Karpathy},
-  title = {nanochat: The best ChatGPT that $100 can buy},
+  title = {nanochat: The best ChatGPT that \$100 can buy},
   year = {2025},
   publisher = {GitHub},
   url = {https://github.com/karpathy/nanochat}


### PR DESCRIPTION
Unescaped $ sign (as in `100$`) is a LaTeX error. The citation becomes misformed. This PR fixes it.