### PR TITLE
Use HF's community kernel for FA3 for Ada and Ampere

### DIFF
--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -18,22 +18,21 @@ import torch.nn.functional as F
 
 
 # =============================================================================
-# Detection: Try to load FA3 on Hopper+ GPUs
+# Detection: Try to load FA3 on CUDA GPUs
 # =============================================================================
 def _load_flash_attention_3():
-    """Try to load Flash Attention 3 (requires Hopper GPU, sm90)."""
+    """Try to load Flash Attention 3."""
+    hf_kernel = 'kernels-community/flash-attn3'
     if not torch.cuda.is_available():
         return None
     try:
-        major, _ = torch.cuda.get_device_capability()
-        # FA3 kernels are compiled for Hopper (sm90) only
-        # Ada (sm89), Blackwell (sm100) need SDPA fallback until FA3 is recompiled
-        if major != 9:
+        from kernels import get_kernel, has_kernel
+        supported = has_kernel(hf_kernel)
+        if not supported:
             return None
         import os
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
-        from kernels import get_kernel
-        return get_kernel('varunneal/flash-attention-3').flash_attn_interface
+        return get_kernel(hf_kernel).flash_attn_interface
     except Exception:
         return None
 

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -2,7 +2,7 @@
 Unified Flash Attention interface with automatic FA3/SDPA switching.
 
 Exports `flash_attn` module that matches the FA3 API exactly, but falls back
-to PyTorch SDPA on non-Hopper GPUs (including Blackwell), MPS, and CPU.
+to PyTorch SDPA on incompatible CUDA GPUs, MPS, and CPU.
 
 Usage (drop-in replacement for FA3):
     from nanochat.flash_attention import flash_attn

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -26,8 +26,8 @@ def _load_flash_attention_3():
     if not torch.cuda.is_available():
         return None
     try:
-        # FA3 kernels are currently compiled for Hopper (sm90) and Ampere (sm80/sm86)
-        # Ada (sm89), Blackwell (sm100) need SDPA fallback until FA3 is recompiled
+        # FA3 kernels are currently compiled for Hopper (sm90), Ada (sm89) and Ampere (sm80/sm86)
+        # Blackwell (sm100) needs SDPA fallback until FA3 is recompiled or FA4 is released
         from kernels import get_kernel, has_kernel
         supported = has_kernel(hf_kernel)
         if not supported:

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -26,6 +26,8 @@ def _load_flash_attention_3():
     if not torch.cuda.is_available():
         return None
     try:
+        # FA3 kernels are currently compiled for Hopper (sm90) and Ampere (sm80/sm86)
+        # Ada (sm89), Blackwell (sm100) need SDPA fallback until FA3 is recompiled
         from kernels import get_kernel, has_kernel
         supported = has_kernel(hf_kernel)
         if not supported:

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -25,11 +25,11 @@ def _load_flash_attention_3():
     if not torch.cuda.is_available():
         return None
     try:
-        cap = torch.cuda.get_device_capability()
+        major, _ = torch.cuda.get_device_capability()
         # FA3 kernels are currently compiled for Hopper (sm90), Ada (sm89) and Ampere (sm80/sm86)
         # Blackwell (sm100) needs SDPA fallback until FA3 is recompiled or FA4 is released
-        # varunneal kernel obtains better results for H100
-        hf_kernel = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
+        # varunneal kernel obtains better results for H100/Hopper
+        hf_kernel = "varunneal/flash-attention-3" if major == 9 else "kernels-community/flash-attn3"
         from kernels import get_kernel
         import os
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -28,12 +28,20 @@ def _load_flash_attention_3():
         major, _ = torch.cuda.get_device_capability()
         # FA3 kernels are currently compiled for Hopper (sm90), Ada (sm89) and Ampere (sm80/sm86)
         # Blackwell (sm100) needs SDPA fallback until FA3 is recompiled or FA4 is released
-        # varunneal kernel obtains better results for H100/Hopper
         import os
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
-        from kernels import get_kernel
-        hf_kernel = "varunneal/flash-attention-3" if major == 9 else "kernels-community/flash-attn3"
-        return get_kernel(hf_kernel).flash_attn_interface
+        from kernels import get_kernel, has_kernel
+        # The varunneal kernel obtains better results for H100/Hopper
+        if major == 9:
+            hf_kernel = "varunneal/flash-attention-3"
+            return get_kernel(hf_kernel).flash_attn_interface
+        else:
+            hf_kernel = "kernels-community/flash-attn3"
+            if has_kernel(hf_kernel):
+                return get_kernel(hf_kernel).flash_attn_interface
+            else:
+                return None
+
     except Exception:
         return None
 

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -29,10 +29,10 @@ def _load_flash_attention_3():
         # FA3 kernels are currently compiled for Hopper (sm90), Ada (sm89) and Ampere (sm80/sm86)
         # Blackwell (sm100) needs SDPA fallback until FA3 is recompiled or FA4 is released
         # varunneal kernel obtains better results for H100/Hopper
-        hf_kernel = "varunneal/flash-attention-3" if major == 9 else "kernels-community/flash-attn3"
-        from kernels import get_kernel
         import os
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
+        from kernels import get_kernel
+        hf_kernel = "varunneal/flash-attention-3" if major == 9 else "kernels-community/flash-attn3"
         return get_kernel(hf_kernel).flash_attn_interface
     except Exception:
         return None

