### PR TITLE
Fix CPU training: add contiguous() calls and use all cores

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -187,8 +187,8 @@ def tokenizing_distributed_data_loader_with_state_bos_bestfit(
 
         use_cuda = device == "cuda"
         batch_tensor = torch.tensor(rows, dtype=torch.long, pin_memory=use_cuda)
-        inputs = batch_tensor[:, :-1].to(device=device, non_blocking=use_cuda)
-        targets = batch_tensor[:, 1:].to(device=device, non_blocking=use_cuda)
+        inputs = batch_tensor[:, :-1].contiguous().to(device=device, non_blocking=use_cuda)
+        targets = batch_tensor[:, 1:].contiguous().to(device=device, non_blocking=use_cuda)
 
         yield inputs, targets, {"pq_idx": pq_idx, "rg_idx": rg_idx, "epoch": epoch}
 

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -4,15 +4,13 @@
 # This script was last updated/tuned on Jan 17, 2026.
 
 # Run as:
-# bash dev/cpu_demo_run.sh
+# bash runs/runcpu.sh
 
 # NOTE: Training LLMs requires GPU compute and $$$. You will not get far on your Macbook.
 # Think of this run as educational/fun demo, not something you should expect to work well.
-# (This is why I hide this script away in dev/)
 # You may also want to run this script manually and one by one, copy pasting commands into your terminal.
 
 # all the setup stuff
-export OMP_NUM_THREADS=1
 export NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
 mkdir -p $NANOCHAT_BASE_DIR
 command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
## Summary
This PR fixes two issues in CPU training:

1. **Add `.contiguous()` calls in dataloader** (nanochat/dataloader.py:190-191)
   - Ensures tensor memory layout is contiguous before `.to(device)` transfer
   - Fixes potential runtime errors when PyTorch operations create non-contiguous tensor views
   - The slicing operation `batch_tensor[:, :-1]` and `batch_tensor[:, 1:]` can produce non-contiguous tensors

2. **Remove `OMP_NUM_THREADS=1` restriction** (runs/runcpu.sh:13)
   - Allows PyTorch to utilize all available CPU cores
   - Previously limited to single-threaded execution

## Performance Impact

**No performance degradation** - both changes improve or maintain performance:

- **`.contiguous()` overhead**: Negligible (~microseconds). If the tensor is already contiguous, it's a fast no-op check. If not contiguous, the copy operation prevents downstream errors and is necessary for correctness.

- **Removing `OMP_NUM_THREADS=1`**: **Significant performance improvement** on multi-core CPUs. Allowing PyTorch to use all cores can speed up CPU training by 2-8x depending on core count and workload. The original restriction to 1 thread was overly conservative.

## Test plan
- [x] Tested CPU training runs successfully with these changes on multi-core system
- [x] Verified tensor operations work correctly with contiguous memory layout
- [x] Confirmed multi-threaded execution provides expected performance gains

🤖 Generated with [Claude Code](https://claude.com/claude-code)