### PR TITLE
fix: validate --target-param-data-ratio before scaling math

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -78,6 +78,8 @@ parser.add_argument("--save-every", type=int, default=-1, help="save checkpoints
 # Output
 parser.add_argument("--model-tag", type=str, default=None, help="override model tag for checkpoint directory name")
 args = parser.parse_args()
+if args.target_param_data_ratio == 0 or args.target_param_data_ratio < -1:
+    parser.error("--target-param-data-ratio must be positive or -1 to disable")
 user_config = vars(args).copy()  # for logging
 # -----------------------------------------------------------------------------
 # Compute init and wandb logging


### PR DESCRIPTION
## Summary
Add early CLI validation for \\--target-param-data-ratio\\ so invalid values fail fast with a clear error instead of reaching the scaling-law math and crashing with \\ZeroDivisionError\\.

## Changes
- reject \\