### PR TITLE
fix lerp dtype handling in fused optimizers

### DIFF
--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -134,10 +134,7 @@ def muon_step_fused(
     red_dim_size = g.size(red_dim)
     v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True) * red_dim_size
     v_norm = v_norm_sq.sqrt()
-    second_momentum_buffer.lerp_(
-        v_mean.to(dtype=second_momentum_buffer.dtype),
-        (1 - beta2).to(dtype=second_momentum_buffer.dtype),
-    )
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
     step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt()
     scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
     v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt()


### PR DESCRIPTION
See https://github.com/karpathy/nanochat/issues/527