### PR TITLE
add MoE (DeepSeek-style, top-k + shared experts) driven by --num-experts

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -21,6 +21,7 @@ import torch.nn.functional as F
 
 from nanochat.common import get_dist_info, print0, COMPUTE_DTYPE
 from nanochat.optim import MuonAdamW, DistMuonAdamW
+from nanochat.moe import MoE
 
 # Our custom Flash Attention module that automatically uses FA3 on Hopper+ and SDPA fallback elsewhere
 from nanochat.flash_attention import flash_attn
@@ -37,6 +38,12 @@ class GPTConfig:
     # Characters: L=long (full context), S=short (quarter context)
     # Examples: "L"=all full context, "SL"=alternating, "SSL"=two short then one long
     window_pattern: str = "SSSL"
+    # MoE config. num_experts <= 1 disables MoE entirely (falls back to dense MLP).
+    num_experts: int = 1
+    top_k: int = 2
+    num_shared_experts: int = 0
+    capacity_factor: float = 1.25
+    moe_aux_loss_coef: float = 0.01
 
 
 def norm(x):
@@ -143,12 +150,18 @@ class Block(nn.Module):
     def __init__(self, config, layer_idx):
         super().__init__()
         self.attn = CausalSelfAttention(config, layer_idx)
-        self.mlp = MLP(config)
+        self.use_moe = config.num_experts > 1
+        self.mlp = MoE(config) if self.use_moe else MLP(config)
 
     def forward(self, x, ve, cos_sin, window_size, kv_cache):
         x = x + self.attn(norm(x), ve, cos_sin, window_size, kv_cache)
-        x = x + self.mlp(norm(x))
-        return x
+        if self.use_moe:
+            mlp_out, aux = self.mlp(norm(x))
+            x = x + mlp_out
+        else:
+            x = x + self.mlp(norm(x))
+            aux = torch.zeros((), device=x.device, dtype=torch.float32)
+        return x, aux
 
 
 class GPT(nn.Module):
@@ -226,8 +239,11 @@ class GPT(nn.Module):
             torch.nn.init.uniform_(block.attn.c_k.weight, -s, s)
             torch.nn.init.uniform_(block.attn.c_v.weight, -s, s)
             torch.nn.init.zeros_(block.attn.c_proj.weight) # projections are zero
-            torch.nn.init.uniform_(block.mlp.c_fc.weight, -s * 0.4, s * 0.4)  # 0.4x init scale for c_fc
-            torch.nn.init.zeros_(block.mlp.c_proj.weight)
+            if block.use_moe:
+                block.mlp.init_weights()  # MoE does its own init (zero c_proj => zero contribution at init)
+            else:
+                torch.nn.init.uniform_(block.mlp.c_fc.weight, -s * 0.4, s * 0.4)  # 0.4x init scale for c_fc
+                torch.nn.init.zeros_(block.mlp.c_proj.weight)
 
         # Per-layer scalars
         # Per-layer resid init: stronger residual at early layers, weaker at deep layers
