### PR TITLE
Enable nanochat to be used as a Python dependency in external projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 dev-ignore/
 report.md
 eval_bundle/
+*.egg-info/
 
 # Secrets
 .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,10 @@ conflicts = [
         { extra = "gpu" },
     ],
 ]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["nanochat"]


### PR DESCRIPTION
**Note**: Not sure if this would be of interest to the project, figured will offer it anyways.

# Summary

Enable nanochat to be used as a Python dependency in external projects.

# Problem

The `pyproject.toml` was missing the `[build-system] `section, which is required for pip to recognize and install the package. Without it, running pip install on nanochat (or adding it as a dependency) would fail because pip didn't know how to build the package.

# Changes

- Added [`build-system]` and [tool.setuptools] sections to pyproject.toml
- Added `*.egg-info/` to `.gitignore`

# Test Plan

Verified nanochat works as a dependency by adding the following to another project:

```
dependencies = [
    "nanochat",
]

[tool.uv.sources]
nanochat = { path = "../nanochat", editable = true }
```