### PR TITLE
Remove inherited parameters from scripts

### DIFF
--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -47,9 +47,7 @@ python -m scripts.base_eval --device-batch-size=1 --split-tokens=16384 --max-per
 # SFT (~10 minutes on my MacBook Pro M3 Max)
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 python -m scripts.chat_sft \
-    --max-seq-len=512 \
-    --device-batch-size=32 \
-    --total-batch-size=16384 \
+    --model-tag=6 \
     --eval-every=200 \
     --eval-tokens=524288 \
     --num-iterations=1500 \

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -47,7 +47,7 @@ python -m scripts.base_eval --device-batch-size=1 --split-tokens=16384 --max-per
 # SFT (~10 minutes on my MacBook Pro M3 Max)
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 python -m scripts.chat_sft \
-    --model-tag=6 \
+    --model-tag=d6 \
     --eval-every=200 \
     --eval-tokens=524288 \
     --num-iterations=1500 \

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -47,7 +47,6 @@ python -m scripts.base_eval --device-batch-size=1 --split-tokens=16384 --max-per
 # SFT (~10 minutes on my MacBook Pro M3 Max)
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 python -m scripts.chat_sft \
-    --model-tag=d6 \
     --eval-every=200 \
     --eval-tokens=524288 \
     --num-iterations=1500 \

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -82,7 +82,7 @@ torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 
 # run SFT and eval the model
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --device-batch-size=16 --run=$WANDB_RUN
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --model-tag=26 --run=$WANDB_RUN
 torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
 
 # chat with the model over CLI! Leave out the -p to chat interactively

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -82,7 +82,7 @@ torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 
 # run SFT and eval the model
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --model-tag=d26 --run=$WANDB_RUN
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --run=$WANDB_RUN
 torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
 
 # chat with the model over CLI! Leave out the -p to chat interactively

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -82,7 +82,7 @@ torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-
 curl -L -o $NANOCHAT_BASE_DIR/identity_conversations.jsonl https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
 
 # run SFT and eval the model
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --model-tag=26 --run=$WANDB_RUN
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --model-tag=d26 --run=$WANDB_RUN
 torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
 
 # chat with the model over CLI! Leave out the -p to chat interactively


### PR DESCRIPTION
Since [this edit](https://github.com/karpathy/nanochat/commit/77f8fb83037d4bb294fb97f987f27c98526c1d96#diff-da38d51155db11564eed12927062d31a2f3efa4409fdb1a7bdf1f4540b95afdc), `sft` inherits some settings from the pretraining phase (which is nice). So we can delete them from the `chat_sft ` commands in the run scripts, ensuring that changing them once in the `base_train` command would automatically copy the new value over to `chat_sft`.

I would personally add in `model-tag` to be more explicit about which checkpoint to start from, but I decided to leave it out of this PR for simplicity.