### PR TITLE
[Research] NanoKnow: A benchmark to evaluate what your nanochat checkpoint actually knows 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ I've published a number of guides that might contain helpful information, most r
 - To customize your nanochat, see [Guide: infusing identity to your nanochat](https://github.com/karpathy/nanochat/discussions/139) in Discussions, which describes how you can tune your nanochat's personality through synthetic data generation and mixing that data into the SFT stage.
 - [Oct 13 2025: original nanochat post](https://github.com/karpathy/nanochat/discussions/1) introducing nanochat, though now it contains some deprecated information and the model is a lot older (with worse results) than current master.
 
+## Benchmarks
+
+[NanoKnow](https://github.com/castorini/NanoKnow) ([paper](https://arxiv.org/abs/2602.20122)) provides pre-built relevance judgments that classify SQuAD and Natural Questions into **supported** (answer exists in fineweb-edu) and **unsupported** (answer not in training data) splits. 28–34% of standard benchmark questions are about facts that never appeared in the training corpus. NanoKnow lets you evaluate your checkpoint on questions it was actually trained on, giving a much cleaner signal of what the model learned.
+
 ## File structure
 
 ```


### PR DESCRIPTION
Hi all! We built **NanoKnow**, and we think it could change how you should evaluate nanochat checkpoints.

**The core idea:** Right now, if you evaluate a nanochat checkpoint on SQuAD or Natural Questions, many of the questions are about facts that *never appeared in fineweb-edu*. Your model literally couldn't have learned those answers. Including those questions in your evaluation is just adding noise — you're penalizing the model for not knowing things it was never taught.

NanoKnow fixes this. We searched the entire fineweb-edu-100b-shuffle corpus and classified every question into:

- **Supported** — the answer exists in the training data (nanochat was actually trained on it)
- **Unsupported** — the answer is nowhere in the training data (nanochat never saw it)

| Dataset | Supported | Unsupported |
|---------|-----------|-------------|
| SQuAD (10,570 questions) | 7,560 (72%) | 3,010 (28%) |
| NQ-Open (3,610 questions) | 2,391 (66%) | 1,219 (34%) |

That means **28–34% of standard benchmark questions are about facts nanochat was never even trained on.** With NanoKnow, you can evaluate on just the supported split and get a much more meaningful signal of what your checkpoint actually learned.

**What we found evaluating 8 nanochat checkpoints:**

1. Closed-book accuracy on supported questions scales clearly with answer frequency in the training data — the signal is very clean once you remove the noise
2. RAG helps most on unsupported questions (as expected), but even on supported questions, adding relevant context improves accuracy — parametric knowledge and retrieval are complementary
3. Irrelevant context actively hurts performance — position and quantity both matter

The supported/unsupported split also lets you properly benchmark RAG: you can separately measure how well retrieval compensates for missing knowledge vs. how much it reinforces existing knowledge.

**Links:**
- Paper: https://arxiv.org/abs/2602.20122
- Code & qrels: https://github.com/castorini/NanoKnow
- Qrels dataset: https://huggingface.co/datasets/LingweiGu/NanoKnow_Benchmark
- Index dataset: https://huggingface.co/datasets/LingweiGu/NanoKnow-Fineweb-Edu-Index
- Post: https://x.com/twitter/status/2026731136198598746

The qrels are ready to use — just download and evaluate your checkpoint. We also release the full pipeline and a [Lucene index](https://huggingface.co/datasets/LingweiGu/NanoKnow-Fineweb-Edu-Index) over fineweb-edu so you can project other benchmarks onto the training corpus yourself.

Would love to hear feedback or see results from other checkpoints!