### PR TITLE
Create convert_to_sharegpt.py

### DIFF
--- a/dev/convert_to_sharegpt.py
+++ b/dev/convert_to_sharegpt.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+os.chdir(r'C:\tmp')
+
+input_file = 'identity_conversations.jsonl'
+output_file = 'identity_conversations_sharegpt.jsonl'
+
+count = 0
+with open(input_file, 'r', encoding='utf-8') as f_in, open(output_file, 'w', encoding='utf-8') as f_out:
+    for line in f_in:
+        messages = json.loads(line.strip())
+        converted = {'conversations': []}
+        for msg in messages:
+            role = 'human' if msg['role'] == 'user' else 'gpt'
+            converted['conversations'].append({
+                'from': role,
+                'value': msg['content']
+            })
+        f_out.write(json.dumps(converted, ensure_ascii=False) + '\n')
+        count += 1
+
+print(f'Converted {count} conversations to ShareGPT format')
+print(f'Output saved to: {output_file}')


### PR DESCRIPTION
Example of the Dataset
https://huggingface.co/datasets/CrowdMind/test-nanochat-mid

Summary
Add conversion script to transform identity conversation data from the current format to ShareGPT format, enabling direct compatibility with Hugging Face datasets and eliminating the need for S3 storage.

Changes
- Added dev/convert_to_sharegpt.py script that converts identity conversation data from {'role': 'user'/'assistant', 'content': '...'} format to ShareGPT format {'conversations': [{'from': 'human'/'gpt', 'value': '...'}]}
- Converts identity_conversations.jsonl to identity_conversations_sharegpt.jsonl

Benefits
- Removes dependency on S3 for identity conversation data
- Direct compatibility with Hugging Face dataset format
- Enables streamlined mid-training workflow with ShareGPT-compatible tools and pipelines

* If this is something you want I can modify the scripts to use it before pull t his PR in