### PR TITLE
fix: skip micro-batches with no valid targets to avoid NaN loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Presently, the main focus of development is on tuning the pretraining stage, whi
 | 2 | 2.91 | 0.74504 | 0.2578 | d26 slightly undertrained **+fp8** | Feb 2 2026 | a67eba3 | @karpathy |
 | 3 | 2.76 | 0.74645 | 0.2602 | bump total batch size to 1M tokens | Feb 5 2026 | 2c062aa | @karpathy |
 | 4 | 2.02 | 0.71854 | 0.2571 | change dataset to NVIDIA ClimbMix | Mar 4 2026 | 324e69c | @ddudek @karpathy |
+| 5 | 1.80 | 0.71808 | 0.2690 | autoresearch [round 1](https://x.com/karpathy/status/2031135152349524125) | Mar 9 2026 | 6ed7d1d | @karpathy |
 
 The primary metric we care about is "time to GPT-2" - the wall clock time needed to outperform the GPT-2 (1.6B) CORE metric on an 8XH100 GPU node. The GPT-2 CORE score is 0.256525. In 2019, the training of GPT-2 cost approximately $43,000 so it is incredible that due to many advances over 7 years across the stack, we can now do so much faster and for well below $100 (e.g. at the current ~$3/GPU/hr, an 8XH100 node is ~$24/hr, so 2 hours is ~$48).
 

--- a/dev/LEADERBOARD.md
+++ b/dev/LEADERBOARD.md
@@ -191,3 +191,8 @@ Mean is 0.25714 (higher than the GPT-2 threshold needed), max-min is 0.01646. So
 
 NOTE: The `val_bpb` is as of this run *NOT* comparable due to the data distribution change to the previous 3 runs. This run happens to be at `0.71854` validation bpb. If the dataset is not changed, the `val_bpb` number is a great, smooth metric to track relative performance w.r.t. and has less noise than CORE.
 
+## Run 5
+
+Achieved Mar 9, 2026 on commit `6ed7d1d`. Exactly the same launch command as Run 4 except `--target-param-data-ratio=8.7`. I ran 5 identical runs, the average CORE was 0.2690, which is quite a bit above the needed threshold of 0.2565. But the reason I didn't decrease the ratio further (i.e. train shorter) is that while the CORE "safety gap" is large, the val_loss safety gap is smaller - 0.71808, which we want to be below the Run 4 val loss of 0.71854. It's likely that we could have reduced the ratio even lower, possibly to 8.6, but it's not worth splitting hairs at this point.
+
+This commit is special because all of the improvements that went into [this commit](https://github.com/karpathy/nanochat/commit/6ed7d1d82cee16c2e26f45d559ad3338447a6c1b) came from fully autonomous "research" done by a private version of [autoresearch](https://github.com/karpathy/autoresearch) run on a d12 model. I wrote more about this in [this tweet](https://x.com/karpathy/status/2031135152349524125). The changes easily translated from d12 to d24, hence new leaderboard record, taking us from 2.02 hours "time to GPT-2" to 1.80 hours.

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -426,14 +426,8 @@ class GPT(nn.Module):
 
         if targets is not None:
             # training: given the targets, compute and return the loss
-            # Check if there are valid targets (not -1) to avoid NaN from all-masked batches
-            valid_mask = targets != -1
-            if valid_mask.any():
-                loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1, reduction=loss_reduction)
-            else:
-                # All targets are masked (e.g., user prompts with small batch sizes)
-                # Return zero loss to avoid NaN during gradient accumulation
-                loss = logits.new_tensor(0.0)
+            # TODO experiment with chunked cross-entropy?
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1, reduction=loss_reduction)
             return loss
         else:
             # inference: just return the logits directly

--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -432,11 +432,18 @@ while True:
     for micro_step in range(grad_accum_steps):
         loss = model(x, y)
         train_loss = loss.detach() # for logging
-        loss = loss / grad_accum_steps # each .backward() is a grad sum => normalize loss here
-        if scaler is not None:
-            scaler.scale(loss).backward()
+        # Check if there are valid targets (not -1) to avoid NaN loss from cross_entropy
+        # When all labels are -1 (ignored), cross_entropy returns NaN
+        has_valid_targets = (y != -1).any()
+        if has_valid_targets:
+            loss = loss / grad_accum_steps # each .backward() is a grad sum => normalize loss here
+            if scaler is not None:
+                scaler.scale(loss).backward()
+            else:
+                loss.backward()
         else:
-            loss.backward()
+            # Skip this micro-batch entirely - contributes zero to gradients
+            pass
         x, y = next(train_loader) # prefetch the next batch while the GPU is busy with forward/backward
         progress = max(progress, approx_progress) # only increase progress monotonically
     # step the optimizer


### PR DESCRIPTION
## Summary

When training with small batch sizes (≤8), it is common for a micro-batch to contain only masked user tokens and padding. Since these positions are set to -1 (ignore_index for cross-entropy), `cross_entropy` returns NaN when all labels are -1 because it divides by zero.

This fix checks if there are any valid targets before computing the loss and skips the backward pass for micro-batches with no valid targets.

## Root Cause

In SFT, the User part of the conversation is masked out (targets set to -1) so the model only learns from the Assistant response. With small batch sizes, a micro-batch may contain only masked tokens and padding, leaving no valid targets for loss computation.

## Fix

Added a check before the backward pass:

```python
has_valid_targets = (y != -1).any()
if has_valid_targets:
    loss.backward()
else:
    pass  # Skip - contributes zero to gradients
```

This prevents NaN gradients from corrupting the model weights.

## Related Issue

Fixes #618