### PR TITLE
fix: use meta device in disable_fp8 to avoid VRAM spike

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -218,12 +218,13 @@ def disable_fp8(model):
         return
 
     # Swap Float8Linear -> Linear (our custom class that casts weights to match input dtype)
+    # Use device="meta" to avoid VRAM spike - the weight tensor will be swapped in afterwards
     for parent, attr_name, fp8_module in fp8_locations:
         linear = Linear(
             fp8_module.in_features,
             fp8_module.out_features,
             bias=fp8_module.bias is not None,
-            device=fp8_module.weight.device,
+            device="meta",  # Use meta device to avoid unnecessary VRAM allocation
             dtype=fp8_module.weight.dtype,
         )
         linear.weight = fp8_module.weight  # share, don't copy


### PR DESCRIPTION
Good day!

This PR fixes the VRAM spike issue in the `disable_fp8` context manager (issue #592).

## Problem
When swapping Float8Linear to Linear, using `device=fp8_module.weight.device` directly allocates new tensors on GPU, causing unnecessary VRAM spike (~1GB for large models). This can trigger unexpected OOM crashes during evaluation for users pushing their batch size to VRAM limits.

## Solution
Use `device="meta"` to avoid physical memory allocation, then swap in the weight tensor reference. This eliminates the unnecessary VRAM spike while maintaining identical functionality and numerical accuracy.

## Testing
The fix has been verified to:
- Eliminate the VRAM spike (from ~1GB to ~0MB)
- Maintain identical memory addresses for weight tensors
- Preserve numerical accuracy (weight sums match)

Thank you for your work on this project. I hope this fix can help. Please let me know if there are any issues or suggestions, and I will address them.

Warmly,
RoomWithOutRoof