### PR TITLE
Unify & generalize training script logic

### DIFF
--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -10,50 +10,22 @@
 # Think of this run as educational/fun demo, not something you should expect to work well.
 # You may also want to run this script manually and one by one, copy pasting commands into your terminal.
 
-# all the setup stuff
-export NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
-mkdir -p $NANOCHAT_BASE_DIR
-command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
-[ -d ".venv" ] || uv venv
-uv sync --extra cpu
-source .venv/bin/activate
-if [ -z "$WANDB_RUN" ]; then
-    WANDB_RUN=dummy
-fi
+# See the train.sh script for more details, configuration options and comments.
 
-# train tokenizer on ~2B characters (~34 seconds on my MacBook Pro M3 Max)
-python -m nanochat.dataset -n 8
-python -m scripts.tok_train --max-chars=2000000000
-python -m scripts.tok_eval
-
-# train a small 4 layer model
+export EXTRA_DEPENDENCIES=cpu
+export WRITE_REPORT=0
+export DATASET_SHARDS_TO_DOWNLOAD=8
+export NPROC_PER_NODE=1
 # I tuned this run to complete in about 30 minutes on my MacBook Pro M3 Max.
 # To get better results, try increasing num_iterations, or get other ideas from your favorite LLM.
-python -m scripts.base_train \
-    --depth=6 \
-    --head-dim=64 \
-    --window-pattern=L \
-    --max-seq-len=512 \
-    --device-batch-size=32 \
-    --total-batch-size=16384 \
-    --eval-every=100 \
-    --eval-tokens=524288 \
-    --core-metric-every=-1 \
-    --sample-every=100 \
-    --num-iterations=5000 \
-    --run=$WANDB_RUN
-python -m scripts.base_eval --device-batch-size=1 --split-tokens=16384 --max-per-task=16
-
-# SFT (~10 minutes on my MacBook Pro M3 Max)
-curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
-python -m scripts.chat_sft \
-    --max-seq-len=512 \
-    --device-batch-size=32 \
-    --total-batch-size=16384 \
-    --eval-every=200 \
-    --eval-tokens=524288 \
-    --num-iterations=1500 \
-    --run=$WANDB_RUN
+export MODEL_DEPTH=6
+export DEVICE_BATCH_SIZE=32
+export EVAL_BATCH_SIZE=1
+export EXTRA_BASE_TRAINING_ARGS="--head-dim=64 --window-pattern=L --max-seq-len=512 --total-batch-size=16384 --eval-every=100 --eval-tokens=524288 --core-metric-every=-1 --sample-every=100 --num-iterations=5000"
+export EXTRA_BASE_EVAL_ARGS="--split-tokens=16384 --max-per-task=16"
+export EXTRA_SFT_TRAINING_ARGS="--max-seq-len=512 --total-batch-size=16384 --eval-every=200 --eval-tokens=524288 --num-iterations=1500"
+export RUN_SFT_EVAL=0
+bash $(dirname $(realpath $0))/train.sh
 
 # Chat with the model over CLI
 # The model should be able to say that it is Paris.

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -10,88 +10,15 @@
 # 3) Example launch with wandb logging, but see below for setting up wandb first:
 # WANDB_RUN=speedrun screen -L -Logfile runs/speedrun.log -S speedrun bash runs/speedrun.sh
 
-# Default intermediate artifacts directory is in ~/.cache/nanochat
-export OMP_NUM_THREADS=1
-export NANOCHAT_BASE_DIR="$HOME/.cache/nanochat"
-mkdir -p $NANOCHAT_BASE_DIR
+# See the train.sh script for more details, configuration options and comments.
 
