### PR TITLE
fix(chat): implement sliding context window management

### DIFF
--- a/scripts/chat_cli.py
+++ b/scripts/chat_cli.py
@@ -9,6 +9,7 @@ import torch
 from nanochat.common import compute_init, autodetect_device_type
 from nanochat.engine import Engine
 from nanochat.checkpoint_manager import load_model
+from nanochat.context_window import ContextWindowManager
 
 parser = argparse.ArgumentParser(description='Chat with the model')
 parser.add_argument('-i', '--source', type=str, default="sft", help="Source of the model: sft|rl")
@@ -18,10 +19,10 @@ parser.add_argument('-p', '--prompt', type=str, default='', help='Prompt the mod
 parser.add_argument('-t', '--temperature', type=float, default=0.6, help='Temperature for generation')
 parser.add_argument('-k', '--top-k', type=int, default=50, help='Top-k sampling parameter')
 parser.add_argument('--device-type', type=str, default='', choices=['cuda', 'cpu', 'mps'], help='Device type for evaluation: cuda|cpu|mps. empty => autodetect')
+parser.add_argument('--reserved-tokens', type=int, default=512, help='Tokens to reserve for response generation')
 args = parser.parse_args()
 
 # Init the model and tokenizer
-
 device_type = autodetect_device_type() if args.device_type == "" else args.device_type
 ddp, ddp_rank, ddp_local_rank, ddp_world_size, device = compute_init(device_type)
 model, tokenizer, meta = load_model(args.source, device, phase="eval", model_tag=args.model_tag, step=args.step)
@@ -34,10 +35,18 @@ assistant_start, assistant_end = tokenizer.encode_special("<|assistant_start|>")
 # Create Engine for efficient generation
 engine = Engine(model, tokenizer)
 
+# Create Context Window Manager to handle long conversations
+context_manager = ContextWindowManager(
+    max_length=model.config.sequence_len,
+    system_tokens=[bos],
+    reserved_tokens=args.reserved_tokens,
+)
+
 print("\nNanoChat Interactive Mode")
 print("-" * 50)
 print("Type 'quit' or 'exit' to end the conversation")
 print("Type 'clear' to start a new conversation")
+print(f"Context window: {model.config.sequence_len} tokens")
 print("-" * 50)
 
 conversation_tokens = [bos]
@@ -75,6 +84,23 @@ while True:
 
     # Kick off the assistant
     conversation_tokens.append(assistant_start)
+    
+    # Apply context window management before generation
+    # This prevents RuntimeError when conversation exceeds sequence_len
+    turn_boundaries = context_manager.get_turn_boundaries(
+        conversation_tokens,
+        user_start=user_start,
+        user_end=user_end,
+        assistant_start=assistant_start,
+        assistant_end=assistant_end,
+    )
+    
+    truncated_tokens = context_manager.truncate(conversation_tokens, turn_boundaries)
+    
+    if len(truncated_tokens) < len(conversation_tokens):
+        # Context was truncated - inform user
+        print(f"\n[Context window: truncated {len(conversation_tokens) - len(truncated_tokens)} old tokens]")
+    
     generate_kwargs = {
         "num_samples": 1,
         "max_tokens": 256,
@@ -83,7 +109,7 @@ while True:
     }
     response_tokens = []
     print("\nAssistant: ", end="", flush=True)
-    for token_column, token_masks in engine.generate(conversation_tokens, **generate_kwargs):
+    for token_column, token_masks in engine.generate(truncated_tokens, **generate_kwargs):
         token = token_column[0] # pop the batch dimension (num_samples=1)
         response_tokens.append(token)
         token_text = tokenizer.decode([token])
@@ -93,6 +119,8 @@ while True:
     # so even if generation ends due to max tokens, we have to append it to the end
     if response_tokens[-1] != assistant_end:
         response_tokens.append(assistant_end)
+    
+    # Add response to conversation (keeping full history for proper turn tracking)
     conversation_tokens.extend(response_tokens)
 
     # In the prompt mode, we only want a single response and exit

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -1,0 +1,127 @@
+"""
+Tests for ContextWindowManager
+"""
+import pytest
+from nanochat.context_window import ContextWindowManager
+
+
+class TestContextWindowManager:
+    """Test context window truncation logic."""
+    
+    def test_no_truncation_needed(self):
+        """When conversation fits, return unchanged."""
+        manager = ContextWindowManager(max_length=100, reserved_tokens=20)
+        tokens = list(range(50))
+        
+        result = manager.truncate(tokens, [])
+        
+        assert result == tokens
+    
+    def test_simple_truncation(self):
+        """Truncate from beginning when no turn boundaries."""
+        manager = ContextWindowManager(max_length=100, reserved_tokens=20)
+        tokens = list(range(150))
+        
+        result = manager.truncate(tokens, [])
+        
+        # Should have 80 tokens (100 - 20 reserved)
+        assert len(result) <= 80
+        # Should keep most recent tokens
+        assert result[-1] == tokens[-1]
+    
+    def test_preserve_system_tokens(self):
+        """System tokens should always be preserved."""
+        system = [0, 1, 2]  # BOS + system
+        manager = ContextWindowManager(
+            max_length=100,
+            reserved_tokens=20,
+            system_tokens=system,
+        )
+        tokens = system + list(range(3, 150))
+        
+        result = manager.truncate(tokens, [])
+        
+        # System tokens preserved
+        assert result[:3] == system
+    
+    def test_turn_boundary_detection(self):
+        """Correctly identify turn boundaries."""
+        manager = ContextWindowManager(max_length=1000)
+        
+        # Simulated conversation: bos + user1 + assistant1 + user2 + assistant2
+        USER_START, USER_END = 100, 101
+        ASST_START, ASST_END = 200, 201
+        
+        tokens = [
+            0,  # bos
+            USER_START, 10, 20, 30, USER_END,  # user turn 1
+            ASST_START, 40, 50, ASST_END,  # assistant turn 1
+            USER_START, 60, 70, USER_END,  # user turn 2
+            ASST_START, 80, 90, ASST_END,  # assistant turn 2
+        ]
+        
+        boundaries = manager.get_turn_boundaries(
+            tokens,
+            user_start=USER_START,
+            user_end=USER_END,
+            assistant_start=ASST_START,
+            assistant_end=ASST_END,
+        )
+        
+        assert len(boundaries) == 2
+        # First turn: user1 + assistant1
+        assert boundaries[0] == (1, 10)
+        # Second turn: user2 + assistant2  
+        assert boundaries[1] == (10, 18)
+    
+    def test_truncate_keeps_recent_turns(self):
+        """When truncating, keep most recent turns."""
+        manager = ContextWindowManager(
+            max_length=20,
+            reserved_tokens=5,
+            system_tokens=[0],
+        )
+        
+        # Turn boundaries: [start, end)
+        turns = [
+            (1, 8),   # Turn 1: 7 tokens
+            (8, 15),  # Turn 2: 7 tokens  
+            (15, 22), # Turn 3: 7 tokens
+        ]
+        
+        tokens = list(range(22))
+        
+        result = manager.truncate(tokens, turns)
+        
+        # Should keep system + most recent turn(s)
+        assert result[0] == 0  # System token
+        # Most recent turn should be preserved
+        assert 15 in result or 16 in result or 17 in result
+    
+    def test_incomplete_turn_ignored(self):
+        """Incomplete turns (no assistant_end) should not be counted."""
+        manager = ContextWindowManager(max_length=1000)
+        
+        USER_START, USER_END = 100, 101
+        ASST_START, ASST_END = 200, 201
+        
+        tokens = [
+            0,
+            USER_START, 10, 20, USER_END,
+            ASST_START, 30, ASST_END,  # Complete turn
+            USER_START, 40, 50, USER_END,  # Incomplete - no assistant response
+        ]
+        
+        boundaries = manager.get_turn_boundaries(
+            tokens,
+            user_start=USER_START,
+            user_end=USER_END,
+            assistant_start=ASST_START,
+            assistant_end=ASST_END,
+        )
+        
+        assert len(boundaries) == 1  # Only complete turn
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

In `scripts/chat_cli.py`, the `conversation_tokens` list grows indefinitely during interactive sessions. When it exceeds `model.config.sequence_len`, the engine receives an oversized tensor that causes a dimension mismatch in attention layers:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x0)
```

This crashes long interactive conversations.

Fixes #581

## Solution

Implement `ContextWindowManager` that:

1. **Tracks conversation turn boundaries** (user message + assistant response pairs)
2. **Applies sliding window** when approaching context limit
3. **Preserves system tokens** (BOS + optional system prompt)
4. **Keeps most recent turns**, drops oldest first
5. **Reserves tokens** for response generation

## Architecture

- `nanochat/context_window.py` - Core window management logic with `ContextWindowManager` class
- `scripts/chat_cli.py` - Integration with user notification when truncation occurs
- `tests/test_context_window.py` - Comprehensive test coverage

## Key Features

### Smart Truncation

```python
# Before: conversation crashes at 2048 tokens
# After: automatically truncates oldest turns to stay within limit
[Context window: truncated 156 old tokens]
```

### Turn Boundary Detection

```python
boundaries = manager.get_turn_boundaries(
    conversation_tokens,
    user_start=user_start,
    user_end=user_end,
    assistant_start=assistant_start,
    assistant_end=assistant_end,
)
# Returns: [(start_idx, end_idx), ...] for each complete turn
```

### Preserves Context

- System tokens always preserved
- Most recent turns prioritized
- At least one turn always kept

## Testing

```bash
python -m pytest tests/test_context_window.py -v
```

- ✅ No truncation when conversation fits
- ✅ Simple truncation from beginning (no turn info)
- ✅ System tokens preserved
- ✅ Turn boundary detection
- ✅ Recent turns kept during truncation
- ✅ Incomplete turns ignored

## Manual Testing

```bash
# Train minimal model with small context
python -m scripts.base_train --depth 2 --aspect-ratio 4 --num-iterations 1 \
    --save-every 1 --model-tag context_test --max-seq-len 64 \
    --device-batch-size 1 --total-batch-size 64 \
    --core-metric-every -1 --eval-every -1 --sample-every -1

# Chat with long conversation (no longer crashes)
python -m scripts.chat_cli -i base -g context_test -s 1
```

## Design Decisions

1. **Separate module** (`context_window.py`) - Keeps chat_cli.py clean, allows reuse
2. **Turn-based truncation** - More natural than arbitrary token cutoff
3. **Notification on truncation** - User aware context was modified
4. **Reserved tokens parameter** - Configurable for different generation lengths