@@ -320,6 +336,9 @@ class GPT(nn.Module):
         This is ~1% off from the exact formulas of Chinchilla paper, the difference is:
         - Chinchilla counts the embedding layer as flops (? weird, it's just a lookup => we ignore)
         - Chinchilla counts exp/sum/divide in attention softmax as flops (a little sus and very tiny => we ignore)
+
+        For MoE: only top_k / num_experts of routed expert params see a given token per forward.
+        Shared experts and the router are always active (included in the active count).
         """
         nparams = sum(p.numel() for p in self.parameters())
         # Exclude non-matmul params: embeddings and per-layer scalars
@@ -327,6 +346,13 @@ class GPT(nn.Module):
         nparams_exclude = (self.transformer.wte.weight.numel() + value_embeds_numel +
                           self.resid_lambdas.numel() + self.x0_lambdas.numel() +
                           self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel())
+        # Exclude inactive MoE expert params: (num_experts - top_k) / num_experts of routed experts.
+        moe_inactive = 0
+        if self.config.num_experts > 1:
+            moe = self.transformer.h[0].mlp
+            expert_hidden = moe.expert_hidden_dim
+            inactive_per_layer = (self.config.num_experts - self.config.top_k) * 2 * self.config.n_embd * expert_hidden
+            moe_inactive = inactive_per_layer * self.config.n_layer
         h, q, t = self.config.n_head, self.config.n_embd // self.config.n_head, self.config.sequence_len
         # Sum attention FLOPs per layer, accounting for sliding window
         attn_flops = 0
@@ -334,7 +360,7 @@ class GPT(nn.Module):
             window = window_size[0]  # (left, right) tuple, we use left
             effective_seq = t if window < 0 else min(window, t)
             attn_flops += 12 * h * q * effective_seq
-        num_flops_per_token = 6 * (nparams - nparams_exclude) + attn_flops
+        num_flops_per_token = 6 * (nparams - nparams_exclude - moe_inactive) + attn_flops
         return num_flops_per_token
 
     def num_scaling_params(self):
@@ -346,8 +372,9 @@ class GPT(nn.Module):
         Ref: https://arxiv.org/abs/2203.15556 (Chinchilla paper)
         Ref: https://arxiv.org/abs/2001.08361 (Kaplan et al. original scaling laws paper)
 
-        Returns a dict with counts for each parameter group, so downstream analysis
-        can experiment with which combination gives the cleanest scaling laws.
+        For MoE, 'active_*' fields count only the parameters active per token
+        (top_k out of num_experts routed experts, plus shared experts).
+        Following DeepSeek convention of reporting both total and active params.
         """
         # Count each group separately (mirrors the grouping in setup_optimizers)
         wte = sum(p.numel() for p in self.transformer.wte.parameters())
@@ -357,13 +384,27 @@ class GPT(nn.Module):
         scalars = self.resid_lambdas.numel() + self.x0_lambdas.numel() + self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel()
         total = wte + value_embeds + lm_head + transformer_matrices + scalars
         assert total == sum(p.numel() for p in self.parameters()), "Parameter count mismatch"
+        # MoE: only top_k/num_experts fraction of routed expert params active per token.
+        # Shared experts are always active so their params stay in the active count.
+        moe_inactive = 0
+        if self.config.num_experts > 1:
+            moe = self.transformer.h[0].mlp
+            expert_hidden = moe.expert_hidden_dim
+            routed_params_per_layer = self.config.num_experts * 2 * self.config.n_embd * expert_hidden
+            inactive_per_layer = routed_params_per_layer * (self.config.num_experts - self.config.top_k) // self.config.num_experts
+            moe_inactive = inactive_per_layer * self.config.n_layer
+        active_transformer_matrices = transformer_matrices - moe_inactive
+        active_total = total - moe_inactive
         return {
             'wte': wte,
             'value_embeds': value_embeds,
             'lm_head': lm_head,
             'transformer_matrices': transformer_matrices,
+            'active_transformer_matrices': active_transformer_matrices,
             'scalars': scalars,
+            'moe_inactive': moe_inactive,
             'total': total,
+            'active_total': active_total,
         }
 
     def setup_optimizer(self, unembedding_lr=0.004, embedding_lr=0.2, matrix_lr=0.02, weight_decay=0.0, scalar_lr=0.5):
@@ -448,10 +489,13 @@ class GPT(nn.Module):
         n_layer = self.config.n_layer
         backout_layer = n_layer // 2  # cache at halfway point
         x_backout = None
+        # Accumulate MoE aux loss across layers (zero-valued for dense blocks).
+        aux_loss_total = torch.zeros((), device=x.device, dtype=torch.float32)
         for i, block in enumerate(self.transformer.h):
             x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
             ve = self.value_embeds[str(i)](idx).to(x.dtype) if str(i) in self.value_embeds else None
-            x = block(x, ve, cos_sin, self.window_sizes[i], kv_cache)
+            x, block_aux = block(x, ve, cos_sin, self.window_sizes[i], kv_cache)
+            aux_loss_total = aux_loss_total + block_aux
             if i == backout_layer:
                 x_backout = x
         # Subtract mid-layer residual to remove low-level features before logit projection
@@ -470,7 +514,8 @@ class GPT(nn.Module):
             # training: given the targets, compute and return the loss
             # TODO experiment with chunked cross-entropy?
             loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1, reduction=loss_reduction)