-# -----------------------------------------------------------------------------
-# Python venv setup with uv
-
-# install uv (if not already installed)
-command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
-# create a .venv local virtual environment (if it doesn't exist)
-[ -d ".venv" ] || uv venv
-# install the repo dependencies
-uv sync --extra gpu
-# activate venv so that `python` uses the project's venv instead of system python
-source .venv/bin/activate
-
-# -----------------------------------------------------------------------------
-# wandb setup
-# If you wish to use wandb for logging (it's nice!, recommended).
-# 1) Make sure to first log in to wandb, e.g. run:
-#    `wandb login`
-# 2) Set the WANDB_RUN environment variable when running this script, e.g.:
-#    `WANDB_RUN=d26 bash speedrun.sh`
-if [ -z "$WANDB_RUN" ]; then
-    # by default use "dummy" : it's handled as a special case, skips logging to wandb
-    WANDB_RUN=dummy
-fi
-
-# -----------------------------------------------------------------------------
-# During the course of the run, we will be writing markdown reports to the report/
-# directory in the base dir. This command clears it out and writes a header section
-# with a bunch of system info and a timestamp that marks the start of the run.
-python -m nanochat.report reset
-
-# -----------------------------------------------------------------------------
-# Tokenizer
-
-# Download the first ~2B characters of pretraining dataset
-# each data shard is ~250M chars
-# so we download 2e9 / 250e6 = 8 data shards at this point
-# each shard is ~100MB of text (compressed), so this is about ~800MB of data on disk
-# look at dev/repackage_data_reference.py for details on how this data was prepared
-python -m nanochat.dataset -n 8
-# Immediately also kick off downloading more shards in the background while tokenizer trains
-# Approximately 350 shards are needed for 10B tokens of data for pretraining.
-# The maximum total number of shards available in the entire dataset is 1822.
-python -m nanochat.dataset -n 370 &
-DATASET_DOWNLOAD_PID=$!
-# train the tokenizer with vocab size 2**15 = 32768 on ~2B characters of data
-python -m scripts.tok_train
-# evaluate the tokenizer (report compression ratio etc.)
-python -m scripts.tok_eval
-
-# -----------------------------------------------------------------------------
-# Base model (pretraining)
-echo "Waiting for dataset download to complete..."
-wait $DATASET_DOWNLOAD_PID
-
-# d24 model (slightly overtrained is enough to beat GPT-2 => increase data:params ratio from compute optimal 10.5 (default) to 12)
-torchrun --standalone --nproc_per_node=8 -m scripts.base_train -- --depth=26 --target-param-data-ratio=8.5 --device-batch-size=16 --fp8 --run=$WANDB_RUN
-# evaluate the model: CORE metric, BPB on train/val, and draw samples
-torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-size=16
-
-# -----------------------------------------------------------------------------
-# SFT (teach the model conversation special tokens, tool use, multiple choice)
-
-# download 2.3MB of synthetic identity conversations to impart a personality to nanochat
-# see dev/gen_synthetic_data.py for details on how this data was prepared and to get a sense of how you can easily tune it
-curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
-
-# run SFT and eval the model
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --device-batch-size=16 --run=$WANDB_RUN
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
+export USE_FP8=1 # use FP8 instead of BF16 training for speed and memory savings
+# (slightly overtrained is enough to beat GPT-2 => increase data:params ratio from compute optimal 10.5 (default) to 12)
+export EXTRA_BASE_TRAINING_ARGS="--target-param-data-ratio=8.5"
+bash $(dirname $(realpath $0))/train.sh
 
 # chat with the model over CLI! Leave out the -p to chat interactively
 # python -m scripts.chat_cli -p "Why is the sky blue?"
 
 # even better, chat with your model over a pretty WebUI ChatGPT style
 # python -m scripts.chat_web
-
-# -----------------------------------------------------------------------------
-# Generate the full report by putting together all the sections
-# report.md is the output and will be copied to current directory for convenience
-python -m nanochat.report generate

