### PR TITLE
Fix MockModel's device definition

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,7 +31,6 @@ class MockModel:
     def __init__(self, vocab_size=262):  # 256 bytes + 6 special tokens
         self.vocab_size = vocab_size
         self.config = MockConfig()
-        self._device = "cpu"
         self._device = torch.device("cpu")
 
     def get_device(self):


### PR DESCRIPTION
Since [this edit](https://github.com/karpathy/nanochat/commit/f9a7e0f111f9955a640c69cd3dfe457813dc4601), the tests have been failing because the `MockModel`'s definition of `get_device()` would return a `str` which would crash in the engine's `generate` function:

```
device = self.model.get_device()
dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
```

with a 
> AttributeError: 'str' object has no attribute 'type'

Even if that code is hacky (as stated by the docstring) and would be improved in the future, I think it'd be good to update `MockModel` to have it in line with `GPT` and prevent similar issues in the future.