-            return loss
+            # Always return (ce_loss, aux_loss) pair. Caller sums them for backward and logs them separately.
+            return loss, aux_loss_total
         else:
             # inference: just return the logits directly
             return logits

--- a/nanochat/loss_eval.py
+++ b/nanochat/loss_eval.py
@@ -30,7 +30,7 @@ def evaluate_bpb(model, batches, steps, token_bytes):
     batch_iter = iter(batches)
     for _ in range(steps):
         x, y = next(batch_iter)
-        loss2d = model(x, y, loss_reduction='none') # (B, T)
+        loss2d, _ = model(x, y, loss_reduction='none') # (B, T); discard MoE aux (scalar, irrelevant for bpb)
         loss2d = loss2d.view(-1) # flatten
         y = y.view(-1) # flatten
         if (y.int() < 0).any(): # mps does not currently have kernel for < 0 for int64, only int32

--- a/nanochat/moe.py
+++ b/nanochat/moe.py
@@ -1,0 +1,180 @@
+"""
+Mixture-of-Experts (MoE) block for nanochat.
+
+Design (DeepSeek-style, see also Tian et al. 2507.17702 for scaling-law guidance):
+- `num_experts` routed experts + `num_shared_experts` always-active experts.
+- Top-k softmax routing, renormalized across chosen experts.
+- Padded-capacity dispatch so all tensor shapes are static => torch.compile works.
+- Switch-style aux loss: lambda * E * sum_e (f_e * p_e), where f_e is the top-1 token
+  fraction (detached) and p_e is the mean router softmax prob (carries gradient).
+- Expert weights stored as 3D nn.Parameter (num_experts, D_in, D_out). Muon orthogonalizes
+  each expert slice independently via batched polar-express (needs leading-dim support
+  in nanochat.optim, already added).
+- Compute-matched default: expert_hidden_dim = 4 * n_embd / (top_k + num_shared_experts),
+  rounded to multiples of 64. Keeps per-token active FFN params ~= dense MLP so that
+  sweeping `num_experts` varies total capacity at roughly fixed active compute.
+
+forward(x) returns (y, aux_loss) where aux_loss is a scalar fp32 tensor already scaled by
+the aux-loss coefficient. The GPT model sums these across blocks and adds to the main CE loss.
+"""
+
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _round_to(x: int, multiple: int) -> int:
+    return max(multiple, ((x + multiple - 1) // multiple) * multiple)
+
+
+def default_expert_hidden(n_embd: int, top_k: int, num_shared_experts: int, head_dim_multiple: int = 64) -> int:
+    """Compute-matched sizing: total active FFN params per token ~= dense MLP (hidden=4*n_embd)."""
+    active_factor = max(1, top_k + num_shared_experts)
+    raw = (4 * n_embd) // active_factor
+    return _round_to(raw, head_dim_multiple)
+
+
+class MoE(nn.Module):
+    """Mixture-of-Experts MLP replacement. Drop-in for nanochat.gpt.MLP when num_experts > 1."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.n_embd = config.n_embd
+        self.num_experts = config.num_experts
+        self.top_k = min(config.top_k, config.num_experts)
+        self.num_shared_experts = config.num_shared_experts
+        self.capacity_factor = config.capacity_factor
+        self.aux_loss_coef = config.moe_aux_loss_coef
+        self.expert_hidden_dim = default_expert_hidden(
+            config.n_embd, self.top_k, self.num_shared_experts
+        )
+
+        # Router: project n_embd -> num_experts. Shape (num_experts, n_embd) so it groups
+        # with other 2D matrix params of like shape across layers in Muon.
+        self.router_weight = nn.Parameter(torch.empty(self.num_experts, self.n_embd))
+
+        # Routed experts as 3D tensors: Muon orthogonalizes each (D, H) / (H, D) slice independently.
+        E, D, H = self.num_experts, self.n_embd, self.expert_hidden_dim
+        self.w_fc = nn.Parameter(torch.empty(E, D, H))
+        self.w_proj = nn.Parameter(torch.empty(E, H, D))
+
+        # Shared experts (always active). Same per-expert sizing as routed.
+        if self.num_shared_experts > 0:
+            S = self.num_shared_experts
+            self.ws_fc = nn.Parameter(torch.empty(S, D, H))
+            self.ws_proj = nn.Parameter(torch.empty(S, H, D))
+        else:
+            self.register_parameter("ws_fc", None)
+            self.register_parameter("ws_proj", None)
+
+    @torch.no_grad()
+    def init_weights(self):
+        """Mirrors nanochat.gpt.MLP init: c_fc uniform +/- 0.4*s, c_proj zeros.
+
+        With c_proj zeros, the MoE block contributes 0 to the residual stream at init
+        (same as dense MLP), so the model starts in a well-behaved state.
+        """
+        s = (3.0 ** 0.5) * self.n_embd ** -0.5
+        # Router: small init so routing starts near-uniform
+        torch.nn.init.uniform_(self.router_weight, -s * 0.02, s * 0.02)
+        # Routed experts
+        torch.nn.init.uniform_(self.w_fc, -s * 0.4, s * 0.4)
+        torch.nn.init.zeros_(self.w_proj)
+        # Shared experts
+        if self.ws_fc is not None:
+            torch.nn.init.uniform_(self.ws_fc, -s * 0.4, s * 0.4)
+            torch.nn.init.zeros_(self.ws_proj)
+
+    def forward(self, x):
+        B, T, D = x.shape
+        N = B * T
+        k = self.top_k
+        E = self.num_experts
+        x_flat = x.view(N, D)
+
+        # ---- Shared-expert branch (always active, no routing) ------------------
+        shared_out = torch.zeros_like(x_flat)
+        if self.ws_fc is not None:
+            ws_fc = self.ws_fc.to(x.dtype)
+            ws_proj = self.ws_proj.to(x.dtype)
+            # Unroll over a small (usually 1) number of shared experts.
+            for s in range(self.num_shared_experts):
+                h = x_flat @ ws_fc[s]
+                h = F.relu(h).square()
+                shared_out = shared_out + h @ ws_proj[s]
+
+        # ---- Router ------------------------------------------------------------
+        router_logits = F.linear(x_flat, self.router_weight.to(x.dtype))  # (N, E)
+        # Aux-loss and top-k probs are computed in fp32 for numerical stability
+        routing_probs = F.softmax(router_logits.float(), dim=-1)  # (N, E) fp32
+        topk_probs_f, topk_idx = routing_probs.topk(k, dim=-1)    # (N, k)
+        topk_probs_f = topk_probs_f / (topk_probs_f.sum(dim=-1, keepdim=True) + 1e-9)
+        topk_probs = topk_probs_f.to(x.dtype)  # (N, k) compute dtype for gating math
+
+        # ---- Aux loss (Switch load balancing) ----------------------------------
+        # f_e = fraction of tokens routing top-1 to expert e (detached)
+        # p_e = mean router softmax prob for expert e (carries gradient)
+        # loss = lambda * E * sum_e(f_e * p_e)
+        with torch.no_grad():
+            one_hot_top1 = F.one_hot(topk_idx[:, 0], num_classes=E).to(routing_probs.dtype)
+            f = one_hot_top1.mean(dim=0)  # (E,)
+        p = routing_probs.mean(dim=0)     # (E,)
+        aux_loss = self.aux_loss_coef * float(E) * (f * p).sum()
+
+        # ---- Padded-capacity dispatch (static shapes) --------------------------
+        capacity = max(1, int(math.ceil(self.capacity_factor * k * N / E)))
+
+        flat_idx = topk_idx.reshape(-1)         # (N*k,) expert assignment
+        flat_probs = topk_probs.reshape(-1)     # (N*k,) gate weight
+        flat_tok = torch.arange(N, device=x.device).repeat_interleave(k)  # (N*k,)
+
+        # Sort by expert id so assignments for the same expert land contiguously.
+        sort_order = flat_idx.argsort(stable=True)
+        sorted_idx = flat_idx[sort_order]
+        sorted_tok = flat_tok[sort_order]
+        sorted_probs = flat_probs[sort_order]
+
+        # Compute each assignment's position within its expert's block:
+        # counts[e] = #tokens routed to expert e; starts[e] = #tokens routed to experts < e.
+        counts = torch.zeros(E, dtype=torch.long, device=x.device)
+        counts.scatter_add_(0, flat_idx, torch.ones_like(flat_idx))
+        starts = F.pad(counts[:-1].cumsum(0), (1, 0))                   # (E,)
+        pos_within = torch.arange(N * k, device=x.device) - starts[sorted_idx]  # (N*k,)
+        keep = (pos_within < capacity).to(x.dtype)                      # 1.0 kept, 0.0 overflow
+        pos_clamped = pos_within.clamp(max=capacity - 1)
+
+        # Flat index into (E*capacity, D) dispatch buffer.
+        flat_scatter_idx = sorted_idx * capacity + pos_clamped          # (N*k,) in [0, E*cap)
+
+        # Dispatch via scatter_add. Overflow entries contribute 0 (keep=0) so they do not
+        # corrupt the already-placed valid token at slot capacity-1.
+        expert_inputs_flat = torch.zeros(E * capacity, D, dtype=x.dtype, device=x.device)
+        expert_inputs_flat.scatter_add_(
+            0,
+            flat_scatter_idx.unsqueeze(-1).expand(-1, D),
+            x_flat[sorted_tok] * keep.unsqueeze(-1),
+        )
+        expert_inputs = expert_inputs_flat.view(E, capacity, D)
+
+        # ---- Per-expert FFN (batched matmul) -----------------------------------
+        w_fc = self.w_fc.to(x.dtype)      # (E, D, H)
+        w_proj = self.w_proj.to(x.dtype)  # (E, H, D)
+        hidden = torch.bmm(expert_inputs, w_fc)   # (E, capacity, H)
+        hidden = F.relu(hidden).square()
+        expert_output = torch.bmm(hidden, w_proj) # (E, capacity, D)
+
+        # ---- Combine: gather expert outputs and weighted-sum back to tokens ----
+        expert_output_flat = expert_output.view(E * capacity, D)
+        gathered = expert_output_flat[flat_scatter_idx]                      # (N*k, D)
+        weighted = gathered * (sorted_probs * keep).unsqueeze(-1)            # zero for overflow
+
+        routed_out = torch.zeros_like(x_flat)
+        routed_out.scatter_add_(
+            0,
+            sorted_tok.unsqueeze(-1).expand(-1, D),
+            weighted,
+        )
+
+        y = (routed_out + shared_out).view(B, T, D)
+        return y, aux_loss

--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -12,6 +12,12 @@ import torch.distributed as dist
 from torch import Tensor
 from nanochat.common import COMPUTE_DTYPE
 
+# Allow more unique shape specializations in the fused Muon/AdamW kernels. Each unique
+# (num_params, *shape) tuple triggers a specialization; MoE introduces extra shapes
+# (router, routed experts, shared experts) beyond the dense transformer's handful.
+# 64 is comfortably above what nanochat needs even with MoE at depth 26+.
+torch._dynamo.config.cache_size_limit = max(torch._dynamo.config.cache_size_limit, 64)
+
 # -----------------------------------------------------------------------------
 """
 Good old AdamW optimizer, fused kernel.
@@ -248,9 +254,15 @@ class MuonAdamW(torch.optim.Optimizer):
             state["momentum_buffer"] = torch.zeros(num_params, *shape, dtype=dtype, device=device)
         momentum_buffer = state["momentum_buffer"]
 
-        # Second momentum buffer is factored, either per-row or per-column
+        # Second momentum buffer is factored, either per-row or per-column.
+        # Generalized for params of rank >= 2: leading dims (before last 2) are preserved
+        # so each (last-2-dims) slice gets its own factored buffer. This lets Muon process
+        # 3D params like MoE expert stacks (E, D, 4D) as E independent 2D matrices.
         if "second_momentum_buffer" not in state:
-            state_shape = (num_params, shape[-2], 1) if shape[-2] >= shape[-1] else (num_params, 1, shape[-1])
+            if shape[-2] >= shape[-1]:
+                state_shape = (num_params,) + tuple(shape[:-1]) + (1,)
+            else:
+                state_shape = (num_params,) + tuple(shape[:-2]) + (1, shape[-1])
             state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)
         second_momentum_buffer = state["second_momentum_buffer"]
         red_dim = -1 if shape[-2] >= shape[-1] else -2
@@ -466,7 +478,10 @@ class DistMuonAdamW(torch.optim.Optimizer):
         if "momentum_buffer" not in state:
             state["momentum_buffer"] = torch.zeros(chunk_size, *shape, dtype=dtype, device=device)
         if "second_momentum_buffer" not in state:
-            state_shape = (chunk_size, shape[-2], 1) if shape[-2] >= shape[-1] else (chunk_size, 1, shape[-1])
+            if shape[-2] >= shape[-1]:
+                state_shape = (chunk_size,) + tuple(shape[:-1]) + (1,)
+            else:
+                state_shape = (chunk_size,) + tuple(shape[:-2]) + (1, shape[-1])
             state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)
         red_dim = -1 if shape[-2] >= shape[-1] else -2
 

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -52,6 +52,12 @@ parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = de
 parser.add_argument("--head-dim", type=int, default=128, help="target head dimension for attention")
 parser.add_argument("--max-seq-len", type=int, default=2048, help="max context length")
 parser.add_argument("--window-pattern", type=str, default="SSSL", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
+# MoE (num_experts <= 1 disables MoE entirely; expert_hidden auto-scales to keep active FFN ~= dense)
+parser.add_argument("--num-experts", type=int, default=1, help="number of routed MoE experts (1 = dense MLP)")
+parser.add_argument("--top-k", type=int, default=2, help="number of experts activated per token")
+parser.add_argument("--num-shared-experts", type=int, default=0, help="DeepSeek-style always-active shared experts")
+parser.add_argument("--capacity-factor", type=float, default=1.25, help="per-expert capacity = ceil(cf * top_k * N / E); overflow tokens drop")
+parser.add_argument("--moe-aux-loss-coef", type=float, default=0.01, help="Switch-style load-balancing aux loss coefficient")
 # Training horizon (only one used, in order of precedence)
 parser.add_argument("--num-iterations", type=int, default=-1, help="explicit number of optimization steps (-1 = disable)")
 parser.add_argument("--target-flops", type=float, default=-1.0, help="calculate num_iterations to reach target_flops (-1 = disable)")
@@ -137,6 +143,10 @@ def build_model_meta(depth):
         sequence_len=args.max_seq_len, vocab_size=vocab_size,
         n_layer=depth, n_head=num_heads, n_kv_head=num_heads, n_embd=model_dim,
         window_pattern=args.window_pattern,
+        num_experts=args.num_experts, top_k=args.top_k,
+        num_shared_experts=args.num_shared_experts,
+        capacity_factor=args.capacity_factor,
+        moe_aux_loss_coef=args.moe_aux_loss_coef,
     )
     with torch.device("meta"):
         model_meta = GPT(config)