--- a/runs/train.sh
+++ b/runs/train.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# Terminate the script if any command exits with a non-zero status (error).
+set -e -o pipefail
+
+# -----------------------------------------------------------------------------
+# Configuration (everything is overridable by setting these env variables)
+SKIP_SETUP=${SKIP_SETUP:-} # Set to 1 to skip installing uv and dependencies
+# Extra training dependencies to install (cpu or gpu)
+EXTRA_DEPENDENCIES=${EXTRA_DEPENDENCIES:-gpu}
+# If you wish to use wandb for logging (it's nice!, recommended).
+# 1) Make sure to first log in to wandb, e.g. run:
+#    `wandb login`
+# 2) Set the WANDB_RUN environment variable when running this script, e.g.:
+#    `WANDB_RUN=d26 bash speedrun.sh`
+WANDB_RUN=${WANDB_RUN:-dummy} # by default use "dummy" : it's handled as a special case, skips logging to wandb
+WRITE_REPORT=${WRITE_REPORT:-1} # Set to 0 to skip writing the markdown report
+# Number of dataset shards to download in background (set to 0 to skip
+# downloading). Each data shard is ~250M chars (~100MB of compressed text). At
+# least 8 shards (~2B characters) are needed for tokenizer training. The maximum
+# total number of shards available in the entire dataset is 1822.
+DATASET_SHARDS_TO_DOWNLOAD=${DATASET_SHARDS_TO_DOWNLOAD:-370}
+TRAIN_TOKENIZER=${TRAIN_TOKENIZER:-1} # Set to 0 to skip tokenizer training
+# Default intermediate artifacts directory is in ~/.cache/nanochat, override by
+# setting NANOCHAT_BASE_DIR to a different path.
+# The number of processes (and GPUs) to use for training/eval.
+NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
+MODEL_DEPTH=${MODEL_DEPTH:-26} # Number of transformer layers
+# Batch size per GPU for training/eval. Decrease if you run out of memory,
+# increase if you have more memory and want to go faster.
+DEVICE_BATCH_SIZE=${DEVICE_BATCH_SIZE:-16}
+EVAL_BATCH_SIZE=${EVAL_BATCH_SIZE:-$DEVICE_BATCH_SIZE}
+USE_FP8=${USE_FP8:-} # Set to 1 to use FP8 training, otherwise will use BF16
+# Extra args to pass to base model training script, see scripts/base_train.py
+EXTRA_BASE_TRAINING_ARGS=${EXTRA_BASE_TRAINING_ARGS:-}
+# Extra args to pass to base model eval script, see scripts/base_eval.py
+EXTRA_BASE_EVAL_ARGS=${EXTRA_BASE_EVAL_ARGS:-}
+# Extra args to pass to SFT training script, see scripts/chat_sft.py
+EXTRA_SFT_TRAINING_ARGS=${EXTRA_SFT_TRAINING_ARGS:-}
+RUN_SFT_EVAL=${RUN_SFT_EVAL:-1} # Set to 0 to skip SFT eval
+# Extra args to pass to SFT eval script, see scripts/chat_eval.py
+EXTRA_SFT_EVAL_ARGS=${EXTRA_SFT_EVAL_ARGS:-}
+export NANOCHAT_BASE_DIR=${NANOCHAT_BASE_DIR:-"$HOME/.cache/nanochat"}
+# Number of threads for OpenMP (set to 1 to avoid oversubscription).
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+
+# -----------------------------------------------------------------------------
+# Setup
+if [ -z "$SKIP_SETUP" ]; then
+    mkdir -p $NANOCHAT_BASE_DIR
+
+    # Python venv setup with uv
+
+    # install uv (if not already installed)
+    command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+    # create a .venv local virtual environment (if it doesn't exist)
+    [ -d ".venv" ] || uv venv
+    # install the repo dependencies
+    uv sync --extra $EXTRA_DEPENDENCIES
+    # activate venv so that `python` uses the project's venv instead of system python
+    source .venv/bin/activate
+else
+    source .venv/bin/activate
+fi
+
+# -----------------------------------------------------------------------------
+if [ "$WRITE_REPORT" -eq "1" ]; then
+    # During the course of the run, we will be writing markdown reports to the
+    # report/ directory in the base dir. This command clears it out and writes a
+    # header section with a bunch of system info and a timestamp that marks the
+    # start of the run.
+    python -m nanochat.report reset
+fi
+
+# -----------------------------------------------------------------------------
+# Pretraining dataset download
+if [ "$DATASET_SHARDS_TO_DOWNLOAD" -gt 0 ]; then
+    # Download the first ~2B characters of pretraining dataset for tokenizer
+    # training. Look at dev/repackage_data_reference.py for details on how this
+    # data was prepared.
+    python -m nanochat.dataset -n 8
+    # Immediately also kick off downloading more shards in the background while
+    # tokenizer trains (if enabled). Approximately 350 shards are needed for 10B
+    # tokens of data for pretraining.
+    if [ "$DATASET_SHARDS_TO_DOWNLOAD" -gt 8 ]; then
+        python -m nanochat.dataset -n $DATASET_SHARDS_TO_DOWNLOAD &
+        DATASET_DOWNLOAD_PID=$!
+    fi
+fi
+
+
+# -----------------------------------------------------------------------------
+# Tokenizer
+if [ "$TRAIN_TOKENIZER" -eq 1 ]; then
+    # train the tokenizer with vocab size 2**15 = 32768 on ~2B characters of
+    # data
+    python -m scripts.tok_train --max-chars=2000000000
+    # evaluate the tokenizer (report compression ratio etc.)
+    python -m scripts.tok_eval
+fi
+
+# -----------------------------------------------------------------------------
+# Complete pretraining dataset download
+if [ "$DATASET_DOWNLOAD_PID" ]; then
+    echo "Waiting for dataset download to complete..."
+    wait $DATASET_DOWNLOAD_PID
+fi
+
+# -----------------------------------------------------------------------------
+# Base model (pretraining)
+if [ "$USE_FP8" -eq "1" ]; then
+    EXTRA_BASE_TRAINING_ARGS+=" --fp8"
+fi
+torchrun --standalone --nproc_per_node=$NPROC_PER_NODE -m scripts.base_train -- --depth=$MODEL_DEPTH --device-batch-size=$DEVICE_BATCH_SIZE --run=$WANDB_RUN $EXTRA_BASE_TRAINING_ARGS
+# evaluate the model: CORE metric, BPB on train/val, and draw samples
+torchrun --standalone --nproc_per_node=$NPROC_PER_NODE -m scripts.base_eval -- --device-batch-size=$EVAL_BATCH_SIZE $EXTRA_BASE_EVAL_ARGS
+
+# -----------------------------------------------------------------------------
+# SFT (teach the model conversation special tokens, tool use, multiple choice)
+
+# Download 2.3MB of synthetic identity conversations to impart a personality to
+# nanochat. See dev/gen_synthetic_data.py for details on how this data was
+# prepared and to get a sense of how you can easily tune it.
+if [ ! -f "$NANOCHAT_BASE_DIR/identity_conversations.jsonl" ]; then
+    curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
+fi
+
+# run SFT and eval the model
+torchrun --standalone --nproc_per_node=$NPROC_PER_NODE -m scripts.chat_sft -- --device-batch-size=$DEVICE_BATCH_SIZE --run=$WANDB_RUN $EXTRA_SFT_TRAINING_ARGS
+if [ "$RUN_SFT_EVAL" -eq "1" ]; then
+    torchrun --standalone --nproc_per_node=$NPROC_PER_NODE -m scripts.chat_eval -- -i sft $EXTRA_SFT_EVAL_ARGS
+fi
+
+# -----------------------------------------------------------------------------
+# Generate the full report by putting together all the sections
+# report.md is the output and will be copied to current directory for convenience
+if [ "$WRITE_REPORT" -eq "1" ]; then
+    python -m nanochat.report generate
+fi


### PR DESCRIPTION
Merge the logic shared by the `runs/speedrun.sh` and `runs/runcpu.sh` scripts into a shared configurable and extensible common script `runs/train.sh`, which can also be used by itself and is configurable via environment variables.

The `train.sh` script provides reasonable defaults (almost exactly matching the speedrun script) and places all of configuration variables in one place at the top of the file for ease of editing/reference/overriding, along with explanatory comments.

This unification reduces the risk of diverging code paths with future modifications.

The code was tested on a single-node 8×H100 (PCIe) and seems to work correctly.

AI disclosure: All edits were done by hand and Github Copilot inline suggestions. Copilot Agent was used for code review before running the code.

See also: #435 Proposal: Merge training shell scripts (original proposal, code has shifted since the original idea).