### PR TITLE
feat: allow top_k=0 in web api to disable filtering

### DIFF
--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -26,7 +26,7 @@ Abuse Prevention:
   - Maximum 8000 characters per message
   - Maximum 32000 characters total conversation length
   - Temperature clamped to 0.0-2.0
-  - Top-k clamped to 1-200
+  - Top-k clamped to 0-200 (0 disables top-k filtering, using full vocabulary)
   - Max tokens clamped to 1-4096
 """
 


### PR DESCRIPTION
## summary
the api validation currently requires `top_k >= 1` but the engine's sampling function treats `top_k=0` the same as `top_k=None` (so both disable top-k filtering and use the full vocabulary). this prevents explicitly overriding the server's default of `top_k=50`.

## what this change does
- changes `MIN_TOP_K` from `1` to `0` in `scripts/chat_web.py`
- updates the docstring to reflect the new range: "Top-k clamped to 0-200 (0 disables top-k filtering)"

## why this matters
currently a user cant access full vocabulary sampling because:
1. the server defaults to `top_k=50`
2. setting `top_k=0` is rejected by validation
3. not setting `top_k` uses the server default (50), not full vocab

this change allows users to explicitly request full vocabulary sampling by setting `top_k=0`.

## engine support
from `nanochat/engine.py` line 205:
```python
if top_k is not None and top_k > 0:
    # apply top-k filtering
else:
    # Use full vocabulary
```

linked to issue #423 