### PR TITLE
Initialize smear and backout lambdas in init_weights()

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -237,6 +237,8 @@ class GPT(nn.Module):
         # Decaying x0 init: earlier layers get more input embedding blending
         for i in range(n_layer):
             self.x0_lambdas.data[i] = 0.20 - (0.15 * i / max(n_layer - 1, 1))
+
+        # Smear/backout scalars and smear gate must be explicitly initialized 
         torch.nn.init.zeros_(self.smear_lambda)
         torch.nn.init.constant_(self.backout_lambda, 0.2)
         torch.nn.init.uniform_(self.smear_gate.weight, 0.0, 0.02)

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -237,6 +237,8 @@ class GPT(nn.Module):
         # Decaying x0 init: earlier layers get more input embedding blending
         for i in range(n_layer):
             self.x0_lambdas.data[i] = 0.20 - (0.15 * i / max(n_layer - 1, 1))
+        self.smear_lambda.fill_(0.0)
+        self.backout_lambda.fill_(0.2)
 
         # Value embeddings (init like c_v: uniform with same std)
         for ve in self.value_embeds.values():

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -237,8 +237,9 @@ class GPT(nn.Module):
         # Decaying x0 init: earlier layers get more input embedding blending
         for i in range(n_layer):
             self.x0_lambdas.data[i] = 0.20 - (0.15 * i / max(n_layer - 1, 1))
-        self.smear_lambda.fill_(0.0)
-        self.backout_lambda.fill_(0.2)
+        torch.nn.init.zeros_(self.smear_lambda)
+        torch.nn.init.constant_(self.backout_lambda, 0.2)
+        torch.nn.init.uniform_(self.smear_gate.weight, 0.0, 0.02)
 
         # Value embeddings (init like c_v: uniform with same std)
         for ve in self.value_embeds.values():


### PR DESCRIPTION
Currently `smear_lambda` and `backout_lambda` are declared in `GPT.__init__()`, but they are not initialized in `init_weights()`.

In `base_train.py` model is initialized on `meta` device and materialized with `to_empty()`, so these params may end up not being initialized.

In my testing, both `smear_lambda` and `backout_lambda` seem to be implicitly initialized to `0.0` by some mechanism in PyTorch, so this issue doesn't present itself easily. Adding `torch.use_deterministic_algorithms(True)` before model init in `base_train.py` makes issue repoducible on my setup. In this case both values become `nan`, which in turn results in training failure (loss=nan).

To be aligned with the constructor, this PR initalizes to `0.0` and `0.2` respectively.