### PR TITLE
Fix stale fwe-train/fwe-val labels after ClimbMix migration

### DIFF
--- a/scripts/tok_eval.py
+++ b/scripts/tok_eval.py
@@ -155,10 +155,10 @@ all_text = [
     ("code", code_text),
     ("math", math_text),
     ("science", science_text),
-    ("fwe-train", train_text),
+    ("climbmix-train", train_text),
 ]
 if val_text:
-    all_text.append(("fwe-val", val_text))
+    all_text.append(("climbmix-val", val_text))
 
 # Try out current default compared to GPT-2 and GPT-4 tokenizers
 tokenizer_results = {}


### PR DESCRIPTION
`scripts/tok_eval.py` labels its two real-data evaluation samples as `fwe-train` and `fwe-val` (`fwe` = FineWeb-Edu). However, after the FineWeb-Edu-100B → ClimbMix-400B migration, these samples are actually read from ClimbMix (`base_data_climbmix/`).

This change renames the labels to `climbmix-train` and `climbmix-val` so that the tokenizer evaluation table and `report.md` accurately reflect the dataset being evaluated.

This is a cosmetic change only and does not affect evaluation behavior or results.