### PR TITLE
Change default sliding window pattern to the recommended "L" when FA3 is not available

### DIFF
--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -168,6 +168,9 @@ def flash_attn_with_kvcache(q, k_cache, v_cache, k=None, v=None, cache_seqlens=N
 
     return y_sdpa.transpose(1, 2)  # back to (B, T, H, D)
 
+def default_window_pattern():
+    # FA3 has native support for window pattern otherwise there is none and it's slow -> fallback to just L
+    return "SSSL" if _use_fa3() else "L"
 
 # =============================================================================
 # Export: flash_attn module interface (drop-in replacement for FA3)

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -50,7 +50,7 @@ parser.add_argument("--depth", type=int, default=20, help="depth of the Transfor
 parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = depth * aspect_ratio")
 parser.add_argument("--head-dim", type=int, default=128, help="target head dimension for attention")
 parser.add_argument("--max-seq-len", type=int, default=2048, help="max context length")
-parser.add_argument("--window-pattern", type=str, default="SSSL", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
+parser.add_argument("--window-pattern", type=str, default="SSSL" if HAS_FA3 else "L", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
 # Training horizon (only one used, in order of precedence)
 parser.add_argument("--num-iterations", type=int, default=-1, help="explicit number of optimization steps (-1 = disable)")
 parser.add_argument("--target-flops", type=float, default=-1.0, help="calculate num_iterations to reach target_flops (-1 = disable)")

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -31,7 +31,7 @@ from nanochat.tokenizer import get_tokenizer, get_token_bytes
 from nanochat.checkpoint_manager import save_checkpoint, load_checkpoint
 from nanochat.loss_eval import evaluate_bpb
 from nanochat.engine import Engine
-from nanochat.flash_attention import HAS_FA3
+from nanochat.flash_attention import HAS_FA3, default_window_pattern
 from scripts.base_eval import evaluate_core
 print_banner()
 
@@ -50,7 +50,7 @@ parser.add_argument("--depth", type=int, default=20, help="depth of the Transfor
 parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = depth * aspect_ratio")
 parser.add_argument("--head-dim", type=int, default=128, help="target head dimension for attention")
 parser.add_argument("--max-seq-len", type=int, default=2048, help="max context length")
-parser.add_argument("--window-pattern", type=str, default="SSSL" if HAS_FA3 else "L", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
+parser.add_argument("--window-pattern", type=str, default=default_window_pattern(), help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
 # Training horizon (only one used, in order of precedence)
 parser.add_argument("--num-iterations", type=int, default=-1, help="explicit number of optimization steps (-1 = disable)")
 parser.add_argument("--target-flops", type=float, default=-1.0, help="calculate num_iterations to reach target_flops (-1 = disable)")


### PR DESCRIPTION
Changes default setting of sliding window pattern for setups without out-of-the-box FA3 support to the recommended in the warning.

This simplifies configuration for beginners running nanochat on their local setups, e.g. consumer grade GPUs like 3090/4090 and others without FA3 support.

Before:
```
$ python -m scripts.base_train --depth=12 --device-batch-size=16
...
GPU: NVIDIA GeForce RTX 3090 | Peak FLOPS (BF16): 7.10e+13
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: Flash Attention 3 not available, using PyTorch SDPA fallback
WARNING: Training will be less efficient without FA3
WARNING: SDPA has no support for sliding window attention (window_pattern='SSSL'). Your GPU utilization will be terrible.
WARNING: Recommend using --window-pattern L for full context attention without alternating sliding window patterns.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Vocab size: 32,768
Model config:
{
  "sequence_len": 2048,
  "vocab_size": 32768,
  "n_layer": 12,
  "n_head": 6,
  "n_kv_head": 6,
  "n_embd": 768,
  "window_pattern": "SSSL"
}
...
step 00011/02205 (0.50%) | loss: 8.170549 | lrm: 1.00 | dt: 13119.33ms | tok/sec: 39,963 | mfu: 45.15 | epoch: 1 | total time: 0.22m | eta: 479.7m
```

After:
```
$ python -m scripts.base_train --depth=12 --device-batch-size=16
...
GPU: NVIDIA GeForce RTX 3090 | Peak FLOPS (BF16): 7.10e+13
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: Flash Attention 3 not available, using PyTorch SDPA fallback
WARNING: Training will be less efficient without FA3
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Vocab size: 32,768
Model config:
{
  "sequence_len": 2048,
  "vocab_size": 32768,
  "n_layer": 12,
  "n_head": 6,
  "n_kv_head": 6,
  "n_embd": 768,
  "window_pattern": "L"
}
...
step 00011/02205 (0.50%) | loss: 8.177470 | lrm: 1.00 | dt: 7127.85ms | tok/sec: 73,554 | mfu: 91.90 | epoch: 1 | total time: 0.12m | eta: 260.6m
```