### PR TITLE
fix(optim): bf16 mixed-precision crashes on MPS

### DIFF
--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -36,16 +36,23 @@ def adamw_step_fused(
     All in one compiled graph to eliminate Python overhead between ops.
     The 0-D CPU tensors avoid recompilation when hyperparameter values change.
     """
+    # Cast scalar hyperparams to p.dtype. nanochat stores some params (wte,
+    # value_embeds) at COMPUTE_DTYPE (bf16/fp16) to save embedding memory; the
+    # shared scalar tensors here are fp32. CUDA implicitly promotes mixed-dtype
+    # operands but MPS hard-fails ("mps.multiply requires same element type"),
+    # so we cast once up front. No-op when p is already fp32.
+    dtype = p.dtype
+    lr_d, wd_d, beta1_d, beta2_d, eps_d = lr_t.to(dtype), wd_t.to(dtype), beta1_t.to(dtype), beta2_t.to(dtype), eps_t.to(dtype)
     # Weight decay (decoupled, applied before the update)
-    p.mul_(1 - lr_t * wd_t)
+    p.mul_(1 - lr_d * wd_d)
     # Update running averages (lerp_ is cleaner and fuses well)
-    exp_avg.lerp_(grad, 1 - beta1_t)
-    exp_avg_sq.lerp_(grad.square(), 1 - beta2_t)
-    # Bias corrections
+    exp_avg.lerp_(grad, 1 - beta1_d)
+    exp_avg_sq.lerp_(grad.square(), 1 - beta2_d)
+    # Bias corrections (in scalar fp32, then cast back to dtype below)
     bias1 = 1 - beta1_t ** step_t
     bias2 = 1 - beta2_t ** step_t
     # Compute update and apply
-    denom = (exp_avg_sq / bias2).sqrt() + eps_t
+    denom = (exp_avg_sq / bias2.to(dtype)).sqrt() + eps_d
     step_size = lr_t / bias1
     p.add_(exp_avg / denom, alpha=-step_size)
 
@@ -126,7 +133,13 @@ def muon_step_fused(
             A = X @ X.mT
             B = b * A + c * (A @ A)
             X = a * X + B @ X
-    g = X
+    # Cast g back to the parameter dtype: the polar express loop above
+    # intentionally runs in bf16 for speed (X = g.bfloat16()), but the rest
+    # of the function (variance reduction, cautious update) needs g to match
+    # stacked_params and second_momentum_buffer dtypes. CUDA implicitly
+    # promotes mixed-dtype operands; MPS hard-fails. No-op when X.dtype
+    # already matches stacked_params.dtype.
+    g = X.to(stacked_params.dtype)
 
     # Variance reduction
     beta2 = beta2_t.to(g.dtype)

--- a/tests/test_optim_bf16.py
+++ b/tests/test_optim_bf16.py
@@ -1,0 +1,71 @@
+"""
+Regression tests for mixed-dtype scalar / parameter handling in optim.py.
+
+These cover the MPS Metal Graph compiler crashes seen with
+NANOCHAT_DTYPE=bfloat16: scalar hyperparams (fp32) being multiplied with
+bf16 params (wte, value_embeds) failed with "mps.multiply requires same
+element type". CUDA implicitly promotes mixed-dtype operands; MPS doesn't.
+"""
+import pytest
+import torch
+
+from nanochat.optim import adamw_step_fused
+
+
+def _device():
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def _scalars():
+    """0-D fp32 scalar tensors matching what MuonAdamW.__init__ creates."""
+    return [
+        torch.tensor(1.0, dtype=torch.float32),     # step
+        torch.tensor(0.01, dtype=torch.float32),    # lr
+        torch.tensor(0.9, dtype=torch.float32),     # beta1
+        torch.tensor(0.999, dtype=torch.float32),   # beta2
+        torch.tensor(1e-8, dtype=torch.float32),    # eps
+        torch.tensor(0.01, dtype=torch.float32),    # wd
+    ]
+
+
+def _sync(device):
+    if device.type == "mps":
+        torch.mps.synchronize()
+
+
+def _run_adamw(p, grad):
+    exp_avg = torch.zeros_like(p)
+    exp_avg_sq = torch.zeros_like(p)
+    p_before = p.clone()
+    adamw_step_fused(p, grad, exp_avg, exp_avg_sq, *_scalars())
+    _sync(p.device)
+    return p_before
+
+
+def test_adamw_step_fused_bf16_param_with_fp32_scalars():
+    """Regression: adamw_step_fused must not crash when p is bf16 but the
+    scalar hyperparams are fp32. This is the standard nanochat config —
+    wte and value_embeds are cast to COMPUTE_DTYPE (bf16) to save memory,
+    while MuonAdamW's shared scalar tensors remain fp32."""
+    device = _device()
+    torch.manual_seed(0)
+    p = torch.randn(64, 32, dtype=torch.bfloat16, device=device)
+    grad = torch.randn_like(p)
+    p_before = _run_adamw(p, grad)
+    assert torch.isfinite(p).all(), "bf16 update produced non-finite values"
+    assert not torch.equal(p, p_before), "weight did not change after step"
+
+
+def test_adamw_step_fused_fp32_param_unchanged():
+    """The fp32 path must still work and produce a sensible update —
+    the dtype-cast patch should be a no-op when p is already fp32."""
+    device = _device()
+    torch.manual_seed(0)
+    p = torch.randn(64, 32, dtype=torch.float32, device=device)
+    grad = torch.randn_like(p)
+    p_before = _run_adamw(p, grad)
+    assert torch.isfinite(p).all()
+    delta = (p - p_before).norm().item()
+    assert 0 < delta < 10, f"unreasonable update magnitude: {delta}"


### PR DESCRIPTION
## Summary

Fixes `NANOCHAT_DTYPE=bfloat16` on Apple Silicon (MPS). Adds two minimal dtype casts in `nanochat/optim.py` so mixed-dtype operands (bf16 params × fp32 scalar tensors) don't crash MPS's Metal Graph compiler. CUDA path unchanged. Closes #685 .

## Repro before fix

On any M-series Mac with MPS:

```bash
NANOCHAT_DTYPE=bfloat16 python -m scripts.base_train --depth=6 --head-dim=64 \
    --window-pattern=L --max-seq-len=512 --device-batch-size=32 \
    --total-batch-size=16384 --num-iterations=5 --run=dummy
```

crashes immediately during the first `optimizer.step()` with:

```
'mps.multiply' op requires the same element type for all operands and results
%4 = "mps.multiply"(%arg2, %3) : (tensor<1xf32>, tensor<32768x384xbf16>) -> tensor<*xf32>
```

The shape `<32768x384>` is the `wte` parameter (vocab × n_embd) — `nanochat` stores `wte` and `value_embeds` at `COMPUTE_DTYPE` (bf16) to save embedding memory, but the optimizer's shared scalar tensors (`lr_t`, `wd_t`, etc.) are fp32. CUDA implicitly promotes mixed-dtype operands; MPS hard-fails.

## Changes

Two minimal fixes in `nanochat/optim.py`:

1. **`adamw_step_fused`**: cast scalar hyperparams (`lr_t`, `wd_t`, `beta1_t`, `beta2_t`, `eps_t`) to `p.dtype` at the top of the function, then use the cast versions. Also cast `bias2` to dtype where it's used. First crash site was `p.mul_(1 - lr_t * wd_t)` on a bf16 `wte`.

2. **`muon_step_fused`**: cast `g` back to `stacked_params.dtype` after the polar express loop. The loop intentionally runs in bf16 for speed (`X = g.bfloat16()`), but without the cast back, the subsequent variance reduction mixes bf16 `g` with fp32 `second_momentum_buffer` (next crash site after fixing AdamW).

All `.to(dtype)` calls are no-ops when the source is already in the target dtype, so the CUDA path's behavior is unchanged.

## Test plan

- [x] bf16 forward + backward + `optimizer.step` work on M2 (MPS) + torch 2.9.1 (this repo's pinned version)
- [x] fp32 path unchanged — identical loss values to master at 6 decimal places over 5 base_train steps
- [x] bf16 + larger `device-batch-size=48` also works (was OOM at fp32; bf16 cuts embedding memory enough to fit)
- [ ] Would appreciate a CUDA reviewer confirming no regression on the CUDA path — I don't have that hardware

## Numerical notes

- bf16 introduces small numerical drift from fp32 (~1e-3 in loss by step 9 in my testing). This is expected for reduced precision and matches what users on bf16-capable hardware would see anyway. A full pretrain comparison (val_bpb at step 5000) would be the rigorous validation but I haven't run that.

## BF16 Experiment Results (prevents OOM at device_batch_size=48)

Ran a horizon-scale A/B to back this up. Same d6 recipe (~74M params, `num_iterations=5000`), single delta `NANOCHAT_DTYPE=bfloat16`, fp32 baseline as reference. Both on an M2 via MPS.

bf16 lands at **val_bpb 1.169138** vs the fp32 baseline's **1.168621** at step 5000 — a gap of **+0.0005 (0.04%)**, well under the per-eval sampling noise on a 524K-token val budget. The descent through warmdown was smooth, no instability spikes, no NaN. At this scale bf16 costs nothing in quality.

The wins on the side:
- checkpoints 34% smaller (185 MB vs 281 MB)
- unblocks `device_batch_size=48` on M2, which OOMs in fp32

Validating end-to-end surfaced a second mixed-dtype boundary on MPS, the same shape as the one this PR fixes. SDPA in `flash_attention.py` rejects bf16 `q` against the fp32 KV cache — CUDA implicitly promotes, MPS hard-rejects:

```
RuntimeError: Expected query, key, and value to have the same dtype,
but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float
```

Fixed by casting k/v to `q`'s dtype at the SDPA boundary — dtype-neutral, leaves the CUDA FA3 path untouched. Happy to send that as a follow-up PR if it's useful.

## AI disclosure

Per the README's contribution policy: this patch was developed in a Claude Code (Anthropic LLM) session debugging bf16 failures on M2. The LLM helped identify the mismatched-dtype call sites by tracing the Metal Graph compiler error messages back to the offending operations. I reviewed each change, tested it on my hardware, and understand the full patch — it's just adding `.to(dtype)` calls at scalar-use sites in `adamw_step_fused`, plus a single cast on `g` after the polar express loop in `muon_step_fused` so subsequent variance reduction sees consistent dtypes. The pattern is the standard "explicit casts at mixed-dtype boundaries" approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
