### PR TITLE
Docs: add NorMuon paper link near second-order momentum implementation

### DIFF
--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -243,6 +243,7 @@ class MuonAdamW(torch.optim.Optimizer):
         momentum_buffer = state["momentum_buffer"]
 
         # Second momentum buffer is factored, either per-row or per-column
+        # from NorMuon: https://arxiv.org/abs/2510.05491
         if "second_momentum_buffer" not in state:
             state_shape = (num_params, shape[-2], 1) if shape[-2] >= shape[-1] else (num_params, 1, shape[-1])
             state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)


### PR DESCRIPTION
Hi! Thanks for the awesome work — it’s been super helpful to read and experiment with.

This PR adds a reference to the NorMuon paper at the spot where the second-order momentum is introduced on top of Muon. Since this is a specific design choice described in the paper, having the link there may help readers quickly find the original motivation and details.

If you’d prefer a different location or wording, I’m happy to adjust!
