### PR TITLE
fix: use meta device in disable_fp8 to avoid VRAM spike

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -223,7 +223,7 @@ def disable_fp8(model):
             fp8_module.in_features,
             fp8_module.out_features,
             bias=fp8_module.bias is not None,
-            device=fp8_module.weight.device,
+            device='meta',  # Use meta device to avoid VRAM spike during allocation
             dtype=fp8_module.weight.dtype,
         )
         linear.weight = fp8_module.weight  # share, don't copy


### PR DESCRIPTION
Fixes issue #592

Problem: The disable_fp8 context manager was allocating new tensors on GPU (device=fp8_module.weight.device), causing unnecessary VRAM allocation.

Solution: Using device=meta creates the tensor without allocating physical memory, then the weight is shared via linear.weight = fp8_module.weight.

Test Results:
- Original: +1024 MB VRAM spike
- Fixed: +0.01 MB VRAM spike