### PR TITLE
Fix role validation error message to match allowed roles

### DIFF
--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -193,7 +193,7 @@ def validate_chat_request(request: ChatRequest):
         if message.role not in ["user", "assistant"]:
             raise HTTPException(
                 status_code=400,
-                detail=f"Message {i} has invalid role. Must be 'user', 'assistant', or 'system'"
+                detail=f"Message {i} has invalid role. Must be 'user' or 'assistant'"
             )
 
     # Validate temperature


### PR DESCRIPTION
The validator only allows user and assistant, but the error text said 'system' was allowed. Updated the message to: "Must be 'user' or 'assistant'".