### PR TITLE
fix: add retry with exponential backoff to download_file_with_lock

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -3,6 +3,7 @@ Common utilities for nanochat.
 """
 
 import os
+import time
 import re
 import logging
 import urllib.request
@@ -78,19 +79,41 @@ def download_file_with_lock(url, filename, postprocess_fn=None):
         if os.path.exists(file_path):
             return file_path
 
-        # Download the content as bytes
-        print(f"Downloading {url}...")
-        with urllib.request.urlopen(url) as response:
-            content = response.read() # bytes
-
-        # Write to local file
-        with open(file_path, 'wb') as f:
-            f.write(content)
-        print(f"Downloaded to {file_path}")
-
-        # Run the postprocess function if provided
-        if postprocess_fn is not None:
-            postprocess_fn(file_path)
+        # Download with retries
+        max_attempts = 5
+        for attempt in range(1, max_attempts + 1):
+            try:
+                print(f"Downloading {url}... (attempt {attempt}/{max_attempts})")
+                with urllib.request.urlopen(url, timeout=30) as response:
+                    content = response.read() # bytes
+                    
+                # Write to local file
+                with open(file_path, 'wb') as f:
+                    f.write(content)
+                print(f"Downloaded to {file_path}")
+                
+                # Run the postprocess function if provided
+                if postprocess_fn is not None:
+                    postprocess_fn(file_path)
+                    
+                return file_path
+            
+            except Exception as e:
+                print(f"Attempt {attempt}/{max_attempts} failed for {filename}: {e}")
+                # Clean up any partial files
+                if os.path.exists(file_path):
+                    try:
+                        os.remove(file_path)
+                    except:
+                        pass
+                # Try a few times with exponential backoff: 2^attempt seconds
+                if attempt < max_attempts:
+                    wait_time = 2 ** attempt
+                    print(f"Waiting {wait_time} seconds before retry...")
+                    time.sleep(wait_time)
+                else:
+                    print(f"Failed to download {filename} after {max_attempts} attempts")
+                    raise
 
     return file_path
 


### PR DESCRIPTION
Fixes #554 

### Impact
Prevents transient network failures (DNS resolution, connection timeout, etc.) from crashing multi-GPU training runs. Without this fix, a single network hiccup during eval_bundle.zip download at step 2000 causes all 8 ranks to hang and abort via NCCL watchdog, losing hours of training progress.

### Change
Added retry logic with exponential backoff and explicit timeout to download_file_with_lock in nanochat/common.py, matching the existing pattern used by download_single_file in nanochat/dataset.py:
• max_attempts = 5 with exponential backoff (2^attempt seconds)
• timeout=30 on urlopen (same as dataset.py's requests.get..., timeout=30))
• Partial file cleanup on failure
• Consistent error message format: Attempt {attempt}/{max_attempts} failed for {filename}: {e}

On a healthy network, the download succeeds on the first attempt and behavior is identical to the original. The existing FileLock mechanism for multi-rank co ordination is unchanged.