### PR TITLE
Have fastapi and uvicorn as optional dependencies only to run chat_web.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For development (adds pytest, matplotlib, ipykernel, transformers, etc.):
 uv sync --extra gpu --group dev
 ```
 
-If you plan on running scripts.chat_web:
+If you plan on running `scripts.chat_web`:
 
 ```bash
 uv sync --extra web

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ For development (adds pytest, matplotlib, ipykernel, transformers, etc.):
 uv sync --extra gpu --group dev
 ```
 
+If you plan on running scripts.chat_web:
+
+```bash
+uv sync --extra web
+```
+
 ### Reproduce and talk to GPT-2
 
 The most fun you can have is to train your own GPT-2 and talk to it. The entire pipeline to do so is contained in the single file [runs/speedrun.sh](runs/speedrun.sh), which is designed to be run on an 8XH100 GPU node. Boot up a new 8XH100 GPU box from your favorite provider (e.g. I use and like [Lambda](https://lambda.ai/service/gpu-cloud)), and kick off the training script:
@@ -51,9 +57,10 @@ The most fun you can have is to train your own GPT-2 and talk to it. The entire 
 bash runs/speedrun.sh
 ```
 
-You may wish to do so in a screen session as this will take ~3 hours to run. Once it's done, you can talk to it via the ChatGPT-like web UI. Make sure again that your local uv virtual environment is active (run `source .venv/bin/activate`), and serve it:
+You may wish to do so in a screen session as this will take ~3 hours to run. Once it's done, you can talk to it via the ChatGPT-like web UI. Make sure again that your local uv virtual environment is active (run `source .venv/bin/activate`) and has the `web` extra installed, and then serve it:
 
 ```bash
+uv sync --extra web
 python -m scripts.chat_web
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,18 @@ uv sync --extra cpu    # (or) Use for CPU-only / MPS
 source .venv/bin/activate
 ```
 
+If you plan on running `scripts.chat_web` to chat with your model via a web UI, add the extra "web":
+
+```bash
+uv sync --extra gpu --extra web    # Use for CUDA (A100/H100/etc.)
+uv sync --extra cpu --extra web    # (or) Use for CPU-only / MPS
+source .venv/bin/activate
+```
+
 For development (adds pytest, matplotlib, ipykernel, transformers, etc.):
 
 ```bash
 uv sync --extra gpu --group dev
-```
-
-If you plan on running `scripts.chat_web`:
-
-```bash
-uv sync --extra web
 ```
 
 ### Reproduce and talk to GPT-2
@@ -57,10 +59,9 @@ The most fun you can have is to train your own GPT-2 and talk to it. The entire 
 bash runs/speedrun.sh
 ```
 
-You may wish to do so in a screen session as this will take ~3 hours to run. Once it's done, you can talk to it via the ChatGPT-like web UI. Make sure again that your local uv virtual environment is active (run `source .venv/bin/activate`) and has the `web` extra installed, and then serve it:
+You may wish to do so in a screen session as this will take ~3 hours to run. Once it's done, you can talk to it via the ChatGPT-like web UI. Make sure again that your local uv virtual environment (with the "web" extra) is active (run `source .venv/bin/activate`), and serve it:
 
 ```bash
-uv sync --extra web
 python -m scripts.chat_web
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,12 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "datasets>=4.0.0",
-    "fastapi>=0.117.1",
     "kernels>=0.11.7",
     "psutil>=7.1.0",
     "rustbpe>=0.1.0",
     "tiktoken>=0.11.0",
     "tokenizers>=0.22.0",
     "torch==2.9.1",
-    "uvicorn>=0.36.0",
     "wandb>=0.21.3",
 ]
 
@@ -58,6 +56,10 @@ cpu = [
 ]
 gpu = [
     "torch==2.9.1",
+]
+web = [
+    "fastapi>=0.117.1",
+    "uvicorn>=0.36.0",
 ]
 
 [tool.uv]

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -62,5 +62,5 @@ python -m scripts.chat_sft \
 # python -m scripts.chat_cli -p "What is the capital of France?"
 
 # Chat with the model over a pretty WebUI ChatGPT style
-# uv sync --extra web
+# uv sync --extra cpu --extra web
 # python -m scripts.chat_web

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -62,4 +62,5 @@ python -m scripts.chat_sft \
 # python -m scripts.chat_cli -p "What is the capital of France?"
 
 # Chat with the model over a pretty WebUI ChatGPT style
+# uv sync --extra web
 # python -m scripts.chat_web

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -89,6 +89,7 @@ torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
 # python -m scripts.chat_cli -p "Why is the sky blue?"
 
 # even better, chat with your model over a pretty WebUI ChatGPT style
+# uv sync --extra web
 # python -m scripts.chat_web
 
 # -----------------------------------------------------------------------------

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -89,7 +89,7 @@ torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
 # python -m scripts.chat_cli -p "Why is the sky blue?"
 
 # even better, chat with your model over a pretty WebUI ChatGPT style
-# uv sync --extra web
+# uv sync --extra gpu --extra web
 # python -m scripts.chat_web
 
 # -----------------------------------------------------------------------------

--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -43,7 +43,7 @@ try:
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import StreamingResponse, HTMLResponse, FileResponse
 except ImportError as exc:
-    raise SystemExit("Missing web dependencies, install with: uv sync --extra web") from exc
+    raise SystemExit("Missing web dependencies, install the extra 'web'") from exc
 from pydantic import BaseModel
 from typing import List, Optional, AsyncGenerator
 from dataclasses import dataclass

--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -38,9 +38,12 @@ import asyncio
 import logging
 import random
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse, HTMLResponse, FileResponse
+try:
+    from fastapi import FastAPI, HTTPException
+    from fastapi.middleware.cors import CORSMiddleware
+    from fastapi.responses import StreamingResponse, HTMLResponse, FileResponse
+except ImportError as exc:
+    raise SystemExit("Missing web dependencies, install with: uv sync --extra web") from exc
 from pydantic import BaseModel
 from typing import List, Optional, AsyncGenerator
 from dataclasses import dataclass


### PR DESCRIPTION
- Takes `fastapi` and `uvicorn` out of the standard list of dependencies
- Make them available by running `uv sync --extra web`
- in `speedrun.sh` and `runcpu.sh`, only suggest running them when the user wants to deploy the chat interface
- print a helpful message when `chat_web.py` is executed without `fastapi` in the environment