### PR TITLE
[UX] Ensure consistent batch size assertion messages (Consistency with #533)

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -122,7 +122,7 @@ depth = model.config.n_layer
 num_flops_per_token = model.estimate_flops()
 tokens_per_fwdbwd = args.device_batch_size * args.max_seq_len # tokens per iteration for a single rank
 world_tokens_per_fwdbwd = tokens_per_fwdbwd * ddp_world_size # total tokens per iteration for all ranks
-assert args.total_batch_size % world_tokens_per_fwdbwd == 0
+assert args.total_batch_size % world_tokens_per_fwdbwd == 0, f"total_batch_size ({args.total_batch_size}) must be a multiple of {world_tokens_per_fwdbwd}."
 grad_accum_steps = args.total_batch_size // world_tokens_per_fwdbwd
 print0(f"Tokens / micro-batch / rank: {args.device_batch_size} x {args.max_seq_len} = {tokens_per_fwdbwd:,}")
 print0(f"Tokens / micro-batch: {world_tokens_per_fwdbwd:,}")


### PR DESCRIPTION
### Description:
This PR brings the informative assertion message from ```base_train.py``` (added in #533) to ```chat_sft.py```

While running SFT after pretraining on an **RTX 3060 (6GB VRAM)**, I found that ```--device-batch-size 6``` is the limit for my hardware. However, this causes a silent ```AssertionError``` because 524,288 is not a multiple of the tokens per step (3,072).

Using the exact wording accepted in the previous PR ensures the repo remains consistent and helps users on consumer hardware quickly debug their batch configurations.

**Log without assert message**
```
(nanochat) ss@ss-Predator-PH315-53:~/nanochat$ WANDB_PROJECT=nanochat_sft WANDB_RUN=sft_v1_d12_test python -m scripts.chat_sft   --model-tag nanochat_v1_d12   --model-step 2205   --device-batch-size 6
Autodetected device type: cuda
2026-03-08 11:33:49,623 - nanochat.common - INFO - Distributed world size: 1
COMPUTE_DTYPE: torch.bfloat16 (auto-detected: CUDA SM 86 (bf16 supported))
2026-03-08 11:33:49,623 - nanochat.common - WARNING - Peak flops undefined for: NVIDIA GeForce RTX 3060 Laptop GPU, MFU will show as 0%
GPU: NVIDIA GeForce RTX 3060 Laptop GPU | Peak FLOPS (BF16): inf
WARNING: Flash Attention 3 not available, using PyTorch SDPA fallback. Training will be less efficient.
2026-03-08 11:33:49,623 - nanochat.checkpoint_manager - INFO - Loading model from /home/ss/.cache/nanochat/base_checkpoints/nanochat_v1_d12 with step 2205
2026-03-08 11:33:50,104 - nanochat.checkpoint_manager - INFO - Building model with config: {'sequence_len': 512, 'vocab_size': 32768, 'n_layer': 12, 'n_head': 6, 'n_kv_head': 6, 'n_embd': 768, 'window_pattern': 'SSSL'}
Inherited max_seq_len=512 from pretrained checkpoint
NOTE: --device-batch-size=6 overrides pretrained value of 4
Inherited total_batch_size=524288 from pretrained checkpoint
Inherited embedding_lr=0.3 from pretrained checkpoint
Inherited unembedding_lr=0.004 from pretrained checkpoint
Inherited matrix_lr=0.02 from pretrained checkpoint
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ss/nanochat/scripts/chat_sft.py", line 125, in <module>
    assert args.total_batch_size % world_tokens_per_fwdbwd == 0
AssertionError
(nanochat) ss@ss-Predator-PH315-53:~/nanochat$ 
```

**Log with assert message**

```
(nanochat) ss@ss-Predator-PH315-53:~/nanochat$ WANDB_PROJECT=nanochat_sft WANDB_RUN=sft_v1_d12_test python -m scripts.chat_sft   --model-tag nanochat_v1_d12   --model-step 2205   --device-batch-size 6
Autodetected device type: cuda
2026-03-08 09:57:09,597 - nanochat.common - INFO - Distributed world size: 1
COMPUTE_DTYPE: torch.bfloat16 (auto-detected: CUDA SM 86 (bf16 supported))
2026-03-08 09:57:09,597 - nanochat.common - WARNING - Peak flops undefined for: NVIDIA GeForce RTX 3060 Laptop GPU, MFU will show as 0%
GPU: NVIDIA GeForce RTX 3060 Laptop GPU | Peak FLOPS (BF16): inf
WARNING: Flash Attention 3 not available, using PyTorch SDPA fallback. Training will be less efficient.
2026-03-08 09:57:09,598 - nanochat.checkpoint_manager - INFO - Loading model from /home/ss/.cache/nanochat/base_checkpoints/nanochat_v1_d12 with step 2205
2026-03-08 09:57:10,080 - nanochat.checkpoint_manager - INFO - Building model with config: {'sequence_len': 512, 'vocab_size': 32768, 'n_layer': 12, 'n_head': 6, 'n_kv_head': 6, 'n_embd': 768, 'window_pattern': 'SSSL'}
Inherited max_seq_len=512 from pretrained checkpoint
NOTE: --device-batch-size=6 overrides pretrained value of 4
Inherited total_batch_size=524288 from pretrained checkpoint
Inherited embedding_lr=0.3 from pretrained checkpoint
Inherited unembedding_lr=0.004 from pretrained checkpoint
Inherited matrix_lr=0.02 from pretrained checkpoint
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ss/nanochat/scripts/chat_sft.py", line 125, in <module>
    assert args.total_batch_size % world_tokens_per_fwdbwd == 0, f"total_batch_size ({args.total_batch_size}) must be a multiple of {world_tokens_per_fwdbwd}."
AssertionError: total_batch_size (524288) must be a multiple of 3072.
```