### PR TITLE
fix: add uv install path in speedrun script

### DIFF
--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -20,6 +20,8 @@ mkdir -p $NANOCHAT_BASE_DIR
 
 # install uv (if not already installed)
 command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+# add uv to PATH for shells that don't auto-pick up ~/.local/bin after install
+export PATH="$HOME/.local/bin:$PATH"
 # create a .venv local virtual environment (if it doesn't exist)
 [ -d ".venv" ] || uv venv
 # install the repo dependencies


### PR DESCRIPTION
## Summary
- add `~/.local/bin` to `PATH` after the `uv` installer runs in `runs/speedrun.sh`
- keep the existing flow intact while fixing shells/container environments where `uv` is installed but not immediately discoverable
- addresses #529

## Validation
- `C:\Program Files\Git\bin\bash.exe -n runs/speedrun.sh`
