### PR TITLE
Fix bug in setting precision

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -170,7 +170,7 @@ def compute_init(device_type="cuda"): # cuda|cpu|mps
 
     # Precision
     if device_type == "cuda":
-        torch.backends.fp32_precision = "tf32" # uses tf32 instead of fp32 for matmuls
+        torch.set_float32_matmul_precision("high") # uses tf32 instead of fp32 for matmuls, see https://docs.pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html
 
     # Distributed setup: Distributed Data Parallel (DDP), optional, and requires CUDA
     is_ddp_requested, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()


### PR DESCRIPTION
Previously, we had 

```python
torch.backends.fp32_precision = "tf32"
```

I do not think this had the desired effect. I tested on my GPU and saw this did not change the precision in test examples. Furthermore, in the [PyTorch docs](https://docs.pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html), they suggest this

```python
torch.backends.cuda.matmul.allow_tf32 = True
```

This can be accomplished through

```python
torch.set_float32_matmul_precision("high")
```