### PR TITLE
fix sft checkpoint dir to match load_model (sft_checkpoints -> chatsft_checkpoints)

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -285,7 +285,7 @@ while True:
     # save checkpoint at the end of the run (only on master process)
     if master_process and last_step and not args.dry_run:
         output_dirname = args.model_tag if args.model_tag else f"d{depth}" # e.g. d12
-        checkpoint_dir = os.path.join(base_dir, "sft_checkpoints", output_dirname)
+        checkpoint_dir = os.path.join(base_dir, "chatsft_checkpoints", output_dirname)
         save_checkpoint(
             checkpoint_dir,
             step,


### PR DESCRIPTION
Fixes sft checkpoint directory used in `chat_sft.py` to match the path found in `checkpoint_manager.py`: https://github.com/karpathy/nanochat/blob/31b61d2d176adcab739c193fa9190afef2e72909/nanochat/checkpoint_manager.py#L168