### PR TITLE
 Fix SSE parsing when model output contains "data: "

### DIFF
--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -360,7 +360,7 @@ async def chat_completions(request: ChatRequest):
                     top_k=request.top_k
                 ):
                     # Accumulate response for logging
-                    chunk_data = json.loads(chunk.replace("data: ", "").strip())
+                    chunk_data = json.loads(chunk.removeprefix("data: ").strip())
                     if "token" in chunk_data:
                         response_tokens.append(chunk_data["token"])
                     yield chunk


### PR DESCRIPTION
Chunks were parsed with replace("data: ", ""), which stripped every occurrence. If the model output contained "data: ", the JSON was corrupted. Switched to removeprefix("data: ") so only the leading prefix is removed.
