### PR TITLE
Docker image for runpod.io to speed up instance setup

### DIFF
--- a/dev/providers/runpod/Dockerfile
+++ b/dev/providers/runpod/Dockerfile
@@ -1,0 +1,20 @@
+FROM runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404
+
+# ── System packages ──────────────────────────────────────────────────────────
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git nano curl ca-certificates screen && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ── Python dependencies (into system Python, torch already in base image) ───
+RUN pip install --no-cache-dir \
+    "datasets>=4.0.0" \
+    "fastapi>=0.117.1" \
+    "kernels>=0.11.7" \
+    "psutil>=7.1.0" \
+    "rustbpe>=0.1.0" \
+    "tiktoken>=0.11.0" \
+    "tokenizers>=0.22.0" \
+    "uvicorn>=0.36.0" \
+    "wandb>=0.21.3"
+
+WORKDIR /workspace

--- a/dev/providers/runpod/build_and_push.sh
+++ b/dev/providers/runpod/build_and_push.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    echo "Usage: $0 <docker-hub-repo> [tag] [--no-push]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 myuser/nanochat-runpod"
+    echo "  $0 myuser/nanochat-runpod v1.0"
+    echo "  $0 myuser/nanochat-runpod latest --no-push"
+    exit 1
+}
+
+[[ $# -lt 1 ]] && usage
+
+DOCKER_REPO="$1"
+TAG="${2:-latest}"
+NO_PUSH=false
+
+for arg in "$@"; do
+    [[ "$arg" == "--no-push" ]] && NO_PUSH=true
+done
+
+IMAGE="${DOCKER_REPO}:${TAG}"
+
+echo ">>> Building ${IMAGE} ..."
+
+docker build -t "$IMAGE" "$SCRIPT_DIR"
+
+echo ">>> Built ${IMAGE}"
+
+if [[ "$NO_PUSH" == true ]]; then
+    echo ">>> Skipping push (--no-push)"
+else
+    echo ">>> Pushing ${IMAGE} ..."
+    docker push "$IMAGE"
+    echo ">>> Pushed ${IMAGE}"
+fi


### PR DESCRIPTION
Speeds up training setup by 10-20 mins (sometimes uv setup takes ages if you get an instance with poor networking), skips uv setup which doesn't make sense on a docker image.

The scripts were used to create this image: https://hub.docker.com/r/ddudekpl/runpod-pytorch-nanochat

# How to use it:
Replace `runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2404` (or any other you're using on runpod) with `ddudekpl/runpod-pytorch-nanochat` (or your own image pushed to the docker hub).

With above you can run nanochat training scripts without the UV setup.

Template to use (runs a small D12): https://console.runpod.io/deploy?template=im4v6z50ix&ref=nfyjbt3c

Example start script:

```
bash -lc '

export PIP_ROOT_USER_ACTION=ignore
export WANDB_API_KEY="${WANDB_API_KEY:-}"
export NPROC_PER_NODE=$RUNPOD_GPU_COUNT
export OMP_NUM_THREADS=1

export DEVICE_BATCH_SIZE=16
export MODEL_DEPTH=12

exec /start.sh &

cd /workspace
if [ -d /workspace/nanochat ]; then
  cd nanochat
else
    git clone "https://github.com/karpathy/nanochat"
    cd nanochat
fi

python -m nanochat.dataset -n 5

echo
echo ">>> Train tokenizer on ~2B chars, then evaluate it ..."
python -m scripts.tok_train --max-chars=2000000000

echo
echo ">>> [Stage 2] Base pretraining (d=${MODEL_DEPTH} model) ..."
time torchrun \
  --standalone \
  --nproc-per-node="${NPROC_PER_NODE}" \
  -m scripts.base_train -- \
    --depth="${MODEL_DEPTH}" \
    --device-batch-size="${DEVICE_BATCH_SIZE}" \
    --max-seq-len=2048 \
    --core-metric-every=500 \
    --eval-every=500 \
    --save-every=1000 \
    --fp8 \
    --sample-every=500 \
    --run="${WANDB_RUN}"

echo "Nanochat script finished, closing in 5 minutes."
sleep 5m

runpodctl stop pod $RUNPOD_POD_ID
'
```