### PR TITLE
Save FP8 tensors in autograd ctx instead of full-precision inputs

### DIFF
--- a/nanochat/fp8.py
+++ b/nanochat/fp8.py
@@ -173,16 +173,15 @@ class _Float8Matmul(torch.autograd.Function):
 
         # === GEMM 2: grad_weight = grad_output.T @ input ===
         # Shapes: [N, B] @ [B, K] -> [N, K]
-        go_fp8_2, go_inv_2 = _to_fp8(grad_output, torch.float8_e5m2)
-        # go_fp8_2 is [B, N] contiguous, we need go.T = [N, B] as first arg.
+        # go_fp8 is [B, N] contiguous, we need go.T = [N, B] as first arg.
         # Transposing gives column-major, but first arg needs row-major,
         # so we must call .contiguous() to physically rearrange the memory.
-        go_T = go_fp8_2.t().contiguous()  # [N, B] row-major
+        go_T = go_fp8.t().contiguous()  # [N, B] row-major
         in_col = _to_col_major(in_fp8)    # [B, K] column-major
         grad_weight = torch._scaled_mm(
             go_T,
             in_col,
-            scale_a=go_inv_2,
+            scale_a=go_inv,
             scale_b=in_inv,
             out_dtype=grad_output.dtype,
             use_fast_accum=False,


### PR DESCRIPTION
**Summary**

This change updates `_Float8Matmul` to (1) save FP8 inputs/weights and their inverse scales in the autograd context instead of the original full-precision tensors, and (2) quantize `grad_output` to FP8 only once in backward and reuse it for both GEMMs. Backward now reuses these quantized tensors directly with `torch._scaled_mm`, avoiding redundant quantization and reducing saved-activation memory, while keeping numerics identical to the previous implementation under the tensorwise scaling recipe.

---

**Motivation**

The original version followed a conservative, torchao-style design:

* In forward, it stored `input_2d` and `weight` (bf16/fp32) in `ctx.save_for_backward`.
* In backward, it:

  * re-quantized `weight` and `input_2d` from full precision, and
  * quantized `grad_output` separately for each of the two backward GEMMs.

This pattern makes sense in a more general setting (like torchao) where:

* you may want to change quantization recipes between forward and backward, and
* you may use different scaling configs or axes for different GEMMs (e.g. rowwise scaling for grad-input vs grad-weight).

In this minimal FP8 training setup, none of that extra flexibility is actually used:

* Backward only ever needs:

  * `quant(input_2d) + its inverse scale`
  * `quant(weight) + its inverse scale`
  * `quant(grad_output) + its inverse scale`
* `_to_fp8` is deterministic for a given tensor and dtype.

That means:

* The FP8 tensors produced in forward are exactly the FP8 tensors backward would recompute from `input_2d` and `weight`.
* Quantizing `grad_output` twice in backward (once for each GEMM) is also redundant under tensorwise scaling: both GEMMs can share the same FP8 representation and scale.

So the full-precision inputs in `ctx`, and the second quantization of `grad_output`, are redundant.

