### PR TITLE
Use requests instead of urllib for downloads, fixes SSL on macOS

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -5,7 +5,7 @@ Common utilities for nanochat.
 import os
 import re
 import logging
-import urllib.request
+import requests
 import torch
 import torch.distributed as dist
 from filelock import FileLock
@@ -100,8 +100,9 @@ def download_file_with_lock(url, filename, postprocess_fn=None):
 
         # Download the content as bytes
         print(f"Downloading {url}...")
-        with urllib.request.urlopen(url) as response:
-            content = response.read() # bytes
+        response = requests.get(url, timeout=60)
+        response.raise_for_status()
+        content = response.content # bytes
 
         # Write to local file
         with open(file_path, 'wb') as f:


### PR DESCRIPTION
## Problem

`nanochat/common.py:download_file_with_lock` uses `urllib.request.urlopen`. On macOS python.org installs, Python's bundled CA cert store is empty by default until the user runs the `Install Certificates.command` post-install script. HTTPS downloads then fail with:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: unable to get local issuer certificate
```

This breaks `runs/runcpu.sh` partway through:
- `scripts.base_eval` can't download `eval_bundle.zip`
- `scripts.chat_sft` can't download `identity_conversations.jsonl`

Reproduced on a clean macOS Python 3.10.0 install, M-series, MPS.

## Fix

Replace the single `urllib.request.urlopen` call with `requests.get`. `requests` uses `certifi` by default, which ships its own CA bundle, so the download works on every supported platform without per-machine cert configuration.

## Notes

- **No new dependency**: `requests` is already imported in `nanochat/dataset.py` and pulled in transitively (via `wandb` / `huggingface_hub`).
- **One-call swap, same semantics**: download bytes -> write to file.
- **`raise_for_status()`** is added so HTTP errors fail loudly instead of silently writing the response body of an error page.
- **60-second timeout** is added; the previous urlopen call had no timeout and could hang indefinitely.

## Test plan
- [x] Patched `download_file_with_lock` successfully fetches `identity_conversations.jsonl` from the same `karpathy-public.s3...` URL that previously failed with `SSLCertVerificationError`
- [x] No new dependency in `pyproject.toml` (`requests` already used in `nanochat/dataset.py`)
- [x] Same semantics: bytes download -> write to file