### PR TITLE
Fix tokenizer serialization: JSON instead of pickle to prevent ARM Docker crashes

### DIFF
--- a/nanochat/tokenizer.py
+++ b/nanochat/tokenizer.py
@@ -191,6 +191,21 @@ class RustBPETokenizer:
 
     @classmethod
     def from_directory(cls, tokenizer_dir):
+        # Try JSON format first (portable, avoids pickle of native Rust objects)
+        json_path = os.path.join(tokenizer_dir, "tokenizer.json")
+        if os.path.exists(json_path):
+            import json
+            with open(json_path, "r") as f:
+                data = json.load(f)
+            mergeable_ranks = {bytes.fromhex(k): v for k, v in data["mergeable_ranks"].items()}
+            enc = tiktoken.Encoding(
+                name=data.get("name", "rustbpe"),
+                pat_str=data["pattern"],
+                mergeable_ranks=mergeable_ranks,
+                special_tokens=data["special_tokens"],
+            )
+            return cls(enc, "<|bos|>")
+        # Fall back to legacy pickle format
         pickle_path = os.path.join(tokenizer_dir, "tokenizer.pkl")
         with open(pickle_path, "rb") as f:
             enc = pickle.load(f)
@@ -256,12 +271,20 @@ class RustBPETokenizer:
         return self.enc.decode(ids)
 
     def save(self, tokenizer_dir):
-        # save the encoding object to disk
+        # Save as portable JSON (avoids pickling tiktoken's native Rust objects,
+        # which causes heap corruption / SIGSEGV on ARM Docker with glibc malloc)
+        import json
         os.makedirs(tokenizer_dir, exist_ok=True)
-        pickle_path = os.path.join(tokenizer_dir, "tokenizer.pkl")
-        with open(pickle_path, "wb") as f:
-            pickle.dump(self.enc, f)
-        print(f"Saved tokenizer encoding to {pickle_path}")
+        data = {
+            "name": self.enc.name,
+            "pattern": self.enc._pat_str,
+            "mergeable_ranks": {k.hex(): v for k, v in self.enc._mergeable_ranks.items()},
+            "special_tokens": self.enc._special_tokens,
+        }
+        json_path = os.path.join(tokenizer_dir, "tokenizer.json")
+        with open(json_path, "w") as f:
+            json.dump(data, f)
+        print(f"Saved tokenizer encoding to {json_path}")
 
     def render_conversation(self, conversation, max_tokens=2048):
         """
@@ -402,5 +425,5 @@ def get_token_bytes(device="cpu"):
     token_bytes_path = os.path.join(tokenizer_dir, "token_bytes.pt")
     assert os.path.exists(token_bytes_path), f"Token bytes not found at {token_bytes_path}? It gets written by tok_train.py"
     with open(token_bytes_path, "rb") as f:
-        token_bytes = torch.load(f, map_location=device)
+        token_bytes = torch.load(f, map_location=device, weights_only=True)
     return token_bytes


### PR DESCRIPTION
## Summary

- **`save()`**: Serialize tokenizer as JSON instead of pickling tiktoken's native
  Rust `Encoding` object. Hex-encodes byte keys for JSON compatibility.
- **`from_directory()`**: Load from JSON when available, fall back to legacy
  `.pkl` files (backward compatible).
- **`get_token_bytes()`**: Add `weights_only=True` to `torch.load` (fixes
  FutureWarning in PyTorch 2.6+, safer default).

## Problem

On ARM Docker (aarch64, e.g. Apple Silicon Macs), `pickle.dump(enc)` of a
tiktoken `Encoding` object triggers non-deterministic heap corruption in
tiktoken's Rust FFI layer. Symptoms:

- `free(): invalid next size (fast)`
- `corrupted double-linked list`
- SIGSEGV (exit 139), SIGABRT (exit 134), SIGTRAP (exit 133)

The crash is non-deterministic — the same command sometimes succeeds,
sometimes crashes. jemalloc (`LD_PRELOAD`) reduces frequency but doesn't
eliminate it. Avoiding pickle of the Rust object entirely fixes the root cause.

## Our view of the performance side-effects

The performance impact is negligible for this use case.

**Save/Load speed**: JSON serialization of the tokenizer is a one-time operation (once during `tok_train`, once at the start of `base_train`). For a 4096-vocab tokenizer, the JSON file is ~200KB. Parsing that takes milliseconds — invisible next to minutes/hours of training.

**File size**: JSON with hex-encoded byte keys is ~2-3x larger than pickle for the same data, but still tiny (hundreds of KB vs the model checkpoints which are MBs/GBs).

**Runtime inference**: Zero impact. Once loaded, the in-memory `tiktoken.Encoding` object is identical regardless of whether it was deserialized from JSON or pickle. All the hot-path encoding/decoding goes through the same Rust code.

**The only real tradeoff**: We access `enc._pat_str`, `enc._mergeable_ranks`, and `enc._special_tokens` which are private attributes of tiktoken's `Encoding`. If tiktoken changes its internals, this could break. But pickle of a Rust-backed object is even more fragile — it's already crashing on ARM.

Short answer: no measurable performance difference. The fix trades a ~2ms pickle load for a ~2ms JSON parse, once per run.

## Test plan

- [x] `tok_train` → saves `tokenizer.json` (no crash on ARM Docker)
- [x] `base_train` → loads from `tokenizer.json`, trains 5 iterations successfully
- [x] Full pipeline tested on Mac ARM Docker (aarch64): data download → tokenizer
  training → pretraining, exit code 0
- [x] Backward compatible: `from_directory()` still loads `.pkl` if no `.json` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed and verified by the author.