@@ -262,8 +272,10 @@ print0(f"Estimated FLOPs per token: {num_flops_per_token:e}")
 # We've already initialized the model so we have Params. Optimal Tokens is now simply target-param-data-ratio * Params
 def get_scaling_params(m):
     # As for which params to use exactly, transformer matrices + lm_head gives cleanest scaling laws (see dev/LOG.md Jan 27, 2026)
+    # For MoE, use active params (only top_k routed experts + shared, not all experts).
+    # Dense collapses to active == total so this is backwards-compatible.
     params_counts = m.num_scaling_params()
-    scaling_params = params_counts['transformer_matrices'] + params_counts['lm_head']
+    scaling_params = params_counts['active_transformer_matrices'] + params_counts['lm_head']
     return scaling_params
 num_scaling_params = get_scaling_params(model)
 target_tokens = int(args.target_param_data_ratio * num_scaling_params) # optimal tokens for the model we are about to train
@@ -507,14 +519,17 @@ while True:
     # evaluate the gradient
     synchronize()
     t0 = time.time()
+    aux_loss_accum = 0.0  # accumulate aux loss across micro-steps for logging
     for micro_step in range(grad_accum_steps):
-        loss = model(x, y)
-        train_loss = loss.detach() # for logging
-        loss = loss / grad_accum_steps # each .backward() is a grad sum => normalize loss here
+        ce_loss, aux_loss = model(x, y)
+        total_loss = ce_loss + aux_loss  # MoE aux flows into backward; aux is 0 for dense
+        train_loss = ce_loss.detach()  # for logging, CE only (comparable across dense/MoE)
+        aux_loss_accum += aux_loss.detach()
+        total_loss = total_loss / grad_accum_steps # each .backward() is a grad sum => normalize loss here
         if scaler is not None:
