### PR TITLE
fix: avoid VRAM allocation in disable_fp8 context manager

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -223,7 +223,7 @@ def disable_fp8(model):
             fp8_module.in_features,
             fp8_module.out_features,
             bias=fp8_module.bias is not None,
-            device=fp8_module.weight.device,
+            device='meta',  # Use meta device to avoid VRAM allocation; weight is shared from fp8_module
             dtype=fp8_module.weight.dtype,
         )
         linear.weight = fp8_module.weight  # share, don't copy


### PR DESCRIPTION
## Summary

Use `device='meta'` instead of `fp8_module.weight.device` to prevent unnecessary GPU memory allocation when swapping Float8Linear to Linear during evaluation.

## Problem

The original code allocated actual GPU memory for every Linear layer during the swap, causing a ~1GB VRAM spike that could trigger OOM when device-batch-size is pushed close to VRAM limits.

## Solution

Using `device='meta'` defers actual memory allocation until the tensor is used. Since the weight is shared from the fp8_module (not copied), no actual allocation is needed.

## Testing

See issue #592 for detailed testing showing:
- Original: +1024 MB memory spike
- Fixed: +0.01 MB (negligible)

Fixes: #592