### PR TITLE
fix: add guard for --target-param-data-ratio=0 to prevent ZeroDivisionError

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -266,6 +266,8 @@ def get_scaling_params(m):
     scaling_params = params_counts['transformer_matrices'] + params_counts['lm_head']
     return scaling_params
 num_scaling_params = get_scaling_params(model)
+if args.target_param_data_ratio == 0:
+    raise ValueError("--target-param-data-ratio must be > 0 or -1 to disable, but got 0")
 target_tokens = int(args.target_param_data_ratio * num_scaling_params) # optimal tokens for the model we are about to train
 
 # Our reference model is d12, this is where a lot of hyperparameters are tuned and then transfered to higher depths (muP style)


### PR DESCRIPTION
## Summary

Setting `--target-param-data-ratio 0` causes a `ZeroDivisionError` during auto-computed batch size calculation, since `target_tokens` and `D_REF` both become 0 and are used as denominators in the scaling math (line 283: `batch_size_ratio = target_tokens / D_REF`).

## Fix

Added an early `ValueError` with a clear error message before the scaling calculations, so users get immediate feedback instead of a confusing `ZeroDivisionError` deep in the stack trace.

## Reproduction

```bash
python -m scripts.base_train --depth 1 --aspect-ratio 1 --target-param-data-ratio 0
```

## Related

Closes #578