### PR TITLE
fix: bpb token_bytes for tokens that decode to U+FFFD

### DIFF
--- a/nanochat/tokenizer.py
+++ b/nanochat/tokenizer.py
@@ -255,6 +255,9 @@ class RustBPETokenizer:
     def decode(self, ids):
         return self.enc.decode(ids)
 
+    def decode_single_token_bytes(self, token_id):
+        return self.enc.decode_single_token_bytes(token_id)
+
     def save(self, tokenizer_dir):
         # save the encoding object to disk
         os.makedirs(tokenizer_dir, exist_ok=True)

--- a/scripts/tok_train.py
+++ b/scripts/tok_train.py
@@ -74,16 +74,11 @@ assert decoded == test_text
 # allows us to report a loss that is invariant to the vocab size of the tokenizer.
 # The bits per byte on the validation set is then one of the primary metrics we care about.
 vocab_size = tokenizer.get_vocab_size()
-special_set = set(tokenizer.get_special_tokens())
-token_strings = [tokenizer.decode([token_id]) for token_id in range(vocab_size)]
-token_bytes = []
+special_set = set(tokenizer.encode_special(token) for token in tokenizer.get_special_tokens())
+token_bytes = [len(tokenizer.decode_single_token_bytes(token_id)) for token_id in range(vocab_size)]
 for token_id in range(vocab_size):
-    token_str = token_strings[token_id] # the Python string representation of this token
-    if token_str in special_set:
-        token_bytes.append(0) # special characters are not counted
-    else:
-        id_bytes = len(token_str.encode("utf-8")) # number of bytes that make up this token
-        token_bytes.append(id_bytes)
+    if token_id in special_set:
+        token_bytes[token_id] = 0 # special characters are not counted
 token_bytes = torch.tensor(token_bytes, dtype=torch.int32, device='cpu')
 token_bytes_path = os.path.join(tokenizer_dir, "token_bytes.pt")
 with open(token_bytes_path, "wb") as f:


### PR DESCRIPTION
## Problem

Fixes incorrect `token_bytes` accounting for BPB evaluation in byte-level BPE tokenizers.

The old code computed per-token byte counts via:

```python
len(tokenizer.decode([token_id]).encode("utf-8"))
```

This computes the incorrect number for tokens whose raw byte payload is not valid standalone UTF-8. In those cases, decoding the token leads to the generic unrepresentable token `U+FFFD` �, whose UTF-8 encoding is 3 bytes, so `token_bytes` gets inflated and biases the `val/bpb` denominator.

## Solution

Compute token byte lengths from raw token bytes ([tiktoken API](https://github.com/openai/tiktoken/blob/dcb39287a1f90a94d4bf6146df25da03c017646f/tiktoken/core.py#L286-L298)) instead:

```python
len(tokenizer.decode_single_token_bytes(token_id))
```

e.g. 
```python
# current 
print(len(tokenizer.decode([128]).encode("utf-8")))   # 3,  128: '�'
# new
len(tokenizer.decode_single_token_bytes(128))   # 1
```

special tokens remain excluded from BPB.

## Testing

- `python -m scripts.tok_train  --max-chars=2000000000 ` and verified it wrote `tokenizer.pkl` and `token_bytes.pt`

- round-trip byte count test

with old tokenizer:
```
tok = get_tokenizer()
token_bytes = get_token_bytes(device="cpu")

text = "i love borzois! 🐕"
ids = tok.encode(text)

tok_sum = int(token_bytes[torch.tensor(ids)].sum().item())
actual = len(text.encode("utf-8"))

print("tokenizer_bytes", tok_sum)
print("actual_utf8_bytes", actual)
```

with old token_bytes:
`
tokenizer_bytes 25
actual_utf8_bytes 20
`

```
for idx in ids:
    print(tok.decode([idx]))
# output:
i
 love
 bor
zo
is
!
 �
�
�
```

with fixed token_bytes:
`
tokenizer_bytes 20
actual_utf8_bytes 20
`

## Impact

- Fixes BPB byte counting for invalid standalone UTF-8 token fragments.