### PR TITLE
Add setuptools for CPU run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ explicit = true
 
 [project.optional-dependencies]
 cpu = [
+    "setuptools>=65.0.0",
     "torch==2.9.1",
 ]
 gpu = [

--- a/uv.lock
+++ b/uv.lock
@@ -1507,6 +1507,7 @@ dependencies = [
 
 [package.optional-dependencies]
 cpu = [
+    { name = "setuptools" },
     { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
     { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
 ]
@@ -1530,6 +1531,7 @@ requires-dist = [
     { name = "kernels", specifier = ">=0.11.7" },
     { name = "psutil", specifier = ">=7.1.0" },
     { name = "rustbpe", specifier = ">=0.1.0" },
+    { name = "setuptools", marker = "extra == 'cpu'", specifier = ">=65.0.0" },
     { name = "tiktoken", specifier = ">=0.11.0" },
     { name = "tokenizers", specifier = ">=0.22.0" },
     { name = "torch", specifier = "==2.9.1" },


### PR DESCRIPTION
On CPU, the current code crashes as-is with

```
bash runs/runcpu.sh

...
  File "/home/ubuntu/git/nanochat/.venv/lib/python3.10/site-packages/torch/_inductor/cpp_builder.py", line 1087, in _get_torch_related_args
    from torch.utils.cpp_extension import include_paths, TORCH_LIB_PATH
  File "/home/ubuntu/git/nanochat/.venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 10, in <module>
    import setuptools
torch._inductor.exc.InductorError: ModuleNotFoundError: No module named 'setuptools'
```

Minimal fix (this PR) is to explicitely add `setuptools` to the requirements when installing the `cpu` extra. I double checked on both a local machine and an A100, both crash before and run fine after this fix.

This doesn't effect GPU runs, those run fine because they use a different code path not involving `cpp_extension`. 