--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -22,16 +22,15 @@ import torch.nn.functional as F
 # =============================================================================
 def _load_flash_attention_3():
     """Try to load Flash Attention 3."""
-    hf_kernel = 'kernels-community/flash-attn3'
     if not torch.cuda.is_available():
         return None
     try:
+        cap = torch.cuda.get_device_capability()
         # FA3 kernels are currently compiled for Hopper (sm90), Ada (sm89) and Ampere (sm80/sm86)
         # Blackwell (sm100) needs SDPA fallback until FA3 is recompiled or FA4 is released
-        from kernels import get_kernel, has_kernel
-        supported = has_kernel(hf_kernel)
-        if not supported:
-            return None
+        # varunneal kernel obtains better results for H100
+        hf_kernel = "varunneal/flash-attention-3" if cap == (9, 0) else "kernels-community/flash-attn3"
+        from kernels import get_kernel
         import os
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
         return get_kernel(hf_kernel).flash_attn_interface

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -22,7 +22,7 @@ import torch.nn.functional as F
 from nanochat.common import get_dist_info, print0
 from nanochat.optim import MuonAdamW, DistMuonAdamW
 
-# Our custom Flash Attention module that automatically uses FA3 on Hopper+ and SDPA fallback elsewhere
+# Our custom Flash Attention module that automatically uses FA3 when compatible and SDPA fallback otherwise
 from nanochat.flash_attention import flash_attn
 
 @dataclass
@@ -93,7 +93,7 @@ class CausalSelfAttention(nn.Module):
         q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
         q, k = norm(q), norm(k) # QK norm
 
-        # Flash Attention (FA3 on Hopper+, PyTorch SDPA fallback elsewhere)
+        # Flash Attention (FA3 or SDPA fallback)
         # window_size is (left, right) tuple: (N, 0) for causal, (-1, 0) for full context
         if kv_cache is None:
             # Training: causal attention with optional sliding window

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -96,7 +96,7 @@ wandb_run = DummyWandb() if use_dummy_wandb else wandb.init(project="nanochat", 
 
 # Flash Attention status
 if HAS_FA3:
-    print0("✓ Using Flash Attention 3 (Hopper GPU detected), efficient, new and awesome.")
+    print0("✓ Using Flash Attention 3: efficient, new and awesome.")
 else:
     print0("!" * 80)
     print0("WARNING: Flash Attention 3 not available, using PyTorch SDPA fallback")

--- a/tests/test_attention_fallback.py
+++ b/tests/test_attention_fallback.py
@@ -7,8 +7,8 @@ Note on test structure:
     Tests are split into two classes due to dtype/device constraints:
 
     1. TestFA3VsSDPA: Comparison tests that run both FA3 and SDPA on the same inputs
-       and verify they produce identical results. These require a Hopper GPU (FA3 only
-       works on sm90+) and use bfloat16 (FA3 doesn't support float32).
+       and verify they produce identical results. These require a compatible GPU (FA3 only
+       works on sm80 and sm90) and use bfloat16 (FA3 doesn't support float32).
 
     2. TestSDPAOnly: Tests that only exercise the SDPA fallback path. These can run
        on any device (CUDA, CPU, MPS) with the appropriate dtype for that device.
@@ -45,11 +45,11 @@ def assert_close(t1, t2, name, atol=1e-2, rtol=1e-2):
 
 
 # =============================================================================
-# FA3 vs SDPA comparison tests (require Hopper GPU)
+# FA3 vs SDPA comparison tests
 # =============================================================================
 @pytest.mark.skipif(not HAS_FA3, reason="FA3 required to compare implementations")
 class TestFA3VsSDPA:
-    """Compare FA3 and SDPA produce identical results. Requires Hopper GPU."""
+    """Compare FA3 and SDPA produce identical results."""
 
     DEVICE = "cuda"
     DTYPE = torch.bfloat16


### PR DESCRIPTION
We currently use `varunneal/flash-attention-3`, but this is only supported on Hopper. The officially supported kernel `kernels-community/flash-attn3` however also works on Ada (RTX 40xx) and on Ampere (A100 and RTX 30xx).

There was a small bug before that is fixed now, cf https://github.com/huggingface/kernels-community/issues/312.

For Hopper, we stay with `varunneal/flash-attention-3` as it's quicker, cf below in thread comments 👇 

## Experiments on 8x A100

I just ran a `speedrun` on an 8x A100 which gave me 

```
GPU: NVIDIA A100-SXM4-80GB | Peak FLOPS (BF16): 3.12e+14
✓ Using Flash Attention 3: efficient, new and awesome.
```

and runs at about 315 `tok/sec`.

On the same branch and the same 8x A100, but using the SDPA fallback and setting `window-pattern="L"`:

```
GPU: NVIDIA A100-SXM4-80GB | Peak FLOPS (BF16): 3.12e+14
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: Flash Attention 3 not available, using PyTorch SDPA fallback
WARNING: Training will be less efficient without FA3
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
gives about 309 `tok/sec`  (using the default `window-pattern` SSSL would be about 226 `tok/sec`.)

So not a huge improvement, but by using `kernels-community/flash-attn3` we can run `speedrun` with the default settings on the A100 & RTX 40/30xx architectures and it will work nicer out of the box.

~~I haven't double checked on an H100 yet, but I would expect the same performance as `varunneal/flash-attention-3`.~~



