### PR TITLE
Restore completion-only loss masking in SFT dataloader

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -293,6 +293,7 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
         targets[mask_targets == 0] = -1
 
         # Mask out padding positions in targets (set to -1 = ignore_index)
+        # For each row, positions >= (content_length - 1) in targets should be masked
         for i, content_len in enumerate(row_lengths):
             if content_len < row_capacity:
                 targets[i, content_len-1:] = -1


### PR DESCRIPTION
## Problem
When chat_sft.py was rewritten in [1ddaad1](https://github.com/karpathy/nanochat/commit/1ddaad1c1c37f3553a59f556bc757c4aea585bef) to use bestfit-pad packing (replacing the old mid_train.py + chat_sft.py split), the loss mask from tokenizer.render_conversation() was accidentally dropped:

```ids, _ = tokenizer.render_conversation(conversation)  # mask discarded```

This causes all tokens - user prompts, BOS, special tokens, tool outputs to contribute to the cross-entropy loss. Before that commit, only assistant completions were trained on, which is standard practice in SFT (InstructGPT, Llama-2, Tulu, etc.).

## Fix
Use the existing mask from render_conversation() through the bestfit packing pipeline and apply it to targets. No new logic. this restores the masking pattern the old dataloader already used, adapted to the current packing structure.

## Results
Both runs use the same d23 pretrained base checkpoint. Only difference is whether the loss mask is applied. 

| Metric (final step) | baseline | masked loss (this PR) |
|---|---|---|
| ChatCORE | 0.315 | **0.355** |
| ChatCORE_cat | 0.27 | **0.295** |
| val/bpb | 0.355 | **0.27** |
| train/loss | ~0.78 | ~0.78 |
| tok/sec | ~25,185 | ~25,250 |

(attaching charts for the same) 

ChatCORE improves ~12%, val bpb drops ~24%, with no training speed regression. Train loss converges to the same value however the masked version starts lower because user-prompt tokens (which are easy to predict but useless to train on) no longer inflate the loss denominator.

 `baseline_sft_nanochat_original (orange)` is the baseline (i.e. existing system)
 `masked_loss_sft_nanochat (pink)` is with the completion-only loss (proposed in PR) 
 
<img width="5056" height="2656" alt="W B Chart 1_3_2026, 1_42_51 pm" src="https://github.com/user-attachments/assets/c23f938c-287a-4bb3-aaad-329d4414575d" />
<img width="5056" height="2656" alt="W B Chart 1_3_2026, 1_43_03 pm" src="https://github.com/user-attachments/assets/3cf339ac-e278-4377-b746-7d1ce18fadf5" />
<img width="5056" height="2656" alt="W B Chart 1_3_2026, 1_43_18 pm" src="https://github.com/user-attachments/assets/befe9495-127a-4e37-81bc-84afe0efc3d6" />
<img width="5056" height="2656" alt="W B Chart 1_3_2026, 1_43_24 pm" src="https://github.com/user-attachments/assets/f5b939a2-1599-4611-bef8-f65e7eaf84a6" />
<img width="5056" height="2656" alt="W B Chart 1_3_2026, 1_44_21 pm" src="https://github.com/user-attachments/assets/3aa08e85-2595-4edf-aabc-93a9f007119f" />

Also ran  `scripts.chat_eval` on both baseline v/s masked loss, here is the output log for both of them (masked loss performs better in all test (except only 0.16% worse in MMLU but margin is way to low to be significant )  


chat_eval results 

## Baseline 

```
Final: 1307/2376 (55.01%)
ARC-Easy accuracy: 55.01%
Final: 514/1172 (43.86%)
ARC-Challenge accuracy: 43.86%
Final: 5122/14042 (36.48%)
MMLU accuracy: 36.48%
Rank 0 | 104/1319 (7.88%)
==================================================
Final: 104/1319 (7.88%)
GSM8K accuracy: 7.88%
Rank 0 | 5/164 (3.05%)
==================================================
Final: 5/164 (3.05%)
HumanEval accuracy: 3.05%
Rank 0 | 253/256 (98.83%)
==================================================
Final: 253/256 (98.83%)
SpellingBee accuracy: 98.83%
```

## Masked loss
```
Final: 1379/2376 (58.04%)
ARC-Easy accuracy: 58.04%
Final: 553/1172 (47.18%)
ARC-Challenge accuracy: 47.18%
Final: 5100/14042 (36.32%)
MMLU accuracy: 36.32%
Rank 0 | 127/1319 (9.63%)
==================================================
Final: 127/1319 (9.63%)
GSM8K accuracy: 9.63%
Rank 0 | 19/164 (11.59%)
==================================================
Final: 19/164 (11.59%)
HumanEval accuracy: 11.59%
Rank 0 | 256/256 (100.00%)
==================================================
Final: 256/256 (100.00%)
SpellingBee accuracy: 100.00%
``` 


TODO :  Will publish a checkpoint  of base_model ( auto regressive ) and two SFT models (baseline v/s masked loss) so that one can recalculate the numbers.  