### PR TITLE
fix: cap few-shot count when dataset is subsampled below num_fewshot

### DIFF
--- a/nanochat/core_eval.py
+++ b/nanochat/core_eval.py
@@ -177,7 +177,11 @@ def evaluate_example(idx, model, tokenizer, data, device, task_meta):
     if num_fewshot > 0:
         rng = random.Random(1234 + idx)
         available_indices = [i for i in range(len(data)) if i != idx]
-        fewshot_indices = rng.sample(available_indices, num_fewshot)
+        effective_fewshot = min(num_fewshot, len(available_indices))
+        if effective_fewshot < num_fewshot:
+            print(f"  Warning: task has only {len(available_indices)} examples "
+                  f"(need {num_fewshot} for few-shot), using {effective_fewshot}")
+        fewshot_indices = rng.sample(available_indices, effective_fewshot)
         fewshot_examples = [data[i] for i in fewshot_indices]
 
     # Render prompts and batch sequences based on task type


### PR DESCRIPTION
## Problem

When running `base_train` with `--core-metric-max-per-task` set to a small value (e.g. 5), tasks with a high `num_fewshot` like Jeopardy (10-shot) crash with:

```
ValueError: Sample larger than population or is negative
```

This happens because the dataset is subsampled to `max_per_task` items (line 156-157 of `base_eval.py`), but the few-shot sampling in `core_eval.py` still tries to draw `num_fewshot` examples from the now-smaller pool.

## Fix

Cap the effective few-shot count to the number of available indices (excluding the current evaluation example). If the cap is lower than the configured `num_fewshot`, print a one-line warning so the user knows the task is running with fewer examples than intended.

## Impact

- Minimal: only affects evaluation code path
- No behavior change when dataset is large enough (normal case)
- Enables rapid CORE eval testing with small `--core-metric-max-per-task` values

Relates to #550.