-            scaler.scale(loss).backward()
+            scaler.scale(total_loss).backward()
         else:
-            loss.backward()
+            total_loss.backward()
         x, y, dataloader_state_dict = next(train_loader) # prefetch the next batch while the GPU is busy with forward/backward
     # step the optimizer
     lrm = get_lr_multiplier(step)
@@ -566,11 +581,13 @@ while True:
     epoch = f"{dataloader_state_dict['epoch']} pq: {dataloader_state_dict['pq_idx']} rg: {dataloader_state_dict['rg_idx']}"
     print0(f"step {step:05d}/{num_iterations:05d} ({pct_done:.2f}%) | loss: {debiased_smooth_loss:.6f} | lrm: {lrm:.2f} | dt: {dt * 1000:.2f}ms | tok/sec: {tok_per_sec:,} | bf16_mfu: {mfu:.2f} | epoch: {epoch} | total time: {total_training_time/60:.2f}m{eta_str}")
     if step % 100 == 0:
+        aux_loss_avg = (aux_loss_accum / max(1, grad_accum_steps)).item() if torch.is_tensor(aux_loss_accum) else float(aux_loss_accum)
         log_data = {
             "step": step,
             "total_training_flops": flops_so_far,
             "total_training_time": total_training_time,
             "train/loss": debiased_smooth_loss,
+            "train/aux_loss": aux_loss_avg,
             "train/lrm": lrm,
             "train/dt": dt,
             "train/tok_per_sec": tok_per_sec,

--- a/scripts/chat_rl.py
+++ b/scripts/chat_rl.py
@@ -261,7 +261,8 @@ for step in range(num_steps):
             rewards = rewards_all[b0:b1]
             advantages = advantages_all[b0:b1]
             # Calculate log probabilities. Note that the loss calculates NLL = -logp, so we negate
-            logp = -model(inputs, targets, loss_reduction='none').view_as(inputs) # (B, T)
+            ce_loss2d, _ = model(inputs, targets, loss_reduction='none')  # discard MoE aux
+            logp = -ce_loss2d.view_as(inputs) # (B, T)
             # Calculate the PG objective. Note that ignore_index=-1 ensures that invalid tokens have loss 0.
             pg_obj = (logp * advantages.unsqueeze(-1)).sum()
             # normalize by the number of valid tokens, number of passes, and examples_per_rank

--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -430,8 +430,9 @@ while True:
     synchronize()
     t0 = time.time()
     for micro_step in range(grad_accum_steps):
-        loss = model(x, y)
-        train_loss = loss.detach() # for logging
+        ce_loss, aux_loss = model(x, y)
+        loss = ce_loss + aux_loss
+        train_loss = ce_loss.detach() # for logging (ce only, comparable to dense)
         loss = loss / grad_accum_steps # each .backward() is a grad sum => normalize loss here
         if scaler is not None:
             scaler.scale(loss).backward()


### PR DESCRIPTION
- new nanochat/moe.py: padded-capacity dispatch, Switch aux loss, compute-matched default expert_hidden = 4*n_embd / (top_k + num_shared_experts)
- experts stored as 3D nn.Parameter (E, D, H) so Muon orthogonalizes each expert independently via batched polar-express; generalized optim.py state_shape to support leading batch dims (backwards-compatible with 2D dense params)
- num_scaling_params now reports active_* fields following DeepSeek convention; base_train.py uses active_transformer_matrices for compute-optimal token budgets so MoE sweeps remain apples-to-apples across E
- GPT.forward returns (ce_loss, aux_loss); callers (base_train, chat_sft, chat_rl, loss_eval) updated to sum them for backward and log ce/aux separately in wandb
- num_experts=1 falls back to the existing dense MLP (no behavior change)
- cache_size_limit bumped to 64 so the fused kernels can specialize over the extra tensor shapes MoE introduces