### PR TITLE
fix: validate --target-param-data-ratio and --target-flops to prevent ZeroDivisionError

### DIFF
--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -79,6 +79,12 @@ parser.add_argument("--save-every", type=int, default=-1, help="save checkpoints
 parser.add_argument("--model-tag", type=str, default=None, help="override model tag for checkpoint directory name")
 args = parser.parse_args()
 user_config = vars(args).copy()  # for logging
+
+# Validate training horizon arguments
+if args.target_param_data_ratio == 0:
+    parser.error("--target-param-data-ratio must be positive (e.g. Chinchilla=20, nanochat default=12) or -1 to disable")
+if args.target_flops == 0:
+    parser.error("--target-flops must be positive or -1 to disable")
 # -----------------------------------------------------------------------------
 # Compute init and wandb logging
 


### PR DESCRIPTION
## Problem

Setting `--target-param-data-ratio 0` causes a crash during auto-computation of the optimal batch size:

```
Traceback (most recent call last):
  ...
  batch_size_ratio = target_tokens / D_REF
ZeroDivisionError: float division by zero
```

Since `--target-param-data-ratio` is used as a denominator in the Chinchilla scaling math (line 273: `D_REF = args.target_param_data_ratio * get_scaling_params(d12_ref)`), a zero value results in a `ZeroDivisionError` instead of a graceful error message. The same issue applies to `--target-flops`.

The existing assertion at line 339 (`assert args.target_param_data_ratio > 0`) fires too late — after the division has already occurred.

## Fix

Add early validation immediately after argument parsing, before any computation that depends on these values:

- Reject `--target-param-data-ratio 0` with a clear message explaining valid values (positive number or -1 to disable)
- Reject `--target-flops 0` for the same reason

This provides a user-friendly error message instead of a cryptic traceback.

Fixes #578