### PR TITLE
Fix speedrun.sh: add uv to PATH for container instances

### DIFF
--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -20,6 +20,8 @@ mkdir -p $NANOCHAT_BASE_DIR
 
 # install uv (if not already installed)
 command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+# add uv to PATH (the installer puts it in ~/.local/bin)
+export PATH="$HOME/.local/bin:$PATH"
 # create a .venv local virtual environment (if it doesn't exist)
 [ -d ".venv" ] || uv venv
 # install the repo dependencies


### PR DESCRIPTION
## Summary
- Adds `export PATH="$HOME/.local/bin:$PATH"` after the `uv` install step in `speedrun.sh`
- The `uv` installer places the binary in `~/.local/bin`, which is not on `PATH` by default in container environments, causing the script to fail immediately after install

Fixes #529 (installer path fix)

## Test plan
- [ ] Run `speedrun.sh` on a fresh container instance where `~/.local/bin` is not on PATH
- [ ] Verify `uv` commands succeed after the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)