### PR TITLE
Use /usr/bin/env bash

### DIFF
--- a/runs/miniseries.sh
+++ b/runs/miniseries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # See speedrun.sh for more comments
 # Usage: ./miniseries.sh [series_name]

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Showing an example run for exercising some of the code paths on the CPU (or MPS on Macbooks)
 # This script was last updated/tuned on Jan 17, 2026.

--- a/runs/scaling_laws.sh
+++ b/runs/scaling_laws.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LABEL="jan26"
 

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is configured to train your own GPT-2 grade LLM (pretraining + finetuning)
 # It is designed to run on a blank 8XH100 GPU node and takes approximately 3 hours to complete.


### PR DESCRIPTION
This replaces `#!/bin/bash` with `#!/usr/bin/env bash`
to improve portability across systems where bash may
not live in `/bin`.

No functional changes.