### PR TITLE
fix: validate generation prompt tokens

### DIFF
--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -175,7 +175,11 @@ class Engine:
     @torch.inference_mode()
     def generate(self, tokens, num_samples=1, max_tokens=None, temperature=1.0, top_k=None, seed=42):
         """Same as generate, but does single prefill and then clones the KV cache."""
-        assert isinstance(tokens, list) and isinstance(tokens[0], int), "expecting list of ints"
+        assert (
+            isinstance(tokens, list)
+            and len(tokens) > 0
+            and all(isinstance(token, int) for token in tokens)
+        ), "expecting non-empty list of ints"
         device = self.model.get_device()
         # NOTE: setting the dtype here and in this way is an ugly hack.
         # Currently the repo assumes that cuda -> bfloat16 and everything else -> float32.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,6 +5,7 @@ python -m pytest tests/test_engine.py -v
 """
 
 import torch
+import pytest
 from nanochat.engine import KVCache, Engine
 from dataclasses import dataclass
 
@@ -244,6 +245,18 @@ def test_num_samples_count():
     for num_samples in [1, 4, 16, 64]:
         results, _ = engine.generate_batch(prompt, num_samples=num_samples, max_tokens=3)
         assert len(results) == num_samples, f"Expected {num_samples} sequences from {num_samples} samples, got {len(results)}"
+
+
+def test_generate_validates_token_input():
+    """Prompt tokens must be a non-empty list of integers."""
+    model = MockModel()
+    engine = Engine(model, ByteTokenizer())
+
+    with pytest.raises(AssertionError, match="expecting non-empty list of ints"):
+        next(engine.generate([], max_tokens=1))
+
+    with pytest.raises(AssertionError, match="expecting non-empty list of ints"):
+        next(engine.generate([261, "bad"], max_tokens=1))
 
 
 def test_different_seeds_introduce_variation_when_temperature_nonzero():


### PR DESCRIPTION
## Summary
- reject empty prompt token lists before indexing into them
- validate that every prompt token is an integer before generation starts
- add a focused engine test for invalid prompt token inputs

## Validation
- .venv/bin/python -m py_compile nanochat/engine.py tests/test_engine.py
- git diff --check

I also attempted uv run --group dev pytest tests/test_engine.py -q, but the local environment needed to download torch==2.9.1 and the dependency setup did not complete in this session.

## AI disclosure
Prepared with Codex assistance; I reviewed the small validation change.