### PR TITLE
fix: avoid NaN loss when all targets are masked

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -426,8 +426,14 @@ class GPT(nn.Module):
 
         if targets is not None:
             # training: given the targets, compute and return the loss
-            # TODO experiment with chunked cross-entropy?
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1, reduction=loss_reduction)
+            # Check if there are valid targets (not -1) to avoid NaN from all-masked batches
+            valid_mask = targets != -1
+            if valid_mask.any():
+                loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1, reduction=loss_reduction)
+            else:
+                # All targets are masked (e.g., user prompts with small batch sizes)
+                # Return zero loss to avoid NaN during gradient accumulation
+                loss = logits.new_tensor(0.0)
             return loss
         else:
             # inference: just return the logits directly


### PR DESCRIPTION
## Summary

When running SFT with small device-batch-sizes (≤8), it's common for a micro-batch to contain only masked user tokens and padding. In this case, all targets are -1 (ignore_index), causing cross_entropy with reduction='mean' to return NaN (division by zero).

This fix checks if there are any valid targets before computing loss. If all targets are masked, it returns zero loss instead of NaN, preventing gradient corruption during gradient accumulation.

## Fix

In `nanochat/gpt.py`, added a check before computing cross-entropy:

```python
valid_mask = targets != -1
if valid_mask.any():
    loss = F.cross_entropy(...)
else:
    loss = logits.new_tensor(0.0)
```

## Related Issue

Fixes #618 - [Bug] scripts/chat_sft.py produces loss: nan from step 00001 on small device-batch-size (≤8) due to fully-masked micro-batches

## Testing

The fix should be tested with:
```bash
python -m scripts.chat_sft --model-tag [MODEL_TAG] --model-step [STEP] --device-batch-size 8 --run sft_reproduction_test
```

Expected: Loss should no longer become NaN at step 1.