### PR TITLE
docs: show model-tag in chat CLI examples

### DIFF
--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -59,7 +59,8 @@ python -m scripts.chat_sft \
 # The model should be able to say that it is Paris.
 # It might even know that the color of the sky is blue.
 # Sometimes the model likes it if you first say Hi before you ask it questions.
-# python -m scripts.chat_cli -p "What is the capital of France?"
+# export MODEL_TAG="d6"
+# python -m scripts.chat_cli -p "What is the capital of France?" --model-tag $MODEL_TAG
 
 # Chat with the model over a pretty WebUI ChatGPT style
 # python -m scripts.chat_web

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -86,7 +86,8 @@ torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --device-batch-s
 torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
 
 # chat with the model over CLI! Leave out the -p to chat interactively
-# python -m scripts.chat_cli -p "Why is the sky blue?"
+# export MODEL_TAG="d24"
+# python -m scripts.chat_cli -p "Why is the sky blue?" --model-tag $MODEL_TAG
 
 # even better, chat with your model over a pretty WebUI ChatGPT style
 # python -m scripts.chat_web


### PR DESCRIPTION
## Summary
- add explicit `MODEL_TAG` examples to `runs/runcpu.sh` and `runs/speedrun.sh`
- show `scripts.chat_cli` with `--model-tag $MODEL_TAG` so users can target the intended SFT checkpoint when multiple depths/checkpoints exist
- addresses #542

## Validation
- `C:\Program Files\Git\bin\bash.exe -n runs/runcpu.sh`
- `C:\Program Files\Git\bin\bash.exe -n runs/speedrun.sh`
