### PR TITLE
pin validation shard by filename instead of sort order

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -20,7 +20,7 @@ import torch
 import pyarrow.parquet as pq
 
 from nanochat.common import get_dist_info
-from nanochat.dataset import list_parquet_files
+from nanochat.dataset import list_parquet_files, split_parquet_paths
 
 def _document_batches(split, resume_state_dict, tokenizer_batch_size):
     """
@@ -35,7 +35,7 @@ def _document_batches(split, resume_state_dict, tokenizer_batch_size):
     warn_on_legacy = ddp_rank == 0 and split == "train" # rank 0 on train split will warn on legacy
     parquet_paths = list_parquet_files(warn_on_legacy=warn_on_legacy)
     assert len(parquet_paths) != 0, "No dataset parquet files found, did you run dataset.py?"
-    parquet_paths = parquet_paths[:-1] if split == "train" else parquet_paths[-1:]
+    parquet_paths = split_parquet_paths(parquet_paths, split)
 
     resume_pq_idx = resume_state_dict["pq_idx"] if resume_state_dict is not None else 0
     resume_rg_idx = resume_state_dict["rg_idx"] if resume_state_dict is not None else None

--- a/nanochat/dataset.py
+++ b/nanochat/dataset.py
@@ -22,6 +22,7 @@ from nanochat.common import get_base_dir
 # The URL on the internet where the data is hosted and downloaded from on demand
 BASE_URL = "https://huggingface.co/datasets/karpathy/climbmix-400b-shuffle/resolve/main"
 MAX_SHARD = 6542 # the last datashard is shard_06542.parquet
+VAL_SHARD = MAX_SHARD # the validation shard is pinned to shard_06542
 index_to_filename = lambda index: f"shard_{index:05d}.parquet" # format of the filenames
 base_dir = get_base_dir()
 DATA_DIR = os.path.join(base_dir, "base_data_climbmix")
@@ -64,15 +65,23 @@ def list_parquet_files(data_dir=None, warn_on_legacy=False):
     parquet_paths = [os.path.join(data_dir, f) for f in parquet_files]
     return parquet_paths
 
+def split_parquet_paths(parquet_paths, split):
+    """Split parquet paths into train or val by matching the pinned validation shard filename."""
+    assert split in ["train", "val"], "split must be 'train' or 'val'"
+    val_filename = index_to_filename(VAL_SHARD)
+    val_paths = [p for p in parquet_paths if os.path.basename(p) == val_filename]
+    assert val_paths, f"Validation shard {val_filename} not found. Run: python -m nanochat.dataset -n 1"
+    return [p for p in parquet_paths if os.path.basename(p) != val_filename] if split == "train" else val_paths
+
 def parquets_iter_batched(split, start=0, step=1):
     """
     Iterate through the dataset, in batches of underlying row_groups for efficiency.
-    - split can be "train" or "val". the last parquet file will be val.
+    - split can be "train" or "val". val is pinned to shard_06542.
     - start/step are useful for skipping rows in DDP. e.g. start=rank, step=world_size
     """
     assert split in ["train", "val"], "split must be 'train' or 'val'"
     parquet_paths = list_parquet_files()
-    parquet_paths = parquet_paths[:-1] if split == "train" else parquet_paths[-1:]
+    parquet_paths = split_parquet_paths(parquet_paths, split)
     for filepath in parquet_paths:
         pf = pq.ParquetFile(filepath)
         for rg_idx in range(start, pf.num_row_groups, step):


### PR DESCRIPTION
Fixes #541

The val split used `parquet_paths[-1:]` which relies on the last file in sorted directory listing. This is fragile - the val shard should always be `shard_06542` regardless of which other shards exist.

Changes:
- Add `VAL_SHARD` constant and `split_parquet_paths()` helper to `dataset.py`
- Both `dataset.py` and `dataloader.py` now use explicit filename matching instead of position-based slicing
- Clear assert message if the val shard is missing

This contribution was developed with AI assistance (Claude Code).