### PR TITLE
fix: validate --target-param-data-ratio=0 to prevent ZeroDivisionError

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -78,6 +78,11 @@ parser.add_argument("--save-every", type=int, default=-1, help="save checkpoints
 # Output
 parser.add_argument("--model-tag", type=str, default=None, help="override model tag for checkpoint directory name")
 args = parser.parse_args()
+
+# Validate training horizon arguments
+if args.target_param_data_ratio == 0:
+    parser.error("--target-param-data-ratio cannot be 0 (would cause division by zero). Use -1 to disable auto-computation or a positive value.")
+
 user_config = vars(args).copy()  # for logging
 # -----------------------------------------------------------------------------
 # Compute init and wandb logging


### PR DESCRIPTION
## Summary

Add early validation in argument parsing to reject `target_param_data_ratio=0`, which would cause a `ZeroDivisionError` during batch size calculation in the Chinchilla scaling law math.

## Problem

Setting `--target-param-data-ratio 0` causes a crash:
```
ZeroDivisionError: division by zero
```

This happens because the ratio is used as a denominator.

## Solution

Add argument validation after parsing to provide a helpful error message instead of a cryptic ZeroDivisionError.

Closes #578