### PR TITLE
Fix/categorical eval dual pass

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# SessionStart hook — install Clarinet's dependencies so tests (and any linters)
+# run in Claude Code on the web sessions.
+#
+# Why not `uv sync --extra cpu`? The project pins torch from the PyTorch CDN
+# (download.pytorch.org), which the web environment's network policy blocks
+# (HTTP 403). The exact pinned torch==2.9.1 is also published on PyPI, which is
+# reachable, so we install the project from PyPI via `uv pip` instead. The PyPI
+# linux torch wheel is CUDA-enabled but runs fine on CPU-only nodes.
+set -euo pipefail
+
+# Only run in the remote (Claude Code on the web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR"
+
+# Create the project virtualenv (idempotent; matches .python-version = 3.10).
+uv venv --python 3.10 .venv
+
+# Install the project (editable) + runtime deps + the `dev` group (pytest, ...).
+# torch==2.9.1 and friends resolve from PyPI; `datasets` brings in pyarrow, etc.
+VIRTUAL_ENV="$PROJECT_DIR/.venv" uv pip install -e . --group dev
+
+# Persist venv activation so the agent's shell finds python/pytest for the session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export VIRTUAL_ENV=\"$PROJECT_DIR/.venv\""
+    echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\""
+  } >> "$CLAUDE_ENV_FILE"
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,7 +6,9 @@
 # (download.pytorch.org), which the web environment's network policy blocks
 # (HTTP 403). The exact pinned torch==2.9.1 is also published on PyPI, which is
 # reachable, so we install the project from PyPI via `uv pip` instead. The PyPI
-# linux torch wheel is CUDA-enabled but runs fine on CPU-only nodes.
+# linux torch wheel is the +cu128 build (CUDA 12.8 + NCCL): it runs fine on
+# CPU-only boxes AND drives GPUs (incl. 8xH100) when a web session has them, so
+# this one hook covers both the CPU and CUDA web environments.
 set -euo pipefail
 
 # Only run in the remote (Claude Code on the web) environment.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,20 @@ eval_bundle/
 # Local setup
 CLAUDE.md
 wandb/
+
+# Stray venv that occasionally lands at repo root (instead of inside .venv/)
+# when uv/pip is invoked oddly; keep these out of commits.
+/bin/
+/lib/
+/lib64/
+/pyvenv.cfg
+/share/
+/include/
+
+# Local installer downloads (ROCm, etc.)
+*.deb
+*.rpm
+
+# Downloaded artifacts from one-off curls
+/index.html
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Andrej Karpathy
+Copyright (c) 2026 Vemund Rundberget
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# Clarinet
+
+Clarinet is a research project by Vemund Rundberget that imports the econometric notion of **instrumental variables** (IV) into the auto-regressive token generation of an LLM. The core idea: use the data source (scientific/formal-reasoning corpora vs. general web text) as an instrument to isolate the reasoning-induced component of next-token transitions.
+
+## Upstream
+
+Clarinet is a fork of [`nanochat`](https://github.com/karpathy/nanochat) by Andrej Karpathy. The original `nanochat/` package is retained largely unchanged so that upstream improvements can be rebased cleanly. Clarinet's contributions live in the sibling `clarinet/` package and a handful of new scripts under `scripts/` and `runs/`.
+
+Both copyrights are preserved in `LICENSE` per the terms of the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,68 @@
-# nanochat
+# Clarinet
 
-![nanochat logo](dev/nanochat.png)
-![scaling laws](dev/scaling_laws_jan26.png)
+Clarinet is a research fork of [nanochat](https://github.com/karpathy/nanochat)
+that imports the econometric notion of **instrumental variables (IV)** into the
+autoregressive token generation of an LLM. The core idea: use a document's
+**data source** — formal-reasoning corpora (math) vs. general web text — as an
+instrument, condition the model on it during training, and then steer generation
+toward the reasoning-induced component of next-token transitions at inference,
+classifier-free-guidance (CFG) style.
 
-nanochat is the simplest experimental harness for training LLMs. It is designed to run on a single GPU node, the code is minimal/hackable, and it covers all major LLM stages including tokenization, pretraining, finetuning, evaluation, inference, and a chat UI. For example, you can train your own GPT-2 capability LLM (which cost ~$43,000 to train in 2019) for only $48 (~2 hours of 8XH100 GPU node) and then talk to it in a familiar ChatGPT-like web UI. On a spot instance, the total cost can be closer to ~$15. More generally, nanochat is configured out of the box to train an entire miniseries of compute-optimal models by setting one single complexity dial: `--depth`, the number of layers in the GPT transformer model (GPT-2 capability happens to be approximately depth 26). All other hyperparameters (the width of the transformer, number of heads, learning rate adjustments, training horizons, weight decays, ...) are calculated automatically in an optimal way.
+In one sentence: Clarinet teaches the model a *source-conditioning channel* (a
+marker token at the start of every document) and then exploits that channel at
+decode time by running the model twice — conditional and unconditional — and
+extrapolating along the direction the marker induces.
 
-For questions about the repo, I recommend either using [DeepWiki](https://deepwiki.com/karpathy/nanochat) from Devin/Cognition to ask questions about the repo, or use the [Discussions tab](https://github.com/karpathy/nanochat/discussions), or come by the [#nanochat](https://discord.com/channels/1020383067459821711/1427295580895314031) channel on Discord.
+> New to the idea? Read **[docs/iv_conditioning.md](docs/iv_conditioning.md)**
+> for a precise, pedagogical walk-through of the whole pipeline.
 
-## Time-to-GPT-2 Leaderboard
+## Relationship to nanochat
 
-Presently, the main focus of development is on tuning the pretraining stage, which takes the most amount of compute. Inspired by the modded-nanogpt repo and to incentivise progress and community collaboration, nanochat maintains a leaderboard for a "GPT-2 speedrun", which is the wall-clock time required to train a nanochat model to GPT-2 grade capability, as measured by the DCLM CORE score. The [runs/speedrun.sh](runs/speedrun.sh) script always reflects the reference way to train GPT-2 grade model and talk to it. The current leaderboard looks as follows:
+Clarinet keeps the upstream `nanochat/` package largely unchanged so that
+upstream improvements rebase cleanly. Clarinet's own contributions live in the
+sibling `clarinet/` package plus a handful of new `scripts/` and `runs/` files:
 
-| # | time | val_bpb | CORE | Description | Date | Commit | Contributors |
-|---|-------------|---------|------|-------------|------|--------|--------------|
-| 0 | 168 hours | - | 0.2565 | Original OpenAI GPT-2 checkpoint | 2019 | - | OpenAI |
-| 1 | 3.04 | 0.74833 | 0.2585 | d24 baseline, slightly overtrained | Jan 29 2026 | 348fbb3 | @karpathy |
-| 2 | 2.91 | 0.74504 | 0.2578 | d26 slightly undertrained **+fp8** | Feb 2 2026 | a67eba3 | @karpathy |
-| 3 | 2.76 | 0.74645 | 0.2602 | bump total batch size to 1M tokens | Feb 5 2026 | 2c062aa | @karpathy |
-| 4 | 2.02 | 0.71854 | 0.2571 | change dataset to NVIDIA ClimbMix | Mar 4 2026 | 324e69c | @ddudek @karpathy |
-| 5 | 1.80 | 0.71808 | 0.2690 | autoresearch [round 1](https://x.com/karpathy/status/2031135152349524125) | Mar 9 2026 | 6ed7d1d | @karpathy |
-| 6 | 1.65 | 0.71800 | 0.2626 | autoresearch round 2 | Mar 14 2026 | a825e63 | @karpathy |
+| Concern | Upstream nanochat | Clarinet addition |
+|---|---|---|
+| Datasets | `nanochat/dataset.py` (climbmix) | `clarinet/dataset.py` (climbmix **+** reasoning, source-labelled) |
+| Data loading | `nanochat/dataloader.py` | `clarinet/dataloader.py` (source markers, CFG dropout, target masking) |
+| Inference | `nanochat/engine.py` | `clarinet/engine.py` (dual-pass IV guidance + L1 adaptive scale) |
+| Reasoning corpus | — | `clarinet/prepare_reasoning_data.py` (FineMath shards) |
+| Training entry | `scripts/base_train.py` | `scripts/clarinet_train.py` (wraps base_train) |
+| Chat CLI | `scripts/chat_cli.py` | `scripts/clarinet_cli.py` (guidance flags) |
+| Guidance sweep | — | `scripts/iv_eval.py` |
 
-The primary metric we care about is "time to GPT-2" - the wall clock time needed to outperform the GPT-2 (1.6B) CORE metric on an 8XH100 GPU node. The GPT-2 CORE score is 0.256525. In 2019, the training of GPT-2 cost approximately $43,000 so it is incredible that due to many advances over 7 years across the stack, we can now do so much faster and for well below $100 (e.g. at the current ~$3/GPU/hr, an 8XH100 node is ~$24/hr, so 2 hours is ~$48).
+Three special tokens are added to the tokenizer (`nanochat/tokenizer.py`):
+`<|src_reasoning|>`, `<|src_general|>`, `<|src_unknown|>`.
 
-See [dev/LEADERBOARD.md](dev/LEADERBOARD.md) for more docs on how to interpret and contribute to the leaderboard.
+## How it works (short version)
+
+1. **Two corpora, one source flag.** `clarinet/dataset.py` lists climbmix
+   (general) and reasoning (FineMath) shards, tagging each with `is_reasoning`.
+2. **Conditioning installed at the dataloader.** Every document is laid out as
+   `[BOS, marker, ...tokens]`. With probability `p_uncond` (default 0.1) the true
+   marker is dropped to `<|src_unknown|>` — the CFG unconditional dropout that
+   makes the model also learn the neutral distribution. The target at each
+   marker position is masked to `-1`, so the model never learns to *predict* the
+   marker — it is purely an input conditioner.
+3. **Dual-pass generation.** `ClarinetEngine` runs two lock-step passes per
+   step (reasoning marker vs. unknown marker) and combines logits as
+   `logit_iv = logit_uncond + w · s · (logit_cond − logit_uncond)`, where
+   `w = iv_weight` and `s` is the scale factor.
+4. **L1 adaptive scale (opt-in).** `s` can adapt per step to the L1
+   (total-variation) distance between the two distributions — spend guidance
+   where the marker actually moves the prediction, back off where it doesn't.
+   The default (`scale_lo == scale_hi == 1.0`) reproduces vanilla CFG exactly.
 
 ## Getting started
 
 ### Setup
 
-nanochat uses [uv](https://docs.astral.sh/uv/) for dependency management. To install:
+Clarinet uses [uv](https://docs.astral.sh/uv/) for dependency management:
 
 ```bash
-uv sync --extra gpu    # Use for CUDA (A100/H100/etc.)
-uv sync --extra cpu    # (or) Use for CPU-only / MPS
+uv sync --extra gpu    # CUDA (A100/H100/etc.)
+uv sync --extra cpu    # (or) CPU-only / MPS
 source .venv/bin/activate
 ```
 
@@ -43,169 +72,156 @@ For development (adds pytest, matplotlib, ipykernel, transformers, etc.):
 uv sync --extra gpu --group dev
 ```
 
-### Reproduce and talk to GPT-2
+> Note: adding the three source-marker special tokens changes the vocabulary, so
+> the tokenizer **must be retrained** before training a model. The run scripts
+> below do this for you.
 
-The most fun you can have is to train your own GPT-2 and talk to it. The entire pipeline to do so is contained in the single file [runs/speedrun.sh](runs/speedrun.sh), which is designed to be run on an 8XH100 GPU node. Boot up a new 8XH100 GPU box from your favorite provider (e.g. I use and like [Lambda](https://lambda.ai/service/gpu-cloud)), and kick off the training script:
+### Run the full Clarinet pipeline
 
-```bash
-bash runs/speedrun.sh
-```
-
-You may wish to do so in a screen session as this will take ~3 hours to run. Once it's done, you can talk to it via the ChatGPT-like web UI. Make sure again that your local uv virtual environment is active (run `source .venv/bin/activate`), and serve it:
-
-```bash
-python -m scripts.chat_web
-```
-
-And then visit the URL shown. Make sure to access it correctly, e.g. on Lambda use the public IP of the node you're on, followed by the port, so for example [http://209.20.xxx.xxx:8000/](http://209.20.xxx.xxx:8000/), etc. Then talk to your LLM as you'd normally talk to ChatGPT! Get it to write stories or poems. Ask it to tell you who you are to see a hallucination. Ask it why the sky is blue. Or why it's green. The speedrun is a 4e19 FLOPs capability model so it's a bit like talking to a kindergartener :).
-
----
-
-<img width="2672" height="1520" alt="image" src="https://github.com/user-attachments/assets/ed39ddf8-2370-437a-bedc-0f39781e76b5" />
-
----
-
-A few more notes:
-
-- The code will run just fine on the Ampere 8XA100 GPU node as well, but a bit slower.
-- All code will run just fine on even a single GPU by omitting `torchrun`, and will produce ~identical results (code will automatically switch to gradient accumulation), but you'll have to wait 8 times longer.
-- If your GPU(s) have less than 80GB, you'll have to tune some of the hyperparameters or you will OOM / run out of VRAM. Look for `--device-batch-size` in the scripts and reduce it until things fit. E.g. from 32 (default) to 16, 8, 4, 2, or even 1. Less than that you'll have to know a bit more what you're doing and get more creative.
-- Most of the code is fairly vanilla PyTorch so it should run on anything that supports that - xpu, mps, or etc, but I haven't personally exercised all of these code paths so there might be sharp edges.
-
-## Research
-
-If you are a researcher and wish to help improve nanochat, two scripts of interest are [runs/scaling_laws.sh](runs/scaling_laws.sh) and [runs/miniseries.sh](runs/miniseries.sh). See [Jan 7 miniseries v1](https://github.com/karpathy/nanochat/discussions/420) for related documentation. For quick experimentation (~5 min pretraining runs) my favorite scale is to train a 12-layer model (GPT-1 sized), e.g. like this:
-
-```
-OMP_NUM_THREADS=1 torchrun --standalone --nproc_per_node=8 -m scripts.base_train -- \
-    --depth=12 \
-    --run="d12" \
-    --model-tag="d12" \
-    --core-metric-every=999999 \
-    --sample-every=-1 \
-    --save-every=-1 \
-```
-
-This uses wandb (run name "d12"), only runs the CORE metric on last step, and it doesn't sample and save intermediate checkpoints. I like to change something in the code, re-run a d12 (or a d16 etc) and see if it helped, in an iteration loop. To see if a run helps, I like to monitor the wandb plots for:
-
-1. `val_bpb` (validation loss in vocab-size-invariant units of bits per byte) as a function of `step`, `total_training_time` and `total_training_flops`.
-2. `core_metric` (the DCLM CORE score)
-3. VRAM utilization, `train/mfu` (Model FLOPS utilization), `train/tok_per_sec` (training throughput)
-
-See an example [here](https://github.com/karpathy/nanochat/pull/498#issuecomment-3850720044).
-
-The important thing to note is that nanochat is written and configured around one single dial of complexity - the depth of the transformer. This single integer automatically determines all other hyperparameters (the width of the transformer, number of heads, learning rate adjustments, training horizons, weight decays, ...) so that the trained model comes out compute optimal. The idea is that the user doesn't have to think about or set any of this, they are simply asking for a smaller or bigger model using `--depth`, and everything "just works". By sweeping out the depth, you achieve the nanochat miniseries of compute optimal models at various sizes. GPT-2 capability model (which is of most interest at the moment) happens to be somewhere around d24-d26 range with the current code. But any candidate changes to the repo have to be principled enough that they work for all settings of depth.
-
-## Running on CPU / MPS
-
-The script [runs/runcpu.sh](runs/runcpu.sh) shows a very simple example of running on CPU or Apple Silicon. It dramatically shrinks the LLM that is being trained to make things fit into a reasonable time interval of a few ten minutes of training. You will not get strong results in this way.
-
-## Precision / dtype
-
-nanochat does not use `torch.amp.autocast`. Instead, precision is managed explicitly through a single global `COMPUTE_DTYPE` (defined in `nanochat/common.py`). By default this is auto-detected based on your hardware:
-
-| Hardware | Default dtype | Why |
-|----------|--------------|-----|
-| CUDA SM 80+ (A100, H100, ...) | `bfloat16` | Native bf16 tensor cores |
-| CUDA SM < 80 (V100, T4, ...) | `float32` | No bf16; fp16 available via `NANOCHAT_DTYPE=float16` (uses GradScaler) |
-| CPU / MPS | `float32` | No reduced-precision tensor cores |
-
-You can override the default with the `NANOCHAT_DTYPE` environment variable:
+Two reference scripts wire together data prep, tokenizer training, pretraining,
+SFT, and the IV guidance sweep:
 
 ```bash
-NANOCHAT_DTYPE=float32 python -m scripts.chat_cli -p "hello"   # force fp32
-NANOCHAT_DTYPE=bfloat16 torchrun --nproc_per_node=8 -m scripts.base_train  # force bf16
+bash runs/clarinet_speedrun.sh     # 8×H100 (Hopper fp8, large batch)
+bash runs/clarinet_local_run.sh    # single-GPU (e.g. ROCm in WSL2), smaller batch
 ```
 
-How it works: model weights are stored in fp32 (for optimizer precision), but our custom `Linear` layer casts them to `COMPUTE_DTYPE` during the forward pass. Embeddings are stored directly in `COMPUTE_DTYPE` to save memory. This gives us the same mixed-precision benefit as autocast but with full explicit control over what runs in which precision.
+The key Clarinet-specific steps inside those scripts are:
 
-Note: `float16` training automatically enables a `GradScaler` in `base_train.py` to prevent gradient underflow. SFT supports this too but RL currently does not. Inference in fp16 works fine everywhere.
+```bash
+# 1. Build the reasoning corpus (FineMath shards)
+python -m clarinet.prepare_reasoning_data -n 50
 
-## Guides
+# 2. Retrain the tokenizer (new special tokens) and the model
+python -m scripts.tok_train
+python -m scripts.clarinet_train \
+    --reasoning-mix-ratio=0.3 --p-uncond=0.1 \
+    --depth=24 --target-param-data-ratio=8 \
+    --run=$WANDB_RUN
 
-I've published a number of guides that might contain helpful information, most recent to least recent:
+# 3. Sweep the IV guidance weight (the actual experiment)
+python -m scripts.iv_eval -i sft --weights 0,1.0,1.5,2.0,3.0
+```
 
-- [Feb 1 2026: Beating GPT-2 for <<$100: the nanochat journey](https://github.com/karpathy/nanochat/discussions/481)
-- [Jan 7 miniseries v1](https://github.com/karpathy/nanochat/discussions/420) documents the first nanochat miniseries of models.
-- To add new abilities to nanochat, see [Guide: counting r in strawberry (and how to add abilities generally)](https://github.com/karpathy/nanochat/discussions/164).
-- To customize your nanochat, see [Guide: infusing identity to your nanochat](https://github.com/karpathy/nanochat/discussions/139) in Discussions, which describes how you can tune your nanochat's personality through synthetic data generation and mixing that data into the SFT stage.
-- [Oct 13 2025: original nanochat post](https://github.com/karpathy/nanochat/discussions/1) introducing nanochat, though now it contains some deprecated information and the model is a lot older (with worse results) than current master.
+`clarinet_train.py` adds `--reasoning-mix-ratio` (default 0.3), `--p-uncond`
+(default 0.1), and `--clarinet-seed`; everything else forwards to
+`base_train.py` unchanged (notably `--depth`, the single complexity dial — see
+below). Validation always uses `p_uncond=0.0` (true marker).
+
+### Talk to the model with IV guidance
+
+```bash
+# vanilla CFG (default)
+python -m scripts.clarinet_cli --iv-weight 2.0 --wald-scale 1.0
+
+# L1 content-adaptive scale (opt-in; recommended starting point)
+python -m scripts.clarinet_cli --iv-weight 2.0 --scale-lo 0.5 --scale-hi 2.0
+```
+
+`iv_weight=0` recovers the unconditional distribution; `iv_weight=1, s=1` the
+conditional distribution exactly; `iv_weight` in ~[1.5, 2.5] is the expected
+useful range. Only the **product `w·s`** affects sampling, so tune them as a
+pair. The adaptive schedule's *direction* is an unvalidated hypothesis — compare
+it against constant `s` on held-out reasoning likelihood / GSM8K before trusting
+it.
+
+## Inherited nanochat foundation
+
+The pieces below come from upstream nanochat and are unchanged by Clarinet.
+
+### One complexity dial: `--depth`
+
+nanochat is configured around a single integer, `--depth` (the number of
+transformer layers). It automatically determines width, number of heads, learning
+rate, training horizon, weight decay, etc., so models come out compute-optimal.
+GPT-2 capability sits around depth 24–26. For fast experimentation a 12-layer
+model trains in ~5 minutes; any change to the repo should be principled enough to
+work across depths.
+
+### Precision / dtype
+
+nanochat manages precision explicitly via a global `COMPUTE_DTYPE` (in
+`nanochat/common.py`), auto-detected from hardware:
+
+| Hardware | Default dtype |
+|----------|--------------|
+| CUDA SM 80+ (A100, H100) | `bfloat16` |
+| CUDA SM < 80 (V100, T4) | `float32` (fp16 via `NANOCHAT_DTYPE=float16`) |
+| CPU / MPS | `float32` |
+
+Override with `NANOCHAT_DTYPE`. Weights are stored in fp32; the custom `Linear`
+casts to `COMPUTE_DTYPE` in the forward pass. `float16` training auto-enables a
+`GradScaler` in `base_train.py`.
+
+### CPU / MPS
+
+[runs/runcpu.sh](runs/runcpu.sh) (upstream) and
+[runs/clarinet_local_run.sh](runs/clarinet_local_run.sh) (Clarinet) show small
+runs that fit in a few tens of minutes. These are educational; you will not get
+strong results.
+
+### Speedrun leaderboard
+
+Upstream nanochat maintains a "time-to-GPT-2" speedrun leaderboard; see
+[dev/LEADERBOARD.md](dev/LEADERBOARD.md) and
+[runs/speedrun.sh](runs/speedrun.sh). Clarinet does not track its own leaderboard
+— its metric of interest is reasoning-task performance as a function of the IV
+guidance weight, measured by `scripts/iv_eval.py`.
 
 ## File structure
 
 ```
 .
-├── LICENSE
 ├── README.md
-├── dev
-│   ├── gen_synthetic_data.py       # Example synthetic data for identity
-│   ├── generate_logo.html
-│   ├── nanochat.png
-│   └── repackage_data_reference.py # Pretraining data shard generation
-├── nanochat
-│   ├── __init__.py                 # empty
-│   ├── checkpoint_manager.py       # Save/Load model checkpoints
-│   ├── common.py                   # Misc small utilities, quality of life
-│   ├── core_eval.py                # Evaluates base model CORE score (DCLM paper)
-│   ├── dataloader.py               # Tokenizing Distributed Data Loader
-│   ├── dataset.py                  # Download/read utils for pretraining data
-│   ├── engine.py                   # Efficient model inference with KV Cache
-│   ├── execution.py                # Allows the LLM to execute Python code as tool
-│   ├── gpt.py                      # The GPT nn.Module Transformer
-│   ├── logo.svg
-│   ├── loss_eval.py                # Evaluate bits per byte (instead of loss)
-│   ├── optim.py                    # AdamW + Muon optimizer, 1GPU and distributed
-│   ├── report.py                   # Utilities for writing the nanochat Report
-│   ├── tokenizer.py                # BPE Tokenizer wrapper in style of GPT-4
-│   └── ui.html                     # HTML/CSS/JS for nanochat frontend
-├── pyproject.toml
-├── runs
-│   ├── miniseries.sh               # Miniseries training script
-│   ├── runcpu.sh                   # Small example of how to run on CPU/MPS
-│   ├── scaling_laws.sh             # Scaling laws experiments
-│   └── speedrun.sh                 # Train the ~$100 nanochat d20
+├── NOTICE.md                       # Clarinet ↔ nanochat relationship
+├── docs
+│   └── iv_conditioning.md          # Technical note: how conditioning works end to end
+├── clarinet                        # Clarinet's contributions
+│   ├── dataset.py                  # Source-labelled climbmix + reasoning shards
+│   ├── dataloader.py               # BOS best-fit loader + markers + CFG dropout + target masking
+│   ├── engine.py                   # Dual-pass IV engine + L1 adaptive scale
+│   └── prepare_reasoning_data.py   # Build the FineMath reasoning corpus
+├── nanochat                        # Upstream nanochat (kept ~unchanged)
+│   ├── dataloader.py / dataset.py  # Base loader / pretraining data
+│   ├── engine.py                   # KV-cache inference (Clarinet subclasses this)
+│   ├── gpt.py                      # GPT transformer (cross-entropy ignore_index=-1, softcap)
+│   ├── tokenizer.py                # BPE tokenizer + the 3 new source markers
+│   └── ...                         # checkpoint_manager, optim, core_eval, report, ...
 ├── scripts
-│   ├── base_eval.py                # Base model: CORE score, bits per byte, samples
-│   ├── base_train.py               # Base model: train
-│   ├── chat_cli.py                 # Chat model: talk to over CLI
-│   ├── chat_eval.py                # Chat model: eval tasks
-│   ├── chat_rl.py                  # Chat model: reinforcement learning
-│   ├── chat_sft.py                 # Chat model: train SFT
-│   ├── chat_web.py                 # Chat model: talk to over WebUI
-│   ├── tok_eval.py                 # Tokenizer: evaluate compression rate
-│   └── tok_train.py                # Tokenizer: train it
-├── tasks
-│   ├── arc.py                      # Multiple choice science questions
-│   ├── common.py                   # TaskMixture | TaskSequence
-│   ├── customjson.py               # Make Task from arbitrary jsonl convos
-│   ├── gsm8k.py                    # 8K Grade School Math questions
-│   ├── humaneval.py                # Misnomer; Simple Python coding task
-│   ├── mmlu.py                     # Multiple choice questions, broad topics
-│   ├── smoltalk.py                 # Conglomerate dataset of SmolTalk from HF
-│   └── spellingbee.py              # Task teaching model to spell/count letters
+│   ├── clarinet_train.py           # Train wrapper (mix ratio, p_uncond)
+│   ├── clarinet_cli.py             # Chat CLI with IV guidance flags
+│   ├── iv_eval.py                  # IV guidance-weight sweep
+│   ├── base_train.py / chat_sft.py / chat_cli.py / ...   # upstream stages
+│   └── ...
+├── runs
+│   ├── clarinet_speedrun.sh        # Full Clarinet pipeline, 8×H100
+│   ├── clarinet_local_run.sh       # Full Clarinet pipeline, single GPU
+│   └── speedrun.sh / runcpu.sh / ...                     # upstream runs
+├── tasks                           # arc, gsm8k, mmlu, humaneval, smoltalk, ...
 ├── tests
-│   └── test_engine.py
+│   ├── test_clarinet_engine.py     # Dual-pass + combine + L1 adaptive-scale tests
+│   ├── test_clarinet_dataloader.py # Interleaving, markers, masking
+│   └── test_engine.py              # upstream engine tests
+├── pyproject.toml
 └── uv.lock
 ```
 
-## Contributing
-
-The goal of nanochat is to improve the state of the art in micro models that are accessible to work with end to end on budgets of < $1000 dollars. Accessibility is about overall cost but also about cognitive complexity - nanochat is not an exhaustively configurable LLM "framework"; there are no giant configuration objects, model factories, or if-then-else monsters in the code base. It is a single, cohesive, minimal, readable, hackable, maximally-forkable "strong baseline" codebase designed to run start to end and produce a ChatGPT model you can talk to. Currently, the most interesting part personally is speeding up the latency to GPT-2 (i.e. getting a CORE score above 0.256525). Currently this takes ~3 hours, but by improving the pretraining stage we can improve this further.
-
-Current AI policy: disclosure. When submitting a PR, please declare any parts that had substantial LLM contribution and that you have not written or that you do not fully understand.
-
 ## Acknowledgements
 
-- The name (nanochat) derives from my earlier project [nanoGPT](https://github.com/karpathy/nanoGPT), which only covered pretraining.
-- nanochat is also inspired by [modded-nanoGPT](https://github.com/KellerJordan/modded-nanogpt), which gamified the nanoGPT repo with clear metrics and a leaderboard, and borrows a lot of its ideas and some implementation for pretraining.
-- Thank you to [HuggingFace](https://huggingface.co/) for fineweb and smoltalk.
-- Thank you [Lambda](https://lambda.ai/service/gpu-cloud) for the compute used in developing this project.
-- Thank you to chief LLM whisperer 🧙‍♂️ Alec Radford for advice/guidance.
-- Thank you to the repo czar Sofie [@svlandeg](https://github.com/svlandeg) for help with managing issues, pull requests and discussions of nanochat.
+- Clarinet is a research project by Vemund Rundberget.
+- It is a fork of [nanochat](https://github.com/karpathy/nanochat) by Andrej
+  Karpathy; the entire training/inference/eval foundation is his. nanochat is in
+  turn inspired by [nanoGPT](https://github.com/karpathy/nanoGPT) and
+  [modded-nanoGPT](https://github.com/KellerJordan/modded-nanogpt).
+- Thank you to [HuggingFace](https://huggingface.co/) for FineWeb, SmolTalk, and
+  FineMath (`HuggingFaceTB/finemath`), used as the reasoning corpus.
+
+See [NOTICE.md](NOTICE.md) for the precise upstream relationship; both copyrights
+are preserved in [LICENSE](LICENSE) per the MIT License.
 
 ## Cite
 
-If you find nanochat helpful in your research cite simply as:
+Clarinet builds directly on nanochat; please cite the upstream project:
 
 ```bibtex
 @misc{nanochat,

--- a/clarinet/__init__.py
+++ b/clarinet/__init__.py
@@ -1,0 +1,7 @@
+"""
+Clarinet: instrumental-variable conditioned LLM, a research fork of nanochat.
+
+See NOTICE.md at the repository root for the relationship to upstream nanochat,
+and C:\\Users\\vrund\\.claude\\plans\\this-is-a-new-glimmering-key.md for the
+v1 implementation plan.
+"""

--- a/clarinet/dataloader.py
+++ b/clarinet/dataloader.py
@@ -3,10 +3,10 @@ Clarinet's BOS-aligned best-fit dataloader.
 
 Differences from nanochat.dataloader.tokenizing_distributed_data_loader_with_state_bos_bestfit:
 
-  1. Documents come from TWO parquet sources — climbmix (general) and
-     proof-pile-2 (reasoning) — interleaved by a deterministic round-robin
-     that honors `reasoning_mix_ratio`. All DDP ranks see the same
-     source-ordering so per-rank row-group sharding stays well-defined.
+  1. Documents come from TWO parquet sources — climbmix (general) and the
+     reasoning corpus (currently FineMath) — interleaved by a deterministic
+     round-robin that honors `reasoning_mix_ratio`. All DDP ranks see the
+     same source-ordering so per-rank row-group sharding stays well-defined.
 
   2. After BOS-prepending, the source-marker token (<|src_reasoning|>,
      <|src_general|>, or <|src_unknown|>) is spliced in at position 1 of
@@ -80,7 +80,7 @@ def _document_batches(split, reasoning_mix_ratio, resume_state_dict, tokenizer_b
     """
     Infinite iterator over (text_batch, is_reasoning, (pq_idx, rg_idx, epoch)).
 
-    pq_idx indexes into the interleaved (climbmix + proof-pile-2) sequence.
+    pq_idx indexes into the interleaved (climbmix + reasoning) sequence.
     DDP sharding is done at the row-group level inside each parquet file,
     matching upstream.
     """

--- a/clarinet/dataloader.py
+++ b/clarinet/dataloader.py
@@ -1,0 +1,218 @@
+"""
+Clarinet's BOS-aligned best-fit dataloader.
+
+Differences from nanochat.dataloader.tokenizing_distributed_data_loader_with_state_bos_bestfit:
+
+  1. Documents come from TWO parquet sources — climbmix (general) and
+     proof-pile-2 (reasoning) — interleaved by a deterministic round-robin
+     that honors `reasoning_mix_ratio`. All DDP ranks see the same
+     source-ordering so per-rank row-group sharding stays well-defined.
+
+  2. After BOS-prepending, the source-marker token (<|src_reasoning|>,
+     <|src_general|>, or <|src_unknown|>) is spliced in at position 1 of
+     each tokenized document. With probability `p_uncond`, the true marker
+     is replaced with <|src_unknown|> — the CFG-style unconditional dropout
+     that makes the unconditional pass at inference well-defined.
+
+  3. Any target whose INPUT position holds <|bos|> is masked to -1.
+     That makes the model never train to predict the source-marker (the
+     token immediately after BOS in every doc) — we want the marker to
+     condition generation, not to be a generation target itself.
+
+Everything else (best-fit packing, DDP row-group sharding, pinned CPU
+staging, GPU single-HtoD copy) matches upstream exactly.
+"""
+
+import random
+
+import pyarrow.parquet as pq
+import torch
+
+from nanochat.common import get_dist_info
+
+from clarinet.dataset import list_parquet_files_with_source
+
+
+SRC_REASONING = "<|src_reasoning|>"
+SRC_GENERAL = "<|src_general|>"
+SRC_UNKNOWN = "<|src_unknown|>"
+
+
+def _interleave_sources(paths_with_source, reasoning_mix_ratio):
+    """
+    Deterministic round-robin interleave of two source lists into a single
+    ordered list, hitting `reasoning_mix_ratio` exactly over each window of
+    1 / gcd(ratio_numerator, denominator) files. Returns [(path, is_reasoning)].
+
+    A deterministic schedule (no RNG) keeps all DDP ranks aligned without
+    needing a shared seed.
+    """
+    climbmix = [p for p in paths_with_source if not p[1]]
+    reasoning = [p for p in paths_with_source if p[1]]
+    if not climbmix or not reasoning:
+        return list(paths_with_source)
+
+    out = []
+    c_idx = r_idx = 0
+    # Schedule based on cumulative target ratio: at step k, the desired count
+    # of reasoning files so far is round(k * ratio). When that increases, emit
+    # a reasoning file; otherwise emit a climbmix file. This produces an
+    # evenly-spread interleaving (no clumping).
+    emitted_reasoning = 0
+    step = 0
+    while c_idx < len(climbmix) or r_idx < len(reasoning):
+        step += 1
+        want_reasoning = round(step * reasoning_mix_ratio)
+        if (want_reasoning > emitted_reasoning and r_idx < len(reasoning)) or c_idx >= len(climbmix):
+            out.append((reasoning[r_idx], True))
+            r_idx += 1
+            emitted_reasoning += 1
+        else:
+            out.append((climbmix[c_idx], False))
+            c_idx += 1
+    return out
+
+
+def _document_batches(split, reasoning_mix_ratio, resume_state_dict, tokenizer_batch_size):
+    """
+    Infinite iterator over (text_batch, is_reasoning, (pq_idx, rg_idx, epoch)).
+
+    pq_idx indexes into the interleaved (climbmix + proof-pile-2) sequence.
+    DDP sharding is done at the row-group level inside each parquet file,
+    matching upstream.
+    """
+    ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()
+
+    paths_with_source = list_parquet_files_with_source(split)
+    interleaved = _interleave_sources(paths_with_source, reasoning_mix_ratio)
+    assert interleaved, "No parquet files found across either source"
+
+    resume_pq_idx = resume_state_dict["pq_idx"] if resume_state_dict is not None else 0
+    resume_rg_idx = resume_state_dict["rg_idx"] if resume_state_dict is not None else None
+    resume_epoch = resume_state_dict.get("epoch", 1) if resume_state_dict is not None else 1
+    first_pass = True
+    epoch = resume_epoch
+
+    while True:
+        pq_idx = resume_pq_idx if first_pass else 0
+        while pq_idx < len(interleaved):
+            filepath, is_reasoning = interleaved[pq_idx]
+            pf = pq.ParquetFile(filepath)
+            if first_pass and (resume_rg_idx is not None) and (pq_idx == resume_pq_idx):
+                base_idx = resume_rg_idx // ddp_world_size
+                base_idx += 1
+                rg_idx = base_idx * ddp_world_size + ddp_rank
+                if rg_idx >= pf.num_row_groups:
+                    pq_idx += 1
+                    continue
+                resume_rg_idx = None
+            else:
+                rg_idx = ddp_rank
+            while rg_idx < pf.num_row_groups:
+                rg = pf.read_row_group(rg_idx)
+                batch = rg.column("text").to_pylist()
+                for i in range(0, len(batch), tokenizer_batch_size):
+                    yield batch[i:i + tokenizer_batch_size], is_reasoning, (pq_idx, rg_idx, epoch)
+                rg_idx += ddp_world_size
+            pq_idx += 1
+        first_pass = False
+        epoch += 1
+
+
+def clarinet_data_loader(
+    tokenizer, B, T, split,
+    reasoning_mix_ratio=0.3,
+    p_uncond=0.1,
+    tokenizer_threads=4,
+    tokenizer_batch_size=128,
+    device="cuda",
+    resume_state_dict=None,
+    buffer_size=1000,
+    seed=0,
+):
+    """
+    BOS-aligned best-fit loader with clarinet source markers + target masking.
+
+    Yields (inputs, targets, state_dict) where:
+      - inputs, targets: (B, T) long tensors on `device`
+      - state_dict: {"pq_idx", "rg_idx", "epoch"} for resume
+
+    `seed` controls the per-doc p_uncond dropout RNG. We seed per rank so
+    different ranks make independent dropout choices, which is fine because
+    each rank handles its own row groups.
+    """
+    assert split in ("train", "val"), "split must be 'train' or 'val'"
+
+    row_capacity = T + 1
+    batches = _document_batches(split, reasoning_mix_ratio, resume_state_dict, tokenizer_batch_size)
+    bos_token = tokenizer.get_bos_token_id()
+    src_reasoning_id = tokenizer.encode_special(SRC_REASONING)
+    src_general_id = tokenizer.encode_special(SRC_GENERAL)
+    src_unknown_id = tokenizer.encode_special(SRC_UNKNOWN)
+
+    _, ddp_rank, _, _ = get_dist_info()
+    rng = random.Random(seed + ddp_rank)
+
+    doc_buffer = []
+    pq_idx, rg_idx, epoch = 0, 0, 1
+
+    def refill_buffer():
+        nonlocal pq_idx, rg_idx, epoch
+        doc_batch, is_reasoning, (pq_idx, rg_idx, epoch) = next(batches)
+        token_lists = tokenizer.encode(doc_batch, prepend=bos_token, num_threads=tokenizer_threads)
+        true_marker = src_reasoning_id if is_reasoning else src_general_id
+        for tokens in token_lists:
+            marker = src_unknown_id if rng.random() < p_uncond else true_marker
+            # tokens already starts with BOS; insert the source marker right after it,
+            # giving [BOS, marker, ...doc_tokens]
+            tokens.insert(1, marker)
+            doc_buffer.append(tokens)
+
+    use_cuda = device == "cuda"
+    row_buffer = torch.empty((B, row_capacity), dtype=torch.long)
+    cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=use_cuda)
+    gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device)
+    cpu_inputs = cpu_buffer[:B * T].view(B, T)
+    cpu_targets = cpu_buffer[B * T:].view(B, T)
+    inputs = gpu_buffer[:B * T].view(B, T)
+    targets = gpu_buffer[B * T:].view(B, T)
+
+    while True:
+        for row_idx in range(B):
+            pos = 0
+            while pos < row_capacity:
+                while len(doc_buffer) < buffer_size:
+                    refill_buffer()
+
+                remaining = row_capacity - pos
+
+                best_idx = -1
+                best_len = 0
+                for i, doc in enumerate(doc_buffer):
+                    doc_len = len(doc)
+                    if doc_len <= remaining and doc_len > best_len:
+                        best_idx = i
+                        best_len = doc_len
+
+                if best_idx >= 0:
+                    doc = doc_buffer.pop(best_idx)
+                    doc_len = len(doc)
+                    row_buffer[row_idx, pos:pos + doc_len] = torch.tensor(doc, dtype=torch.long)
+                    pos += doc_len
+                else:
+                    shortest_idx = min(range(len(doc_buffer)), key=lambda i: len(doc_buffer[i]))
+                    doc = doc_buffer.pop(shortest_idx)
+                    row_buffer[row_idx, pos:pos + remaining] = torch.tensor(doc[:remaining], dtype=torch.long)
+                    pos += remaining
+
+        cpu_inputs.copy_(row_buffer[:, :-1])
+        cpu_targets.copy_(row_buffer[:, 1:])
+        # Mask the marker-prediction targets: any position whose input is BOS
+        # has the source marker as its next-token label; we don't want to train
+        # the model to predict source.
+        cpu_targets[cpu_inputs == bos_token] = -1
+
+        state_dict = {"pq_idx": pq_idx, "rg_idx": rg_idx, "epoch": epoch}
+
+        gpu_buffer.copy_(cpu_buffer, non_blocking=use_cuda)
+        yield inputs, targets, state_dict

--- a/clarinet/dataloader.py
+++ b/clarinet/dataloader.py
@@ -47,8 +47,11 @@ def _interleave_sources(paths_with_source, reasoning_mix_ratio):
     A deterministic schedule (no RNG) keeps all DDP ranks aligned without
     needing a shared seed.
     """
-    climbmix = [p for p in paths_with_source if not p[1]]
-    reasoning = [p for p in paths_with_source if p[1]]
+    # Pull just the paths — paths_with_source entries are (path, is_reasoning)
+    # tuples, and we re-wrap below. Failing to unwrap here used to produce
+    # nested tuples that downstream pyarrow rejected.
+    climbmix = [p for p, is_r in paths_with_source if not is_r]
+    reasoning = [p for p, is_r in paths_with_source if is_r]
     if not climbmix or not reasoning:
         return list(paths_with_source)
 

--- a/clarinet/dataset.py
+++ b/clarinet/dataset.py
@@ -2,9 +2,9 @@
 Source-labelled parquet listing for clarinet.
 
 Combines the existing climbmix shards (from nanochat/dataset.py) with the
-proof-pile-2 shards produced by clarinet/prepare_proof_pile.py, attaching an
-is_reasoning flag to each path so the clarinet dataloader can pick a
-source-marker token per document.
+reasoning-corpus shards produced by clarinet/prepare_reasoning_data.py,
+attaching an is_reasoning flag to each path so the clarinet dataloader can
+pick a source-marker token per document.
 
 Train/val convention matches upstream nanochat: last shard in each source dir
 is the validation shard, all earlier shards are train.
@@ -16,24 +16,31 @@ from nanochat.common import get_base_dir
 from nanochat.dataset import list_parquet_files as list_climbmix_parquet_files
 
 REASONING_DIR_NAME = "reasoning_data"
-PROOF_PILE_DIR_NAME = "proof_pile_2"
+FINEMATH_DIR_NAME = "finemath"
 
 
-def proof_pile_dir():
-    """Where prepare_proof_pile.py writes shards, and where the dataloader reads them from."""
-    return os.path.join(get_base_dir(), REASONING_DIR_NAME, PROOF_PILE_DIR_NAME)
+def reasoning_data_dir():
+    """
+    Where prepare_reasoning_data.py writes the reasoning-corpus shards, and where
+    the dataloader reads them from. Currently FineMath (HuggingFaceTB/finemath,
+    finemath-4plus subset) — the original plan called for EleutherAI/proof-pile-2
+    but their data hosting rotted out (data files return 404 on HF Hub as of
+    2026-05). FineMath is the closest practical replacement: parquet-native,
+    actively maintained, math-focused.
+    """
+    return os.path.join(get_base_dir(), REASONING_DIR_NAME, FINEMATH_DIR_NAME)
 
 
-def list_proof_pile_parquet_files():
-    """Returns paths to proof-pile-2 shards written by prepare_proof_pile.py."""
-    pdir = proof_pile_dir()
-    if not os.path.isdir(pdir):
+def list_reasoning_parquet_files():
+    """Returns paths to reasoning-corpus shards written by prepare_reasoning_data.py."""
+    rdir = reasoning_data_dir()
+    if not os.path.isdir(rdir):
         return []
     files = sorted(
-        f for f in os.listdir(pdir)
+        f for f in os.listdir(rdir)
         if f.endswith(".parquet") and not f.endswith(".tmp")
     )
-    return [os.path.join(pdir, f) for f in files]
+    return [os.path.join(rdir, f) for f in files]
 
 
 def list_parquet_files_with_source(split):
@@ -45,10 +52,10 @@ def list_parquet_files_with_source(split):
     assert split in ("train", "val"), "split must be 'train' or 'val'"
 
     climbmix = list_climbmix_parquet_files(warn_on_legacy=(split == "train"))
-    reasoning = list_proof_pile_parquet_files()
+    reasoning = list_reasoning_parquet_files()
     assert reasoning, (
-        f"No proof-pile-2 shards found under {proof_pile_dir()}. "
-        "Run `python -m clarinet.prepare_proof_pile` first."
+        f"No reasoning-corpus shards found under {reasoning_data_dir()}. "
+        "Run `python -m clarinet.prepare_reasoning_data` first."
     )
 
     if split == "train":

--- a/clarinet/dataset.py
+++ b/clarinet/dataset.py
@@ -15,7 +15,13 @@ import os
 from nanochat.common import get_base_dir
 from nanochat.dataset import list_parquet_files as list_climbmix_parquet_files
 
-from clarinet.prepare_proof_pile import proof_pile_dir
+REASONING_DIR_NAME = "reasoning_data"
+PROOF_PILE_DIR_NAME = "proof_pile_2"
+
+
+def proof_pile_dir():
+    """Where prepare_proof_pile.py writes shards, and where the dataloader reads them from."""
+    return os.path.join(get_base_dir(), REASONING_DIR_NAME, PROOF_PILE_DIR_NAME)
 
 
 def list_proof_pile_parquet_files():

--- a/clarinet/dataset.py
+++ b/clarinet/dataset.py
@@ -1,0 +1,55 @@
+"""
+Source-labelled parquet listing for clarinet.
+
+Combines the existing climbmix shards (from nanochat/dataset.py) with the
+proof-pile-2 shards produced by clarinet/prepare_proof_pile.py, attaching an
+is_reasoning flag to each path so the clarinet dataloader can pick a
+source-marker token per document.
+
+Train/val convention matches upstream nanochat: last shard in each source dir
+is the validation shard, all earlier shards are train.
+"""
+
+import os
+
+from nanochat.common import get_base_dir
+from nanochat.dataset import list_parquet_files as list_climbmix_parquet_files
+
+from clarinet.prepare_proof_pile import proof_pile_dir
+
+
+def list_proof_pile_parquet_files():
+    """Returns paths to proof-pile-2 shards written by prepare_proof_pile.py."""
+    pdir = proof_pile_dir()
+    if not os.path.isdir(pdir):
+        return []
+    files = sorted(
+        f for f in os.listdir(pdir)
+        if f.endswith(".parquet") and not f.endswith(".tmp")
+    )
+    return [os.path.join(pdir, f) for f in files]
+
+
+def list_parquet_files_with_source(split):
+    """
+    Returns [(path, is_reasoning), ...] for the requested split across both
+    corpora. Last shard in each source dir is val; everything else is train.
+    Caller (the dataloader) chooses how to interleave the two sources.
+    """
+    assert split in ("train", "val"), "split must be 'train' or 'val'"
+
+    climbmix = list_climbmix_parquet_files(warn_on_legacy=(split == "train"))
+    reasoning = list_proof_pile_parquet_files()
+    assert reasoning, (
+        f"No proof-pile-2 shards found under {proof_pile_dir()}. "
+        "Run `python -m clarinet.prepare_proof_pile` first."
+    )
+
+    if split == "train":
+        climbmix = climbmix[:-1]
+        reasoning = reasoning[:-1]
+    else:
+        climbmix = climbmix[-1:]
+        reasoning = reasoning[-1:]
+
+    return [(p, False) for p in climbmix] + [(p, True) for p in reasoning]

--- a/clarinet/engine.py
+++ b/clarinet/engine.py
@@ -1,0 +1,155 @@
+"""
+Clarinet inference engine — dual-pass IV-style token generation.
+
+At every decode step we run the model twice:
+  - Conditional pass: prompt prefixed with [BOS, <|src_reasoning|>, ...]
+  - Unconditional pass: prompt prefixed with [BOS, <|src_unknown|>, ...]
+
+Then combine logits as
+
+    logit_iv = logit_uncond + w * s * (logit_cond - logit_uncond)
+
+where
+  - w is the standard guidance weight (`iv_weight`)
+  - s is the Wald-style scale factor (`wald_scale`); s=1 reduces to vanilla CFG.
+    A learned-from-hidden-states estimator for s is left as future work
+    (would require exposing pre-lm_head activations from gpt.py).
+
+Two parallel KVCaches are maintained — one per conditioning. Both consume the
+same sampled-token sequence after combination, so they stay in lock-step.
+"""
+
+import torch
+
+from nanochat.engine import Engine, KVCache, RowState, sample_next_token, use_calculator
+
+
+class ClarinetEngine(Engine):
+
+    SRC_REASONING = "<|src_reasoning|>"
+    SRC_UNKNOWN = "<|src_unknown|>"
+
+    def _prefix_with_marker(self, tokens, marker_id, bos_id):
+        # Splice marker into the prompt to mirror training-time layout
+        # ([BOS, marker, ...]). If the prompt doesn't already start with BOS
+        # (uncommon — chat/render_conversation always prepends one), add it.
+        if tokens and tokens[0] == bos_id:
+            return [tokens[0], marker_id, *tokens[1:]]
+        return [bos_id, marker_id, *tokens]
+
+    @staticmethod
+    def combine_logits(logit_cond, logit_uncond, iv_weight, wald_scale):
+        """
+        Wald-scaled IV combine: logit_uncond + w*s*(logit_cond - logit_uncond).
+        w=0 returns the unconditional logits; w=1, s=1 returns the conditional
+        logits exactly. Extracted as a static method for unit-testability.
+        """
+        return logit_uncond + iv_weight * wald_scale * (logit_cond - logit_uncond)
+
+    @torch.inference_mode()
+    def generate(self, tokens, num_samples=1, max_tokens=None, temperature=1.0,
+                 top_k=None, seed=42, iv_weight=1.5, wald_scale=1.0):
+        """
+        IV-conditioned generation. iv_weight=0 recovers the unconditional
+        distribution; iv_weight=1, wald_scale=1 recovers the conditional
+        distribution exactly. iv_weight in [1.5, 2.5] is the expected
+        useful range.
+
+        Forwards everything else (tool-use state machine, forced tokens,
+        completion detection) from the upstream Engine.generate().
+        """
+        assert isinstance(tokens, list) and isinstance(tokens[0], int), "expecting list of ints"
+        device = self.model.get_device()
+        dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+        rng = torch.Generator(device=device)
+        rng.manual_seed(seed)
+
+        get_special = lambda s: self.tokenizer.encode_special(s)
+        python_start = get_special("<|python_start|>")
+        python_end = get_special("<|python_end|>")
+        output_start = get_special("<|output_start|>")
+        output_end = get_special("<|output_end|>")
+        assistant_end = get_special("<|assistant_end|>")
+        bos = self.tokenizer.get_bos_token_id()
+        src_reasoning_id = get_special(self.SRC_REASONING)
+        src_unknown_id = get_special(self.SRC_UNKNOWN)
+
+        cond_tokens = self._prefix_with_marker(tokens, src_reasoning_id, bos)
+        uncond_tokens = self._prefix_with_marker(tokens, src_unknown_id, bos)
+        # The two variants differ only at position 1 (the marker), so they have
+        # equal length; the decode loop relies on that.
+        assert len(cond_tokens) == len(uncond_tokens)
+        prompt_len = len(cond_tokens)
+
+        m = self.model.config
+        kv_model_kwargs = {"num_heads": m.n_kv_head, "head_dim": m.n_embd // m.n_head, "num_layers": m.n_layer}
+
+        def run_prefill(prompt_tokens):
+            cache = KVCache(batch_size=1, seq_len=prompt_len, device=device, dtype=dtype, **kv_model_kwargs)
+            ids = torch.tensor([prompt_tokens], dtype=torch.long, device=device)
+            logits = self.model.forward(ids, kv_cache=cache)
+            logits = logits[:, -1, :].expand(num_samples, -1)
+            return cache, logits
+
+        cond_prefill, cond_logits = run_prefill(cond_tokens)
+        uncond_prefill, uncond_logits = run_prefill(uncond_tokens)
+
+        kv_length_hint = (prompt_len + max_tokens) if max_tokens is not None else self.model.config.sequence_len
+
+        def expand_to_decode_cache(prefill_cache):
+            decode_cache = KVCache(batch_size=num_samples, seq_len=kv_length_hint, device=device, dtype=dtype, **kv_model_kwargs)
+            decode_cache.prefill(prefill_cache)
+            return decode_cache
+
+        cond_cache = expand_to_decode_cache(cond_prefill)
+        uncond_cache = expand_to_decode_cache(uncond_prefill)
+        del cond_prefill, uncond_prefill
+
+        logits = self.combine_logits(cond_logits, uncond_logits, iv_weight, wald_scale)
+
+        row_states = [RowState(tokens.copy()) for _ in range(num_samples)]
+
+        num_generated = 0
+        while True:
+            if max_tokens is not None and num_generated >= max_tokens:
+                break
+            if all(state.completed for state in row_states):
+                break
+
+            next_ids = sample_next_token(logits, rng, temperature, top_k)
+            sampled_tokens = next_ids[:, 0].tolist()
+
+            token_column = []
+            token_masks = []
+            for i, state in enumerate(row_states):
+                is_forced = len(state.forced_tokens) > 0
+                token_masks.append(0 if is_forced else 1)
+                next_token = state.forced_tokens.popleft() if is_forced else sampled_tokens[i]
+                token_column.append(next_token)
+                state.current_tokens.append(next_token)
+                if next_token == assistant_end or next_token == bos:
+                    state.completed = True
+                if next_token == python_start:
+                    state.in_python_block = True
+                    state.python_expr_tokens = []
+                elif next_token == python_end and state.in_python_block:
+                    state.in_python_block = False
+                    if state.python_expr_tokens:
+                        expr = self.tokenizer.decode(state.python_expr_tokens)
+                        result = use_calculator(expr)
+                        if result is not None:
+                            result_tokens = self.tokenizer.encode(str(result))
+                            state.forced_tokens.append(output_start)
+                            state.forced_tokens.extend(result_tokens)
+                            state.forced_tokens.append(output_end)
+                    state.python_expr_tokens = []
+                elif state.in_python_block:
+                    state.python_expr_tokens.append(next_token)
+
+            yield token_column, token_masks
+            num_generated += 1
+
+            ids = torch.tensor(token_column, dtype=torch.long, device=device).unsqueeze(1)
+            cond_logits = self.model.forward(ids, kv_cache=cond_cache)[:, -1, :]
+            uncond_logits = self.model.forward(ids, kv_cache=uncond_cache)[:, -1, :]
+            logits = self.combine_logits(cond_logits, uncond_logits, iv_weight, wald_scale)

--- a/clarinet/engine.py
+++ b/clarinet/engine.py
@@ -201,3 +201,62 @@ class ClarinetEngine(Engine):
             cond_logits = self.model.forward(ids, kv_cache=cond_cache)[:, -1, :]
             uncond_logits = self.model.forward(ids, kv_cache=uncond_cache)[:, -1, :]
             logits = combine(cond_logits, uncond_logits)
+
+    @torch.inference_mode()
+    def categorical_logits_at(self, token_lists, answer_positions,
+                              iv_weight=1.5, wald_scale=1.0,
+                              scale_lo=1.0, scale_hi=1.0):
+        """
+        Dual-pass categorical logits: insert source markers, run conditional
+        and unconditional forward passes, combine via IV formula, and return
+        logits at the answer positions.
+
+        This is the categorical-evaluation counterpart of generate() — it
+        applies the same dual-pass IV combine to every answer position in a
+        batched forward pass (no autoregressive decoding).
+
+        Args:
+            token_lists: list of list of int — unpadded token sequences
+            answer_positions: list of int — position of the answer token in each
+                sequence (indexing into the *original* sequences before marker
+                insertion)
+            iv_weight: guidance weight (0 = unconditional, 1 = conditional)
+            wald_scale: constant scale factor
+            scale_lo, scale_hi: bounds for L1 adaptive scale (lo == hi -> constant)
+        Returns:
+            (B, V) tensor of combined logits at the answer positions
+        """
+        device = self.model.get_device()
+        bos = self.tokenizer.get_bos_token_id()
+        src_reasoning_id = self.tokenizer.encode_special(self.SRC_REASONING)
+        src_unknown_id = self.tokenizer.encode_special(self.SRC_UNKNOWN)
+
+        # Insert source markers — shifts each sequence by 1 (or 2 if BOS missing)
+        cond_lists = [self._prefix_with_marker(ids, src_reasoning_id, bos)
+                      for ids in token_lists]
+        uncond_lists = [self._prefix_with_marker(ids, src_unknown_id, bos)
+                        for ids in token_lists]
+        adjusted_positions = [
+            pos + len(marked) - len(orig)
+            for pos, orig, marked in zip(answer_positions, token_lists, cond_lists)
+        ]
+
+        max_length = max(len(ids) for ids in cond_lists)
+        cond_padded = [ids + [bos] * (max_length - len(ids)) for ids in cond_lists]
+        uncond_padded = [ids + [bos] * (max_length - len(ids)) for ids in uncond_lists]
+
+        cond_ids = torch.tensor(cond_padded, dtype=torch.long, device=device)
+        uncond_ids = torch.tensor(uncond_padded, dtype=torch.long, device=device)
+
+        cond_logits = self.model(cond_ids)      # (B, T', V)
+        uncond_logits = self.model(uncond_ids)   # (B, T', V)
+
+        # Extract logits at adjusted answer positions
+        B = cond_logits.size(0)
+        positions = torch.tensor(adjusted_positions, device=device)
+        arange = torch.arange(B, device=device)
+        cond_at = cond_logits[arange, positions]      # (B, V)
+        uncond_at = uncond_logits[arange, positions]   # (B, V)
+
+        s = self.l1_adaptive_scale(cond_at, uncond_at, wald_scale, scale_lo, scale_hi)
+        return self.combine_logits(cond_at, uncond_at, iv_weight, s)

--- a/clarinet/engine.py
+++ b/clarinet/engine.py
@@ -11,9 +11,18 @@ Then combine logits as
 
 where
   - w is the standard guidance weight (`iv_weight`)
-  - s is the Wald-style scale factor (`wald_scale`); s=1 reduces to vanilla CFG.
-    A learned-from-hidden-states estimator for s is left as future work
-    (would require exposing pre-lm_head activations from gpt.py).
+  - s is the scale factor (`wald_scale`); s=1 reduces to vanilla CFG.
+
+The scale s may be held constant (vanilla CFG) or made *content-adaptive* per
+decode step via the L1 (total-variation) distance between the conditional and
+unconditional next-token distributions — see `l1_adaptive_scale`. The intuition:
+spend guidance budget where the source marker actually changes the prediction
+(high divergence) and back off where it doesn't (low divergence). This measures
+the marker's effect directly in output space, from the two logit vectors we
+already compute, so it needs no probe and no extra forward pass. It is an
+adaptive-CFG schedule, not a causal estimator — the modulation *direction* is a
+hypothesis to validate against held-out reasoning likelihood / GSM8K, with
+constant s (scale_lo == scale_hi) as the control it must beat.
 
 Two parallel KVCaches are maintained — one per conditioning. Both consume the
 same sampled-token sequence after combination, so they stay in lock-step.
@@ -46,14 +55,49 @@ class ClarinetEngine(Engine):
         """
         return logit_uncond + iv_weight * wald_scale * (logit_cond - logit_uncond)
 
+    @staticmethod
+    def l1_adaptive_scale(logit_cond, logit_uncond, base_scale, scale_lo, scale_hi):
+        """
+        Content-adaptive scale from the L1 (total-variation) distance between
+        the conditional and unconditional next-token distributions.
+
+        Returns a per-row scale with the logits' leading shape and trailing
+        dim 1 (broadcastable over the vocab axis in combine_logits):
+
+            s = base_scale * (scale_lo + (scale_hi - scale_lo) * d)
+
+        where d in [0, 1] is the total-variation distance (= 0.5 * L1) between
+        softmax(logit_cond) and softmax(logit_uncond). When the source marker
+        barely changes the prediction (d ~ 0) the scale relaxes toward
+        scale_lo; when it strongly forks the prediction (d ~ 1) it rises toward
+        scale_hi.
+
+        scale_lo == scale_hi short-circuits to the constant `base_scale *
+        scale_lo` (no softmax computed), and the default scale_lo == scale_hi
+        == 1.0 is exactly vanilla CFG. Both logits are already softcapped by
+        gpt.py, which is the same space the combine happens in.
+        """
+        if scale_lo == scale_hi:
+            return base_scale * scale_lo
+        p = torch.softmax(logit_cond.float(), dim=-1)
+        q = torch.softmax(logit_uncond.float(), dim=-1)
+        d = 0.5 * (p - q).abs().sum(dim=-1, keepdim=True)  # (..., 1) in [0, 1]
+        return base_scale * (scale_lo + (scale_hi - scale_lo) * d)
+
     @torch.inference_mode()
     def generate(self, tokens, num_samples=1, max_tokens=None, temperature=1.0,
-                 top_k=None, seed=42, iv_weight=1.5, wald_scale=1.0):
+                 top_k=None, seed=42, iv_weight=1.5, wald_scale=1.0,
+                 scale_lo=1.0, scale_hi=1.0):
         """
         IV-conditioned generation. iv_weight=0 recovers the unconditional
         distribution; iv_weight=1, wald_scale=1 recovers the conditional
         distribution exactly. iv_weight in [1.5, 2.5] is the expected
         useful range.
+
+        scale_lo / scale_hi enable the L1 content-adaptive scale schedule (see
+        l1_adaptive_scale). The default scale_lo == scale_hi == 1.0 keeps s
+        constant at `wald_scale` (vanilla CFG). A recommended starting point
+        for the adaptive variant is scale_lo=0.5, scale_hi=2.0.
 
         Forwards everything else (tool-use state machine, forced tokens,
         completion detection) from the upstream Engine.generate().
@@ -105,7 +149,11 @@ class ClarinetEngine(Engine):
         uncond_cache = expand_to_decode_cache(uncond_prefill)
         del cond_prefill, uncond_prefill
 
-        logits = self.combine_logits(cond_logits, uncond_logits, iv_weight, wald_scale)
+        def combine(cond, uncond):
+            s = self.l1_adaptive_scale(cond, uncond, wald_scale, scale_lo, scale_hi)
+            return self.combine_logits(cond, uncond, iv_weight, s)
+
+        logits = combine(cond_logits, uncond_logits)
 
         row_states = [RowState(tokens.copy()) for _ in range(num_samples)]
 
@@ -152,4 +200,4 @@ class ClarinetEngine(Engine):
             ids = torch.tensor(token_column, dtype=torch.long, device=device).unsqueeze(1)
             cond_logits = self.model.forward(ids, kv_cache=cond_cache)[:, -1, :]
             uncond_logits = self.model.forward(ids, kv_cache=uncond_cache)[:, -1, :]
-            logits = self.combine_logits(cond_logits, uncond_logits, iv_weight, wald_scale)
+            logits = combine(cond_logits, uncond_logits)

--- a/clarinet/prepare_proof_pile.py
+++ b/clarinet/prepare_proof_pile.py
@@ -22,16 +22,10 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from datasets import interleave_datasets, load_dataset
 
-from nanochat.common import get_base_dir
+from clarinet.dataset import proof_pile_dir
 
-REASONING_DIR_NAME = "reasoning_data"
-PROOF_PILE_DIR_NAME = "proof_pile_2"
 DOCS_PER_SHARD = 65536  # ~64 row groups of 1024 docs each, in line with climbmix shard sizes
 DOCS_PER_ROW_GROUP = 1024
-
-
-def proof_pile_dir():
-    return os.path.join(get_base_dir(), REASONING_DIR_NAME, PROOF_PILE_DIR_NAME)
 
 
 def streaming_proof_pile(subsets):

--- a/clarinet/prepare_proof_pile.py
+++ b/clarinet/prepare_proof_pile.py
@@ -1,0 +1,102 @@
+"""
+One-time download + re-shard of EleutherAI/proof-pile-2 into the same parquet
+layout that nanochat/dataset.py expects for climbmix:
+  <base_dir>/reasoning_data/proof_pile_2/shard_NNNNN.parquet
+  - single 'text' column
+  - ~docs_per_row_group docs per row group (matches climbmix layout for the
+    upstream best-fit dataloader's row-group-at-a-time read pattern)
+
+Run once before clarinet pretraining:
+
+  python -m clarinet.prepare_proof_pile --num-shards 50
+
+proof-pile-2 has three subsets: algebraic-stack, arxiv, open-web-math. We
+stream-interleave them so each shard mixes domains rather than ordering by
+subset (which would create epoch-level distribution shift).
+"""
+
+import argparse
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from datasets import interleave_datasets, load_dataset
+
+from nanochat.common import get_base_dir
+
+REASONING_DIR_NAME = "reasoning_data"
+PROOF_PILE_DIR_NAME = "proof_pile_2"
+DOCS_PER_SHARD = 65536  # ~64 row groups of 1024 docs each, in line with climbmix shard sizes
+DOCS_PER_ROW_GROUP = 1024
+
+
+def proof_pile_dir():
+    return os.path.join(get_base_dir(), REASONING_DIR_NAME, PROOF_PILE_DIR_NAME)
+
+
+def streaming_proof_pile(subsets):
+    streams = [
+        load_dataset("EleutherAI/proof-pile-2", subset, split="train", streaming=True)
+        for subset in subsets
+    ]
+    return interleave_datasets(streams, stopping_strategy="all_exhausted")
+
+
+def write_shard(out_dir, shard_idx, texts):
+    path = os.path.join(out_dir, f"shard_{shard_idx:05d}.parquet")
+    table = pa.table({"text": texts})
+    # Match the climbmix layout (compressed, multiple row groups per shard) so
+    # the upstream loader's read_row_group path behaves identically.
+    pq.write_table(
+        table,
+        path,
+        compression="zstd",
+        row_group_size=DOCS_PER_ROW_GROUP,
+    )
+    return path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download and re-shard proof-pile-2")
+    parser.add_argument("-n", "--num-shards", type=int, default=50,
+                        help="Number of train shards to write (validation shard is always written last). "
+                             "At DOCS_PER_SHARD=65536 docs/shard this gives ~3M docs per 50 shards.")
+    parser.add_argument("--subsets", nargs="+",
+                        default=["algebraic-stack", "arxiv", "open-web-math"],
+                        help="Which proof-pile-2 subsets to interleave.")
+    args = parser.parse_args()
+
+    out_dir = proof_pile_dir()
+    os.makedirs(out_dir, exist_ok=True)
+    print(f"Writing proof-pile-2 shards to: {out_dir}")
+    print(f"Subsets: {args.subsets}")
+
+    stream = streaming_proof_pile(args.subsets)
+
+    buffer = []
+    shard_idx = 0
+    total_shards = args.num_shards + 1  # +1 for validation shard, mirrors climbmix layout
+
+    for record in stream:
+        text = record.get("text")
+        if not text:
+            continue
+        buffer.append(text)
+        if len(buffer) >= DOCS_PER_SHARD:
+            path = write_shard(out_dir, shard_idx, buffer)
+            print(f"  wrote {path} ({len(buffer)} docs)")
+            buffer = []
+            shard_idx += 1
+            if shard_idx >= total_shards:
+                break
+
+    if buffer and shard_idx < total_shards:
+        path = write_shard(out_dir, shard_idx, buffer)
+        print(f"  wrote {path} ({len(buffer)} docs, final partial shard)")
+        shard_idx += 1
+
+    print(f"Done. Wrote {shard_idx} shards.")
+
+
+if __name__ == "__main__":
+    main()

--- a/clarinet/prepare_reasoning_data.py
+++ b/clarinet/prepare_reasoning_data.py
@@ -1,18 +1,23 @@
 """
-One-time download + re-shard of EleutherAI/proof-pile-2 into the same parquet
+One-time download + re-shard of HuggingFaceTB/finemath into the same parquet
 layout that nanochat/dataset.py expects for climbmix:
-  <base_dir>/reasoning_data/proof_pile_2/shard_NNNNN.parquet
+  <base_dir>/reasoning_data/finemath/shard_NNNNN.parquet
   - single 'text' column
-  - ~docs_per_row_group docs per row group (matches climbmix layout for the
+  - ~DOCS_PER_ROW_GROUP docs per row group (matches climbmix layout for the
     upstream best-fit dataloader's row-group-at-a-time read pattern)
+
+History: clarinet's original plan called for EleutherAI/proof-pile-2 as the
+reasoning instrument. As of 2026-05, proof-pile-2's data hosting on HF Hub
+has rotted (the dataset card and loader script resolve, but the actual data
+files return 404). FineMath (HuggingFaceTB/finemath, finemath-4plus subset)
+is the practical replacement: parquet-native (no zstandard or trust_remote_code
+gymnastics), actively maintained, math-focused. Narrower than proof-pile-2's
+algebraic-stack + arxiv + open-web-math mix, but still a clear "reasoning-rich"
+instrument distinct from general web text.
 
 Run once before clarinet pretraining:
 
-  python -m clarinet.prepare_proof_pile --num-shards 50
-
-proof-pile-2 has three subsets: algebraic-stack, arxiv, open-web-math. We
-stream-interleave them so each shard mixes domains rather than ordering by
-subset (which would create epoch-level distribution shift).
+  python -m clarinet.prepare_reasoning_data --num-shards 50
 """
 
 import argparse
@@ -20,20 +25,18 @@ import os
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-from datasets import interleave_datasets, load_dataset
+from datasets import load_dataset
 
-from clarinet.dataset import proof_pile_dir
+from clarinet.dataset import reasoning_data_dir
 
+DEFAULT_REPO = "HuggingFaceTB/finemath"
+DEFAULT_CONFIG = "finemath-4plus"
 DOCS_PER_SHARD = 65536  # ~64 row groups of 1024 docs each, in line with climbmix shard sizes
 DOCS_PER_ROW_GROUP = 1024
 
 
-def streaming_proof_pile(subsets):
-    streams = [
-        load_dataset("EleutherAI/proof-pile-2", subset, split="train", streaming=True)
-        for subset in subsets
-    ]
-    return interleave_datasets(streams, stopping_strategy="all_exhausted")
+def streaming_corpus(repo, config):
+    return load_dataset(repo, config, split="train", streaming=True)
 
 
 def write_shard(out_dir, shard_idx, texts):
@@ -51,21 +54,21 @@ def write_shard(out_dir, shard_idx, texts):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Download and re-shard proof-pile-2")
+    parser = argparse.ArgumentParser(description="Download and re-shard the reasoning corpus")
     parser.add_argument("-n", "--num-shards", type=int, default=50,
                         help="Number of train shards to write (validation shard is always written last). "
                              "At DOCS_PER_SHARD=65536 docs/shard this gives ~3M docs per 50 shards.")
-    parser.add_argument("--subsets", nargs="+",
-                        default=["algebraic-stack", "arxiv", "open-web-math"],
-                        help="Which proof-pile-2 subsets to interleave.")
+    parser.add_argument("--repo", default=DEFAULT_REPO,
+                        help="HF dataset repo ID. Default: HuggingFaceTB/finemath")
+    parser.add_argument("--config", default=DEFAULT_CONFIG,
+                        help="HF dataset config / subset. Default: finemath-4plus")
     args = parser.parse_args()
 
-    out_dir = proof_pile_dir()
+    out_dir = reasoning_data_dir()
     os.makedirs(out_dir, exist_ok=True)
-    print(f"Writing proof-pile-2 shards to: {out_dir}")
-    print(f"Subsets: {args.subsets}")
+    print(f"Writing {args.repo}/{args.config} shards to: {out_dir}")
 
-    stream = streaming_proof_pile(args.subsets)
+    stream = streaming_corpus(args.repo, args.config)
 
     buffer = []
     shard_idx = 0

--- a/docs/iv_conditioning.md
+++ b/docs/iv_conditioning.md
@@ -357,3 +357,178 @@ also that generation behavior depends only on the **product `w·s`**, so `w` and
 The dataloader installs a conditioning channel; the engine exploits it; the L1
 schedule is an opt-in, still-to-be-validated refinement of *how hard* to lean on
 that channel at each step.
+
+---
+
+## 8. Running the complete setup, step by step
+
+This section is operational: how to actually train a Clarinet model and talk to
+it. Section 7 is the *what*; this is the *how*.
+
+### 8.1 Prerequisites and hardware
+
+- **Dependency manager:** [uv](https://docs.astral.sh/uv/). Install with
+  `curl -LsSf https://astral.sh/uv/install.sh | sh` if you don't have it.
+- **Hardware, three tiers:**
+  - **8×H100** — the reference. The full speedrun is ~3.5 h. `--fp8` is used and
+    is **Hopper-only** (H100, not A100).
+  - **1×H100 (or any single GPU)** — works unchanged; the trainer auto-switches
+    to gradient accumulation (`base_train.py:407-410`), producing the *same*
+    model in ~8× the wall-clock. Drop `--fp8` on non-Hopper cards.
+  - **CPU / MPS** — only for exercising code paths on a tiny model; see
+    `runs/runcpu.sh`. You will not get useful results.
+- **Scratch space:** set a base directory for data and checkpoints. The scripts
+  use `CLARINET_BASE_DIR` (defaults to `~/.cache/nanochat`):
+  ```bash
+  export CLARINET_BASE_DIR="$HOME/.cache/nanochat"
+  ```
+
+### 8.2 The fast path: one script
+
+Everything below is wired into two reference scripts. Pick the one matching your
+hardware and run it:
+
+```bash
+bash runs/clarinet_speedrun.sh      # 8×H100 (fp8, large batch), ~3.5 h
+bash runs/clarinet_local_run.sh     # single GPU (smaller batch, --save-every for resume)
+```
+
+Optionally name the run for Weights & Biases: `WANDB_RUN=clarinet-v1 bash runs/clarinet_speedrun.sh`
+(omit and it logs to a dummy run). Run inside `screen`/`tmux` for long jobs.
+
+The rest of this section breaks that script into its stages so you can run them
+one at a time, understand each, or restart partway through.
+
+### 8.3 Step 0 — environment and dependencies
+
+```bash
+[ -d ".venv" ] || uv venv
+uv sync --extra gpu        # CUDA 12.8 (H100); use --extra cpu for CPU/MPS
+source .venv/bin/activate
+```
+
+**Network caveat (important on locked-down nodes).** `uv sync` pulls torch from
+the PyTorch CDN (`download.pytorch.org`). If that host is blocked by your
+environment's network policy (e.g. Claude Code on the web returns HTTP 403),
+`uv sync` fails. Fall back to PyPI, whose `torch==2.9.1` linux wheel is itself
+the `+cu128` build (CUDA 12.8 + NCCL — identical on H100):
+
+```bash
+uv pip install -e .                 # runtime deps
+uv pip install -e . --group dev     # + pytest etc. for running the test suite
+```
+
+`runs/clarinet_speedrun.sh` already does this fallback automatically, and the
+`.claude/hooks/session-start.sh` SessionStart hook performs the PyPI install for
+you in web sessions.
+
+### 8.4 Step 1 — datasets (two corpora)
+
+Download the general corpus (climbmix) and build the reasoning corpus (FineMath)
+in parallel. The first small download feeds tokenizer training; the larger ones
+run in the background:
+
+```bash
+python -m nanochat.report reset                 # start a fresh run report
+
+python -m nanochat.dataset -n 8                  # 8 climbmix shards (for the tokenizer)
+python -m nanochat.dataset -n 170 &              # full climbmix (~GPT-2 capacity)
+python -m clarinet.prepare_reasoning_data -n 50 &  # ~50 FineMath shards
+```
+
+For a quick smoke test use far fewer shards (e.g. `-n 8` for both). Wait for the
+background jobs (`wait`) before training.
+
+### 8.5 Step 2 — tokenizer (must be retrained)
+
+Clarinet adds three special tokens (`<|src_reasoning|>`, `<|src_general|>`,
+`<|src_unknown|>`) to `SPECIAL_TOKENS`, so **any pre-existing tokenizer is
+incompatible** — retrain it. It is trained on general-source data only, so the
+vocabulary isn't skewed toward math/proof notation:
+
+```bash
+python -m scripts.tok_train
+python -m scripts.tok_eval
+```
+
+### 8.6 Step 3 — IV-conditioned pretraining
+
+This is where the source-marker conditioning is installed (sections 2–4). The
+two Clarinet-specific knobs are `--reasoning-mix-ratio` (fraction of reasoning
+shards, default 0.3) and `--p-uncond` (CFG dropout, default 0.1); everything
+else forwards to `base_train.py`.
+
+**8×H100:**
+```bash
+torchrun --standalone --nproc_per_node=8 -m scripts.clarinet_train -- \
+    --reasoning-mix-ratio=0.3 --p-uncond=0.1 \
+    --depth=24 --target-param-data-ratio=8 --device-batch-size=16 --fp8 --run=$WANDB_RUN
+```
+
+**Single GPU** (no `torchrun`, no `--` separator; smaller per-device batch, drop
+`--fp8` off Hopper). Gradient accumulation makes up the same total batch:
+```bash
+python -m scripts.clarinet_train \
+    --reasoning-mix-ratio=0.3 --p-uncond=0.1 \
+    --depth=24 --target-param-data-ratio=8 \
+    --device-batch-size=2 --save-every=500 --run=$WANDB_RUN
+```
+
+If you hit out-of-memory, lower `--device-batch-size` (16 → 8 → 4 → 2 → 1);
+correctness is unchanged, only the accumulation step count grows.
+
+Then evaluate the base model (plain single-pass eval, no IV combine yet):
+```bash
+torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-size=16
+```
+
+### 8.7 Step 4 — supervised finetuning (SFT)
+
+```bash
+curl -L -o "$CLARINET_BASE_DIR/identity_conversations.jsonl" \
+    https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
+
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --device-batch-size=16 --run=$WANDB_RUN
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft   # reference, single-pass
+```
+
+### 8.8 Step 5 — the IV experiment: guidance-weight sweep
+
+This is the actual Clarinet measurement — accuracy as a function of the guidance
+weight `w`. It is **single-GPU by design** (the dual-pass engine keeps two KV
+caches and we want clean per-task numbers), so run it on one device even if you
+trained on eight:
+
+```bash
+python -m scripts.iv_eval -i sft \
+    -a GSM8K,ARC-Easy,ARC-Challenge,MMLU,HumanEval,SpellingBee \
+    --weights 0,0.5,1.0,1.5,2.0,3.0,5.0
+```
+
+`w=0` is the unconditional baseline; `w=1` is plain conditional; `w>1` is the
+guided regime. To also probe the L1 adaptive schedule, pass `--wald-scale` (and,
+once exposed there, the `scale_lo`/`scale_hi` knobs) — remembering that only the
+product `w·s` matters, so sweep one with the other fixed.
+
+### 8.9 Step 6 — talk to it, and finish the report
+
+```bash
+python -m scripts.clarinet_cli --iv-weight 2.0 -p "Prove that sqrt(2) is irrational."
+# enable the L1 adaptive scale:
+python -m scripts.clarinet_cli --iv-weight 2.0 --scale-lo 0.5 --scale-hi 2.0
+
+python -m nanochat.report generate     # assemble the run report
+```
+
+### 8.10 Resuming, and running the tests
+
+- **Resume:** the trainer checkpoints every `--save-every` steps and the
+  Clarinet dataloader persists `{pq_idx, rg_idx, epoch}`, so re-running the same
+  script after an interruption (or spot preemption) auto-resumes from the latest
+  checkpoint. This is why the single-GPU script sets `--save-every=500`.
+- **Tests** (needs the `dev` group installed, step 0):
+  ```bash
+  python -m pytest tests/test_clarinet_engine.py tests/test_clarinet_dataloader.py -q
+  ```
+  These are hermetic (mock model + byte tokenizer) and run in seconds on CPU —
+  no GPU or trained checkpoint required.

--- a/docs/iv_conditioning.md
+++ b/docs/iv_conditioning.md
@@ -1,0 +1,359 @@
+# Clarinet: source-conditioned generation, end to end
+
+This note explains how Clarinet conditions an autoregressive language model on
+the *source* of a document, how that conditioning is installed during training,
+and how it is exploited at inference — including the L1 content-adaptive
+guidance schedule. It is written to be read top to bottom: each layer builds on
+the one before it.
+
+Clarinet is a research fork of nanochat. Everything below concerns the files in
+`clarinet/` (`dataset.py`, `dataloader.py`, `engine.py`) plus the special-token
+registration in `nanochat/tokenizer.py` and the loss path in `nanochat/gpt.py`.
+The technique is a classifier-free-guidance (CFG) adaptation of autoregressive
+text generation, dressed in instrumental-variable (IV) vocabulary; we keep the
+IV names because the code uses them, but the honest description is "CFG with a
+source marker."
+
+---
+
+## 1. The core idea
+
+A plain language model learns one next-token distribution `p(x_t | x_<t)`. We
+would like to *steer* generation toward a particular kind of text — here,
+"reasoning"-style (math, step-by-step) continuations versus generic web text —
+without training a separate model or a reward model.
+
+The mechanism is a single extra token, the **source marker**, placed at the
+start of every document. During training the model sees the marker that
+describes where the document came from, so it learns a *conditional*
+distribution `p(x_t | x_<t, marker)`. At inference we run the model twice —
+once with the "reasoning" marker, once with a neutral "unknown" marker — and
+push the output distribution in the direction the marker induces. That push is
+the whole game; sections 5–6 make it precise.
+
+The reason a *single* model can produce both the conditional and the neutral
+distribution is a training-time dropout trick (section 4). The reason we are
+allowed to set the marker ourselves at inference rather than sampling it is a
+target-masking trick (section 4). Both are small, and both are load-bearing.
+
+---
+
+## 2. The special tokens
+
+Three markers are registered as special tokens in
+`nanochat/tokenizer.py` (`SPECIAL_TOKENS`, lines 28–30):
+
+```
+<|src_reasoning|>   # document came from the reasoning corpus
+<|src_general|>     # document came from the general corpus
+<|src_unknown|>     # source deliberately hidden (the "neutral" marker)
+```
+
+They get fixed integer ids at the top of the vocabulary, alongside the existing
+chat/tool specials (`<|bos|>`, `<|assistant_end|>`, `<|python_start|>`, …). The
+tokenizer exposes `encode_special(name) -> id` and `get_bos_token_id()`, which
+both the dataloader and the engine use to look these ids up by name rather than
+hard-coding integers.
+
+`<|bos|>` (beginning-of-sequence) is not new, but it is central: it marks the
+start of every document and doubles as the document separator inside a packed
+training row. Every document, in training and inference, has the layout
+
+```
+[ <|bos|> , <marker> , ...document tokens... ]
+   pos 0      pos 1        pos 2 onward
+```
+
+The marker always sits at **position 1**, immediately after BOS.
+
+---
+
+## 3. Datasets: two corpora with a source flag
+
+`clarinet/dataset.py` combines two parquet-backed corpora:
+
+- **climbmix** — the general corpus inherited from upstream nanochat
+  (`nanochat.dataset.list_parquet_files`).
+- **reasoning** — math/reasoning shards written by
+  `clarinet/prepare_reasoning_data.py`. This is currently FineMath
+  (`HuggingFaceTB/finemath`, `finemath-4plus`); the original plan named
+  `proof-pile-2`, but its HF hosting 404s as of 2026-05, and FineMath is the
+  closest parquet-native, actively-maintained replacement.
+
+The public entry point is:
+
+```python
+list_parquet_files_with_source(split)  ->  [(path, is_reasoning), ...]
+```
+
+It returns every shard for the requested split, each tagged with a boolean
+`is_reasoning`. The train/val convention matches upstream exactly: within each
+source directory the **last shard is validation**, all earlier shards are
+training. So `split="train"` drops the last shard of each corpus and returns the
+rest; `split="val"` keeps only the last shard of each. The function asserts that
+reasoning shards exist, with a message pointing at
+`python -m clarinet.prepare_reasoning_data`, because a silent empty reasoning
+set would quietly collapse Clarinet back into plain nanochat.
+
+Note what this function does *not* do: it does not interleave or order the two
+sources. It just labels them. Ordering is the dataloader's job, because ordering
+has to be consistent across distributed-training ranks.
+
+---
+
+## 4. The dataloader: where conditioning is installed
+
+`clarinet/dataloader.py` is a modified copy of upstream's BOS-aligned best-fit
+loader. It does five things on top of the original; the first three are what
+make conditioning work.
+
+### 4.1 Deterministic interleaving of the two sources
+
+`_interleave_sources(paths_with_source, reasoning_mix_ratio)` merges the climbmix
+and reasoning shard lists into one ordered list that hits the target mix ratio
+(default `0.3`) as evenly as possible. The schedule is purely arithmetic — at
+step `k` the desired cumulative count of reasoning files is `round(k * ratio)`,
+and a reasoning file is emitted whenever that target ticks up:
+
+```python
+want_reasoning = round(step * reasoning_mix_ratio)
+if want_reasoning > emitted_reasoning and reasoning_left:
+    emit reasoning file
+else:
+    emit climbmix file
+```
+
+This spreads the reasoning shards evenly (no clumping) and, crucially, uses **no
+RNG**. Every distributed rank computes the identical ordering from the identical
+shard list, so the per-rank row-group sharding downstream is well-defined
+without a shared seed.
+
+### 4.2 BOS prepend, marker splice, and unconditional dropout
+
+`_document_batches` walks the interleaved shard list, reads parquet row groups,
+and yields batches of raw document strings tagged with their `is_reasoning`
+flag. `refill_buffer` (inside `clarinet_data_loader`) then tokenizes each batch
+with a BOS prepended:
+
+```python
+token_lists = tokenizer.encode(doc_batch, prepend=bos_token, ...)
+```
+
+so every document already starts `[BOS, ...]`. The marker is spliced in right
+after BOS:
+
+```python
+true_marker = src_reasoning_id if is_reasoning else src_general_id
+for tokens in token_lists:
+    marker = src_unknown_id if rng.random() < p_uncond else true_marker
+    tokens.insert(1, marker)            # -> [BOS, marker, ...doc tokens]
+    doc_buffer.append(tokens)
+```
+
+The `p_uncond` line (default `0.1`) is the **classifier-free-guidance
+unconditional dropout**: 10% of documents have their true marker replaced by
+`<|src_unknown|>`. This is what teaches the *one* set of weights to model the
+neutral distribution `p(x | unknown)` in addition to the source-conditional
+distributions. Without it, `<|src_unknown|>` would be an out-of-distribution
+token at inference and the unconditional pass (section 5) would be meaningless.
+
+The dropout RNG is seeded per rank (`seed + ddp_rank`), so ranks make
+independent dropout choices — fine, since each rank owns disjoint row groups.
+
+### 4.3 Best-fit packing and target masking
+
+Documents are packed into rows of width `T + 1` using a best-fit heuristic: for
+each position, take the longest buffered document that still fits; if none fits,
+truncate the shortest to fill the remainder. This is upstream's packing,
+unchanged, and it is why a single row contains several documents each starting
+with its own BOS.
+
+After packing, inputs and targets are the usual shifted pair, plus one new line:
+
+```python
+cpu_inputs.copy_(row_buffer[:, :-1])    # tokens 0 .. T-1
+cpu_targets.copy_(row_buffer[:, 1:])    # tokens 1 .. T
+cpu_targets[cpu_inputs == bos_token] = -1
+```
+
+That last line is the **marker target mask**. The token that follows a BOS is
+always the source marker; setting those target positions to `-1` means the model
+is *never trained to predict the marker*. Combined with
+`F.cross_entropy(..., ignore_index=-1)` in `nanochat/gpt.py:477`, the marker
+contributes zero loss as an output. It is purely an input that conditions the
+distribution — which is exactly why, at inference, we are free to set it
+ourselves rather than letting the model emit it.
+
+### 4.4 The plumbing that did not change
+
+Everything else mirrors upstream: DDP sharding at the row-group level
+(`rg_idx += ddp_world_size`), a pinned CPU staging buffer, a single
+host-to-device copy per batch, and a resumable `state_dict` of
+`{pq_idx, rg_idx, epoch}`. `pq_idx` now indexes the *interleaved* shard list, so
+resume points stay valid across the combined corpus.
+
+### 4.5 What training therefore learns
+
+`scripts/clarinet_train.py` drives this loader with `p_uncond` from its CLI for
+the train split and `p_uncond=0.0` for the validation split (we always evaluate
+with the true marker). The net effect: a model whose next-token logits are a
+function of the marker placed at position 1 — call them `ℓ(x | context, marker)`
+— and which has seen enough `<|src_unknown|>` examples to give a sensible neutral
+distribution `ℓ(x | context, unknown)`.
+
+---
+
+## 5. The inference engine: dual-pass guidance
+
+`clarinet/engine.py` defines `ClarinetEngine(Engine)`. The upstream engine runs
+the model once per decode step; Clarinet runs it **twice**, once per
+conditioning, and combines the two logit vectors.
+
+### 5.1 Building the two prompts
+
+`_prefix_with_marker` reproduces the training layout for the prompt, once with
+the reasoning marker (the *conditional* prompt) and once with the unknown marker
+(the *unconditional* prompt):
+
+```
+cond   = [BOS, <|src_reasoning|>, ...prompt]
+uncond = [BOS, <|src_unknown|>,  ...prompt]
+```
+
+They differ only at position 1, so they are guaranteed equal length — the decode
+loop relies on this, and `generate` asserts it. (If a prompt does not already
+begin with BOS, the helper prepends one; chat rendering always does.)
+
+### 5.2 Two KV caches in lock-step
+
+Each prompt gets its own prefill and its own `KVCache`. After prefill, both
+caches are expanded to the decode width and advanced together: every step, the
+*same* chosen token is appended to both caches. The two passes therefore share
+an identical suffix and differ only by the single marker token baked into their
+respective prefixes. This doubles compute and KV memory — the real cost of the
+method — but keeps the two distributions exactly comparable at every step.
+
+### 5.3 Combining the logits
+
+The combine is a static method (extracted for unit-testing):
+
+```python
+combine_logits(cond, uncond, w, s) = uncond + w * s * (cond - uncond)
+```
+
+with `w = iv_weight` and `s` the scale factor. The vector `(cond - uncond)` is
+*the direction in logit space that the reasoning marker induces*; we walk `w·s`
+steps along it starting from the unconditional logits:
+
+- `w = 0` → unconditional distribution.
+- `w = 1, s = 1` → conditional distribution exactly.
+- `w > 1` (useful range ~1.5–2.5) → **extrapolation beyond** the conditional —
+  push harder toward reasoning-mode tokens than the conditional model alone.
+
+Because softmax normalizes away additive constants, this is multiplicative in
+probability space:
+
+```
+p_iv(x)  ∝  p_uncond(x)^(1 - ws) · p_cond(x)^(ws)
+```
+
+a product-of-experts / geometric extrapolation: tokens the marker makes
+*relatively* more likely are boosted super-linearly, tokens it makes less likely
+are suppressed, and tokens it is neutral about (`p_cond ≈ p_uncond`) are
+untouched. One important subtlety: this all happens on the **softcapped** logits
+(`15·tanh(raw/15)`, `nanochat/gpt.py:472`), the same space the model emits — not
+on raw pre-softcap logits.
+
+Sampling, temperature/top-k, the calculator tool-use state machine, forced
+tokens, and completion detection are all inherited unchanged from upstream and
+run on the *combined* logits.
+
+---
+
+## 6. The L1 content-adaptive scale
+
+Until recently `s` was a constant (`wald_scale`, default `1.0` ≡ vanilla CFG).
+The new feature makes `s` optionally **vary per decode step** based on how much
+the marker actually changes the prediction at that step.
+
+### 6.1 The signal and the schedule
+
+At each step we already hold the two distributions. Their **L1 / total-variation
+distance** is a single scalar summary of how far apart they are:
+
+```
+d = 0.5 * Σ_v | softmax(cond)_v - softmax(uncond)_v |        # d in [0, 1]
+```
+
+`d ≈ 0` means the marker barely matters here (context already pins the next
+token); `d ≈ 1` means the reasoning and neutral continuations sharply disagree.
+The scale is a linear interpolation keyed on `d`:
+
+```python
+s = base_scale * (scale_lo + (scale_hi - scale_lo) * d)
+```
+
+implemented in `l1_adaptive_scale` (a static method, per-row, returning shape
+`(rows, 1)` so it broadcasts over the vocab axis in `combine_logits`). The
+intent is to *spend guidance budget where the marker is decisive and back off
+where it is irrelevant.*
+
+### 6.2 Properties and the backward-compatible default
+
+- **Floor / ceiling.** At `d = 0`, `s = base·scale_lo`; at `d = 1`,
+  `s = base·scale_hi`. The schedule is monotone in `d` and bounded to
+  `[base·scale_lo, base·scale_hi]`.
+- **Exact CFG default.** `scale_lo == scale_hi` short-circuits to the constant
+  `base·scale_lo` *without even computing the softmax*. The shipped default
+  `scale_lo = scale_hi = 1.0` therefore reproduces vanilla CFG bit-for-bit, so
+  the feature is inert until explicitly enabled.
+- **Recommended opt-in.** `scale_lo = 0.5, scale_hi = 2.0` is the suggested
+  starting point.
+
+The CLI exposes this in `scripts/clarinet_cli.py`:
+
+```bash
+# vanilla CFG (default)
+python -m scripts.clarinet_cli --iv-weight 2.0 --wald-scale 1.0
+# adaptive
+python -m scripts.clarinet_cli --iv-weight 2.0 --scale-lo 0.5 --scale-hi 2.0
+```
+
+### 6.3 What this is, and what it is not
+
+This is an **adaptive-CFG schedule**, not a causal estimator. An earlier design
+tried to derive `s` as a Wald/IV ratio from pre-`lm_head` hidden states; review
+found that incoherent (it divided a vocab-length logit vector by a scalar
+"first-stage," pointed the modulation the wrong way, and relied on an exclusion
+restriction the transformer does not satisfy). The L1 version keeps only the
+defensible core: a cheap, output-space measure of how much the marker moves the
+prediction, computed from logits we already have — no probe, no hidden-state
+plumbing, no third forward pass.
+
+Crucially, the *direction* of the modulation ("more guidance where `d` is high")
+is a **hypothesis**, not a theorem. It must be validated against held-out
+reasoning likelihood or a downstream metric like GSM8K, with constant `s` as the
+control it has to beat — which is exactly why the default is the control. Note
+also that generation behavior depends only on the **product `w·s`**, so `w` and
+`s` are not separately identifiable from samples alone; tune them as a pair.
+
+---
+
+## 7. End to end, in one breath
+
+1. **Prepare data.** `prepare_reasoning_data.py` writes FineMath shards;
+   `dataset.list_parquet_files_with_source` labels every shard reasoning/general.
+2. **Train.** The dataloader interleaves the two corpora deterministically,
+   prepends `[BOS, marker]` to each document (dropping the marker to
+   `<|src_unknown|>` 10% of the time), best-fit-packs them into rows, and masks
+   the marker-prediction targets to `-1`. The model learns
+   `p(x | context, marker)` and a neutral `p(x | context, unknown)`.
+3. **Generate.** `ClarinetEngine` runs two lock-step passes (reasoning marker
+   vs. unknown marker), combines their logits as
+   `uncond + w·s·(cond − uncond)`, optionally lets `s` adapt per step via the L1
+   distance between the two distributions, and samples from the result —
+   feeding the chosen token back into both KV caches.
+
+The dataloader installs a conditioning channel; the engine exploits it; the L1
+schedule is an opt-in, still-to-be-validated refinement of *how hard* to lean on
+that channel at each step.

--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -68,15 +68,17 @@ setup_default_logging()
 logger = logging.getLogger(__name__)
 
 def get_base_dir():
-    # co-locate nanochat intermediates with other cached data in ~/.cache (by default)
-    if os.environ.get("NANOCHAT_BASE_DIR"):
-        nanochat_dir = os.environ.get("NANOCHAT_BASE_DIR")
-    else:
+    # co-locate nanochat intermediates with other cached data in ~/.cache (by default).
+    # CLARINET_BASE_DIR is accepted as an alias so clarinet users don't have to set the
+    # nanochat-prefixed variable; NANOCHAT_BASE_DIR still wins if both are set, to keep
+    # any existing nanochat workflows on this machine unchanged.
+    base_dir = os.environ.get("NANOCHAT_BASE_DIR") or os.environ.get("CLARINET_BASE_DIR")
+    if not base_dir:
         home_dir = os.path.expanduser("~")
         cache_dir = os.path.join(home_dir, ".cache")
-        nanochat_dir = os.path.join(cache_dir, "nanochat")
-    os.makedirs(nanochat_dir, exist_ok=True)
-    return nanochat_dir
+        base_dir = os.path.join(cache_dir, "nanochat")
+    os.makedirs(base_dir, exist_ok=True)
+    return base_dir
 
 def download_file_with_lock(url, filename, postprocess_fn=None):
     """

--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -279,6 +279,32 @@ class Engine:
             ids = torch.tensor(token_column, dtype=torch.long, device=device).unsqueeze(1)
             logits = self.model.forward(ids, kv_cache=kv_cache_decode)[:, -1, :]  # (B, vocab_size)
 
+    @torch.inference_mode()
+    def categorical_logits_at(self, token_lists, answer_positions):
+        """
+        Compute logits at the answer positions for a batch of prompts.
+
+        Used by categorical evaluation (multiple-choice tasks like ARC, MMLU).
+        Subclasses can override to apply guidance (e.g. dual-pass IV combine).
+
+        Args:
+            token_lists: list of list of int — unpadded token sequences
+            answer_positions: list of int — position of the answer token in each
+                sequence (indexing into the *original* sequences before any
+                marker insertion)
+        Returns:
+            (B, V) tensor of logits at the answer positions
+        """
+        device = self.model.get_device()
+        bos = self.tokenizer.get_bos_token_id()
+        max_length = max(len(ids) for ids in token_lists)
+        padded = [ids + [bos] * (max_length - len(ids)) for ids in token_lists]
+        prompt_ids = torch.tensor(padded, dtype=torch.long, device=device)
+        logits = self.model(prompt_ids)  # (B, T, V)
+        B = logits.size(0)
+        positions = torch.tensor(answer_positions, device=device)
+        return logits[torch.arange(B, device=device), positions]  # (B, V)
+
     def generate_batch(self, tokens, num_samples=1, **kwargs):
         """
         Non-streaming batch generation that just returns the final token sequences.

--- a/nanochat/tokenizer.py
+++ b/nanochat/tokenizer.py
@@ -22,6 +22,12 @@ SPECIAL_TOKENS = [
     "<|python_end|>",
     "<|output_start|>", # python REPL outputs back to assistant
     "<|output_end|>",
+    # clarinet: source markers used as the IV instrument. one is prepended right after
+    # <|bos|> at the start of each document, identifying which corpus the document came
+    # from (or <|src_unknown|> when dropped out during training, à la classifier-free guidance).
+    "<|src_reasoning|>",
+    "<|src_general|>",
+    "<|src_unknown|>",
 ]
 
 # NOTE: this split pattern deviates from GPT-4 in that we use \p{N}{1,2} instead of \p{N}{1,3}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[build-system]
+# Without an explicit build-system, pip falls back to setuptools and tries
+# auto-discovery, which fails because the repo has multiple top-level dirs
+# (`nanochat`, `clarinet`, `runs`, `dev`, `tests`, ...). uv users don't hit
+# this because uv handles editable installs without invoking the build
+# backend. With this section, `pip install -e .` uses hatchling, which honors
+# the explicit packages list in [tool.hatch.build.targets.wheel] below.
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "clarinet"
 version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "nanochat"
+name = "clarinet"
 version = "0.1.0"
-description = "the minimal full-stack ChatGPT clone"
+description = "Instrumental-variable conditioned LLM, research fork of nanochat by Vemund Rundberget"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -69,3 +69,8 @@ conflicts = [
         { extra = "gpu" },
     ],
 ]
+
+# Explicit package list: project name no longer matches a single top-level dir,
+# so we tell the build backend which directories to ship.
+[tool.hatch.build.targets.wheel]
+packages = ["nanochat", "clarinet"]

--- a/runs/clarinet_local_run.sh
+++ b/runs/clarinet_local_run.sh
@@ -38,9 +38,12 @@ mkdir -p "$CLARINET_BASE_DIR"
 command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
 [ -d ".venv" ] || uv venv
 uv sync --extra cpu --group dev      # bootstraps everything except torch
-# Swap in the ROCm torch build (overrides the cpu wheel from uv sync):
+# Swap in the ROCm torch build (overrides the cpu wheel from uv sync).
+# torch 2.9.1's ROCm wheels are only published at rocm6.3 and rocm6.4;
+# matching the system ROCm runtime version is best (we assume 6.4 since
+# that's what AMD's current WSL installer ships).
 .venv/bin/pip install --quiet --force-reinstall torch==2.9.1 \
-    --index-url https://download.pytorch.org/whl/rocm6.2
+    --index-url https://download.pytorch.org/whl/rocm6.4
 source .venv/bin/activate
 
 # Sanity: GPU must be visible

--- a/runs/clarinet_local_run.sh
+++ b/runs/clarinet_local_run.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# clarinet local run for single-GPU setups (e.g. AMD RX 7900 XT in WSL2 with ROCm).
+#
+# Differences from runs/clarinet_speedrun.sh (which targets 8xH100 + Hopper-specific features):
+#   - no torchrun / single GPU
+#   - no --fp8 (Hopper-only)
+#   - much smaller --device-batch-size (gradient accumulation makes up the effective batch)
+#   - bfloat16 dtype explicitly set
+#   - --save-every=500 so the run is resumable if power flickers
+#   - trimmed IV sweep (4 weights, 3 tasks) to fit a ~14-day local budget
+#
+# Expected wall-clock at d24 on a single RX 7900 XT (~70 TFLOPs achieved bf16, no FA3):
+#   pretraining: ~12-15 days, SFT: ~4-6 hrs, chat_eval: ~6-12 hrs, IV sweep: ~12-24 hrs
+#   total: ~13-17 days
+#
+# Launch unattended so it survives terminal close and WSL idle:
+#   mkdir -p ~/clarinet/logs
+#   screen -L -Logfile ~/clarinet/logs/run.log -dmS clarinet \
+#       bash -c "nohup bash runs/clarinet_local_run.sh > ~/clarinet/logs/run.full.log 2>&1"
+#   screen -ls    # verify 'clarinet' detached
+#
+# Resume after a crash (checkpoint dir name printed at run start):
+#   bash runs/clarinet_local_run.sh    # the train scripts auto-resume from latest
+
+set -e
+
+export OMP_NUM_THREADS=4
+export CLARINET_BASE_DIR="${CLARINET_BASE_DIR:-$HOME/.cache/nanochat}"
+export NANOCHAT_DTYPE=bfloat16
+# AMD RDNA3 arch hint for PyTorch ROCm:
+export HSA_OVERRIDE_GFX_VERSION="${HSA_OVERRIDE_GFX_VERSION:-11.0.0}"
+
+mkdir -p "$CLARINET_BASE_DIR"
+
+# -----------------------------------------------------------------------------
+# Venv
+
+command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+[ -d ".venv" ] || uv venv
+uv sync --extra cpu --group dev      # bootstraps everything except torch
+# Swap in the ROCm torch build (overrides the cpu wheel from uv sync):
+.venv/bin/pip install --quiet --force-reinstall torch==2.9.1 \
+    --index-url https://download.pytorch.org/whl/rocm6.2
+source .venv/bin/activate
+
+# Sanity: GPU must be visible
+python -c "import torch; assert torch.cuda.is_available(), 'CUDA/ROCm device not visible'; print('Device:', torch.cuda.get_device_name(0))"
+
+# -----------------------------------------------------------------------------
+# wandb (optional, default off — set WANDB_RUN to enable)
+
+if [ -z "$WANDB_RUN" ]; then
+    WANDB_RUN=dummy
+fi
+
+# -----------------------------------------------------------------------------
+# Report header
+
+python -m nanochat.report reset
+
+# -----------------------------------------------------------------------------
+# Data: climbmix (general) + FineMath (reasoning instrument)
+
+# Climbmix: 170 shards covers d24 at ratio=8 with safe margin.
+python -m nanochat.dataset -n 8           # 8 shards minimum for tokenizer step
+python -m nanochat.dataset -n 170 &
+DATASET_DOWNLOAD_PID=$!
+
+# FineMath: 50 shards covers the 30% reasoning slice at d24.
+python -m clarinet.prepare_reasoning_data -n 50 &
+REASONING_PID=$!
+
+# Tokenizer (re)train. Required because clarinet added 3 special tokens, so any
+# pre-existing tokenizer artifact would have wrong vocab indices.
+python -m scripts.tok_train
+python -m scripts.tok_eval
+
+echo "Waiting for climbmix download to complete..."
+wait $DATASET_DOWNLOAD_PID
+echo "Waiting for FineMath prep to complete..."
+wait $REASONING_PID
+
+# -----------------------------------------------------------------------------
+# Pretraining — the long stage (~12-15 days at d24 on a 7900 XT)
+# device-batch-size=2 is the conservative starting point for 20 GB VRAM.
+# Bump to 4 if you've confirmed it fits in a smoke test; total-batch-size
+# stays the same (just fewer gradient-accumulation microsteps).
+
+python -m scripts.clarinet_train \
+    --reasoning-mix-ratio=0.3 --p-uncond=0.1 \
+    --depth=24 --target-param-data-ratio=8 \
+    --device-batch-size=2 \
+    --total-batch-size=524288 \
+    --save-every=500 \
+    --run=$WANDB_RUN
+
+# Base model eval (~30 min on single GPU)
+python -m scripts.base_eval --device-batch-size=2
+
+# -----------------------------------------------------------------------------
+# SFT (~4-6 hrs)
+
+curl -L -o "$CLARINET_BASE_DIR/identity_conversations.jsonl" \
+    https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
+
+python -m scripts.chat_sft --device-batch-size=2 --run=$WANDB_RUN
+
+# Vanilla chat eval for reference accuracy without IV combination
+python -m scripts.chat_eval -i sft
+
+# -----------------------------------------------------------------------------
+# IV guidance weight sweep — the actual clarinet experiment.
+# Trimmed for local time budget: 4 weights (anchors + likely-optimal range),
+# 3 tasks (one reasoning-heavy, one categorical, one style/breadth).
+# Re-run the full sweep on a rented box later for the publication-grade numbers.
+
+python -m scripts.iv_eval -i sft \
+    -a GSM8K,ARC-Easy,MMLU \
+    --weights 0,1.0,1.5,2.0,3.0
+
+# -----------------------------------------------------------------------------
+# Bonus: chat with a chosen weight after the run finishes
+#   python -m scripts.clarinet_cli --iv-weight=2.0 -p "Prove sqrt(2) is irrational."
+
+python -m nanochat.report generate
+echo "Done. Report at: $CLARINET_BASE_DIR/report/report.md"

--- a/runs/clarinet_local_run.sh
+++ b/runs/clarinet_local_run.sh
@@ -42,7 +42,8 @@ uv sync --extra cpu --group dev      # bootstraps everything except torch
 # torch 2.9.1's ROCm wheels are only published at rocm6.3 and rocm6.4;
 # matching the system ROCm runtime version is best (we assume 6.4 since
 # that's what AMD's current WSL installer ships).
-.venv/bin/pip install --quiet --force-reinstall torch==2.9.1 \
+# Use `uv pip` (not `.venv/bin/pip`) because uv-created venvs don't ship pip.
+uv pip install --quiet --force-reinstall torch==2.9.1 \
     --index-url https://download.pytorch.org/whl/rocm6.4
 source .venv/bin/activate
 

--- a/runs/clarinet_speedrun.sh
+++ b/runs/clarinet_speedrun.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Clarinet end-to-end pipeline: tokenizer + IV-conditioned pretraining + SFT + IV sweep eval.
+# Designed to run on an 8xH100 node. Approximate budget: ~3.5 hours (vs ~3 for vanilla
+# nanochat speedrun) — the extra is dual-source data and the IV weight sweep at the end.
+#
+# Example:
+#   bash runs/clarinet_speedrun.sh
+#   screen -L -Logfile runs/clarinet_speedrun.log -S clarinet bash runs/clarinet_speedrun.sh
+#   WANDB_RUN=clarinet-v1 bash runs/clarinet_speedrun.sh
+
+export OMP_NUM_THREADS=1
+export CLARINET_BASE_DIR="${CLARINET_BASE_DIR:-$HOME/.cache/nanochat}"
+mkdir -p "$CLARINET_BASE_DIR"
+
+# -----------------------------------------------------------------------------
+# Python venv setup with uv
+command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+[ -d ".venv" ] || uv venv
+uv sync --extra gpu
+source .venv/bin/activate
+
+# -----------------------------------------------------------------------------
+# wandb setup (optional)
+if [ -z "$WANDB_RUN" ]; then
+    WANDB_RUN=dummy
+fi
+
+# -----------------------------------------------------------------------------
+# Report header
+python -m nanochat.report reset
+
+# -----------------------------------------------------------------------------
+# Data: climbmix (general) + proof-pile-2 (reasoning instrument)
+
+# Start downloading climbmix shards in the background.
+# 170 climbmix shards for ~GPT-2 capacity, +20 padding.
+python -m nanochat.dataset -n 8                    # 8 shards for tokenizer training
+python -m nanochat.dataset -n 170 &
+DATASET_DOWNLOAD_PID=$!
+
+# Prepare proof-pile-2 reasoning shards in parallel (~50 shards = ~3M docs).
+# Note: requires `datasets` and may need HF auth for the EleutherAI repo.
+python -m clarinet.prepare_proof_pile -n 50 &
+PROOF_PILE_PID=$!
+
+# Tokenizer (must be retrained because clarinet added 3 new special tokens to SPECIAL_TOKENS).
+# Trained only on general-source data so the vocab isn't biased toward math/proofs.
+python -m scripts.tok_train
+python -m scripts.tok_eval
+
+# -----------------------------------------------------------------------------
+# Base model: clarinet IV-conditioned pretraining
+echo "Waiting for climbmix download to complete..."
+wait $DATASET_DOWNLOAD_PID
+echo "Waiting for proof-pile-2 prep to complete..."
+wait $PROOF_PILE_PID
+
+# d24 model, same compute envelope as vanilla speedrun, with clarinet's source-marker
+# conditioning and CFG-style dropout. Mix ratio and dropout are the v1 defaults.
+torchrun --standalone --nproc_per_node=8 -m scripts.clarinet_train -- \
+    --reasoning-mix-ratio=0.3 --p-uncond=0.1 \
+    --depth=24 --target-param-data-ratio=8 --device-batch-size=16 --fp8 --run=$WANDB_RUN
+
+# CORE / BPB eval on the base model (single-pass, no IV combine yet — vanilla eval).
+torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-size=16
+
+# -----------------------------------------------------------------------------
+# SFT
+curl -L -o "$CLARINET_BASE_DIR/identity_conversations.jsonl" \
+    https://karpathy-public.s3.us-west-2.amazonaws.com/identity_conversations.jsonl
+
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --device-batch-size=16 --run=$WANDB_RUN
+
+# Vanilla single-pass chat eval (for a reference accuracy without IV combination)
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
+
+# -----------------------------------------------------------------------------
+# IV guidance weight sweep — the actual clarinet experiment.
+# Single-GPU because the eval engine maintains two parallel KV caches and we
+# want clean per-task accuracy numbers without DDP averaging noise on small task sets.
+python -m scripts.iv_eval -i sft \
+    -a GSM8K,ARC-Easy,ARC-Challenge,MMLU,HumanEval,SpellingBee \
+    --weights 0,0.5,1.0,1.5,2.0,3.0,5.0
+
+# -----------------------------------------------------------------------------
+# Bonus: interactive chat with a chosen weight, e.g.
+#   python -m scripts.clarinet_cli --iv-weight 2.0 -p "Prove that sqrt(2) is irrational."
+
+python -m nanochat.report generate

--- a/runs/clarinet_speedrun.sh
+++ b/runs/clarinet_speedrun.sh
@@ -17,7 +17,15 @@ mkdir -p "$CLARINET_BASE_DIR"
 # Python venv setup with uv
 command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
 [ -d ".venv" ] || uv venv
-uv sync --extra gpu
+# Intended path: the `gpu` extra installs the CUDA 12.8 (Hopper/H100) torch
+# build, sourced from download.pytorch.org/whl/cu128 — correct for an 8xH100
+# node with open network. On environments whose network policy blocks that CDN
+# (e.g. Claude Code on the web), fall back to PyPI, whose linux torch==2.9.1
+# wheel is itself the +cu128 build and drives H100s identically (CUDA 12.8, NCCL).
+uv sync --extra gpu || {
+    echo "uv sync --extra gpu failed (PyTorch CDN unreachable?); installing from PyPI instead."
+    uv pip install -e .
+}
 source .venv/bin/activate
 
 # -----------------------------------------------------------------------------

--- a/runs/clarinet_speedrun.sh
+++ b/runs/clarinet_speedrun.sh
@@ -31,7 +31,7 @@ fi
 python -m nanochat.report reset
 
 # -----------------------------------------------------------------------------
-# Data: climbmix (general) + proof-pile-2 (reasoning instrument)
+# Data: climbmix (general) + FineMath (reasoning instrument)
 
 # Start downloading climbmix shards in the background.
 # 170 climbmix shards for ~GPT-2 capacity, +20 padding.
@@ -39,10 +39,9 @@ python -m nanochat.dataset -n 8                    # 8 shards for tokenizer trai
 python -m nanochat.dataset -n 170 &
 DATASET_DOWNLOAD_PID=$!
 
-# Prepare proof-pile-2 reasoning shards in parallel (~50 shards = ~3M docs).
-# Note: requires `datasets` and may need HF auth for the EleutherAI repo.
-python -m clarinet.prepare_proof_pile -n 50 &
-PROOF_PILE_PID=$!
+# Prepare FineMath reasoning shards in parallel (~50 shards = ~3M docs).
+python -m clarinet.prepare_reasoning_data -n 50 &
+REASONING_PID=$!
 
 # Tokenizer (must be retrained because clarinet added 3 new special tokens to SPECIAL_TOKENS).
 # Trained only on general-source data so the vocab isn't biased toward math/proofs.
@@ -53,8 +52,8 @@ python -m scripts.tok_eval
 # Base model: clarinet IV-conditioned pretraining
 echo "Waiting for climbmix download to complete..."
 wait $DATASET_DOWNLOAD_PID
-echo "Waiting for proof-pile-2 prep to complete..."
-wait $PROOF_PILE_PID
+echo "Waiting for FineMath prep to complete..."
+wait $REASONING_PID
 
 # d24 model, same compute envelope as vanilla speedrun, with clarinet's source-marker
 # conditioning and CFG-style dropout. Mix ratio and dropout are the v1 defaults.

--- a/scripts/chat_eval.py
+++ b/scripts/chat_eval.py
@@ -85,11 +85,10 @@ def run_generative_eval(task_object, tokenizer, model, engine, num_samples, max_
 # A lot easier because we don't have to sample. Therefore, we can actually go
 # batches at a time and just check the logits for correct answer choices.
 
-def run_categorical_eval(task_object, tokenizer, model, batch_size, max_problems=None):
+def run_categorical_eval(task_object, tokenizer, engine, batch_size, max_problems=None):
 
     ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()
-    device = model.get_device()
-    bos = tokenizer.get_bos_token_id() # use BOS as pad token is ok, these positions are ignored
+    device = engine.model.get_device()
 
     # We'll process batches of independent problems at a time because there is no sampling needed
     num_problems = len(task_object) if max_problems is None else min(len(task_object), max_problems)
@@ -105,14 +104,10 @@ def run_categorical_eval(task_object, tokenizer, model, batch_size, max_problems
         # Prepare the batch of problems. They might all be of different length, so we pad/collate them.
         conversations = [task_object[ii] for ii in range(i0, i1)]
         prompt_ids = [tokenizer.render_for_completion(conversation) for conversation in conversations] # TODO: remake the way this works
-        max_length = max(len(ids) for ids in prompt_ids)
         answer_time_positions = [len(ids) - 1 for ids in prompt_ids] # where the last token is (and the predicted answer)
-        padded_prompt_ids = [ids + [bos] * (max_length - len(ids)) for ids in prompt_ids]
-        prompt_ids = torch.tensor(padded_prompt_ids, dtype=torch.long, device=device)
 
-        # Get the logits for the whole batch of conversations in parallel (efficiency win here)
-        with torch.no_grad():
-            logits = model(prompt_ids) # (B, T, V)
+        # Get logits at answer positions via the engine (enables dual-pass IV guidance)
+        answer_logits = engine.categorical_logits_at(prompt_ids, answer_time_positions) # (B, V)
 
         # Focus on the available answer on just the letters corresponding to choices
         # Note that this helps the evaluation a lot because it specifically narrows the focus to only the available letters
@@ -128,9 +123,8 @@ def run_categorical_eval(task_object, tokenizer, model, batch_size, max_problems
                     assert len(encoded_letter) == 1, "Each letter must be a single token"
                     letter_to_id_cache[letter] = encoded_letter[0]
                 letter_ids.append(letter_to_id_cache[letter])
-            # focus logits just down to the answer position and the available letters of the answer
-            answer_pos = answer_time_positions[idx]
-            focus_logits = logits[idx, answer_pos, letter_ids]
+            # focus logits just down to the available letters of the answer
+            focus_logits = answer_logits[idx, letter_ids]
             # get the argmax letter (the predicted answer)
             argmax_letter_id = focus_logits.argmax(dim=-1).item()
             predicted_letter = letters[argmax_letter_id]
@@ -171,7 +165,7 @@ def run_chat_eval(task_name, model, tokenizer, engine,
     if task_object.eval_type == 'generative':
         acc = run_generative_eval(task_object, tokenizer, model, engine, num_samples, max_new_tokens, temperature, top_k, max_problems=max_problems)
     elif task_object.eval_type == 'categorical':
-        acc = run_categorical_eval(task_object, tokenizer, model, batch_size, max_problems=max_problems)
+        acc = run_categorical_eval(task_object, tokenizer, engine, batch_size, max_problems=max_problems)
     else:
         raise ValueError(f"Unsupported task evaluation type: {task_object.eval_type}")
     return acc

--- a/scripts/clarinet_cli.py
+++ b/scripts/clarinet_cli.py
@@ -1,0 +1,43 @@
+"""
+Clarinet interactive chat CLI — wraps scripts.chat_cli with the dual-pass
+IV engine and adds CLI flags for the guidance weight and Wald scale:
+
+    python -m scripts.clarinet_cli --iv-weight 2.0 --wald-scale 1.0
+
+All other flags (--prompt, --temperature, --top-k, --model-tag, etc.) are
+forwarded to the upstream chat_cli unchanged.
+"""
+
+import argparse
+import sys
+
+import nanochat.engine
+
+from clarinet.engine import ClarinetEngine
+
+
+def _parse_and_strip_clarinet_args():
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--iv-weight", type=float, default=1.5,
+                     help="IV guidance weight w. w=0 -> unconditional; w=1 -> conditional only; w>1 -> guided.")
+    pre.add_argument("--wald-scale", type=float, default=1.0,
+                     help="Wald-style scale factor s. s=1 matches vanilla CFG.")
+    args, remaining = pre.parse_known_args()
+    sys.argv = [sys.argv[0]] + remaining
+    return args
+
+
+def _install_clarinet_engine(iv_weight, wald_scale):
+    class _BoundClarinetEngine(ClarinetEngine):
+        def generate(self, *args, **kwargs):
+            kwargs.setdefault("iv_weight", iv_weight)
+            kwargs.setdefault("wald_scale", wald_scale)
+            yield from super().generate(*args, **kwargs)
+
+    nanochat.engine.Engine = _BoundClarinetEngine
+
+
+if __name__ == "__main__":
+    cli_args = _parse_and_strip_clarinet_args()
+    _install_clarinet_engine(cli_args.iv_weight, cli_args.wald_scale)
+    import scripts.chat_cli  # noqa: F401

--- a/scripts/clarinet_cli.py
+++ b/scripts/clarinet_cli.py
@@ -1,8 +1,13 @@
 """
 Clarinet interactive chat CLI — wraps scripts.chat_cli with the dual-pass
-IV engine and adds CLI flags for the guidance weight and Wald scale:
+IV engine and adds CLI flags for the guidance weight and scale:
 
     python -m scripts.clarinet_cli --iv-weight 2.0 --wald-scale 1.0
+
+To enable the L1 content-adaptive scale schedule (spend guidance budget where
+the source marker actually moves the prediction):
+
+    python -m scripts.clarinet_cli --iv-weight 2.0 --scale-lo 0.5 --scale-hi 2.0
 
 All other flags (--prompt, --temperature, --top-k, --model-tag, etc.) are
 forwarded to the upstream chat_cli unchanged.
@@ -21,17 +26,25 @@ def _parse_and_strip_clarinet_args():
     pre.add_argument("--iv-weight", type=float, default=1.5,
                      help="IV guidance weight w. w=0 -> unconditional; w=1 -> conditional only; w>1 -> guided.")
     pre.add_argument("--wald-scale", type=float, default=1.0,
-                     help="Wald-style scale factor s. s=1 matches vanilla CFG.")
+                     help="Base scale factor s. s=1 matches vanilla CFG.")
+    pre.add_argument("--scale-lo", type=float, default=1.0,
+                     help="L1-adaptive scale floor (applied at zero cond/uncond "
+                          "divergence). scale-lo == scale-hi == 1.0 -> constant CFG.")
+    pre.add_argument("--scale-hi", type=float, default=1.0,
+                     help="L1-adaptive scale ceiling (applied at max divergence). "
+                          "Try --scale-lo 0.5 --scale-hi 2.0 to enable adaptation.")
     args, remaining = pre.parse_known_args()
     sys.argv = [sys.argv[0]] + remaining
     return args
 
 
-def _install_clarinet_engine(iv_weight, wald_scale):
+def _install_clarinet_engine(iv_weight, wald_scale, scale_lo, scale_hi):
     class _BoundClarinetEngine(ClarinetEngine):
         def generate(self, *args, **kwargs):
             kwargs.setdefault("iv_weight", iv_weight)
             kwargs.setdefault("wald_scale", wald_scale)
+            kwargs.setdefault("scale_lo", scale_lo)
+            kwargs.setdefault("scale_hi", scale_hi)
             yield from super().generate(*args, **kwargs)
 
     nanochat.engine.Engine = _BoundClarinetEngine
@@ -39,5 +52,6 @@ def _install_clarinet_engine(iv_weight, wald_scale):
 
 if __name__ == "__main__":
     cli_args = _parse_and_strip_clarinet_args()
-    _install_clarinet_engine(cli_args.iv_weight, cli_args.wald_scale)
+    _install_clarinet_engine(cli_args.iv_weight, cli_args.wald_scale,
+                             cli_args.scale_lo, cli_args.scale_hi)
     import scripts.chat_cli  # noqa: F401

--- a/scripts/clarinet_train.py
+++ b/scripts/clarinet_train.py
@@ -24,7 +24,7 @@ from clarinet.dataloader import clarinet_data_loader
 def _parse_and_strip_clarinet_args():
     pre = argparse.ArgumentParser(add_help=False)
     pre.add_argument("--reasoning-mix-ratio", type=float, default=0.3,
-                     help="Fraction of training docs sampled from proof-pile-2 (vs climbmix).")
+                     help="Fraction of training docs sampled from the reasoning corpus (FineMath) vs climbmix.")
     pre.add_argument("--p-uncond", type=float, default=0.1,
                      help="Probability of overriding the true source marker with <|src_unknown|> during training.")
     pre.add_argument("--clarinet-seed", type=int, default=0,

--- a/scripts/clarinet_train.py
+++ b/scripts/clarinet_train.py
@@ -1,0 +1,69 @@
+"""
+Clarinet pretraining entry point.
+
+Wraps scripts.base_train by substituting clarinet's source-marker-aware
+dataloader in place of the upstream BOS-bestfit one. Two clarinet-specific
+flags are parsed first and stripped from sys.argv so base_train's argparse
+doesn't see them; everything else passes through:
+
+    torchrun --nproc_per_node=8 -m scripts.clarinet_train \\
+        --depth=20 --reasoning-mix-ratio=0.3 --p-uncond=0.1
+
+This shim keeps scripts/base_train.py and nanochat/ entirely untouched so
+upstream rebases stay clean.
+"""
+
+import argparse
+import sys
+
+import nanochat.dataloader as _upstream_dataloader
+
+from clarinet.dataloader import clarinet_data_loader
+
+
+def _parse_and_strip_clarinet_args():
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--reasoning-mix-ratio", type=float, default=0.3,
+                     help="Fraction of training docs sampled from proof-pile-2 (vs climbmix).")
+    pre.add_argument("--p-uncond", type=float, default=0.1,
+                     help="Probability of overriding the true source marker with <|src_unknown|> during training.")
+    pre.add_argument("--clarinet-seed", type=int, default=0,
+                     help="Seed for the per-doc p_uncond dropout RNG (seeded per rank).")
+    clarinet_args, remaining = pre.parse_known_args()
+    sys.argv = [sys.argv[0]] + remaining
+    return clarinet_args
+
+
+def _install_clarinet_dataloader(clarinet_args):
+    def train_loader(tokenizer, B, T, split, **kwargs):
+        return clarinet_data_loader(
+            tokenizer, B, T, split,
+            reasoning_mix_ratio=clarinet_args.reasoning_mix_ratio,
+            p_uncond=clarinet_args.p_uncond,
+            seed=clarinet_args.clarinet_seed,
+            **kwargs,
+        )
+
+    def val_loader(tokenizer, B, T, split, **kwargs):
+        # Eval is deterministic — always use the true marker (no dropout) and
+        # drop the resume state_dict from the yields to match the upstream
+        # non-stateful loader's contract.
+        for inputs, targets, _state in clarinet_data_loader(
+            tokenizer, B, T, split,
+            reasoning_mix_ratio=clarinet_args.reasoning_mix_ratio,
+            p_uncond=0.0,
+            seed=clarinet_args.clarinet_seed,
+            **kwargs,
+        ):
+            yield inputs, targets
+
+    _upstream_dataloader.tokenizing_distributed_data_loader_with_state_bos_bestfit = train_loader
+    _upstream_dataloader.tokenizing_distributed_data_loader_bos_bestfit = val_loader
+
+
+if __name__ == "__main__":
+    clarinet_args = _parse_and_strip_clarinet_args()
+    _install_clarinet_dataloader(clarinet_args)
+    # base_train.py runs at import time (argparse + training loop are
+    # module-level), so importing it after the patch is what kicks off training.
+    import scripts.base_train  # noqa: F401

--- a/scripts/iv_eval.py
+++ b/scripts/iv_eval.py
@@ -31,6 +31,10 @@ def make_engine(model, tokenizer, iv_weight, wald_scale):
             kwargs.setdefault("iv_weight", iv_weight)
             kwargs.setdefault("wald_scale", wald_scale)
             yield from super().generate(*args, **kwargs)
+        def categorical_logits_at(self, *args, **kwargs):
+            kwargs.setdefault("iv_weight", iv_weight)
+            kwargs.setdefault("wald_scale", wald_scale)
+            return super().categorical_logits_at(*args, **kwargs)
     return _BoundClarinetEngine(model, tokenizer)
 
 

--- a/scripts/iv_eval.py
+++ b/scripts/iv_eval.py
@@ -1,0 +1,96 @@
+"""
+Sweep the IV guidance weight `w` across a set of evaluation tasks and report
+accuracy vs w. Used to validate that clarinet's IV-conditioned inference
+beats the conditional-only baseline on reasoning tasks at moderate w, and to
+locate the over-guidance collapse point.
+
+Loads the model once, then for each w in --weights reconstructs a
+ClarinetEngine bound to that weight and runs the requested tasks via
+chat_eval's helpers.
+
+Example:
+    python -m scripts.iv_eval -i sft -a GSM8K,ARC-Easy --weights 0,1,1.5,2,3,5
+"""
+
+import argparse
+
+from nanochat.checkpoint_manager import load_model
+from nanochat.common import autodetect_device_type, compute_cleanup, compute_init, print0
+
+from clarinet.engine import ClarinetEngine
+from scripts.chat_eval import run_chat_eval
+
+
+def parse_weights(spec):
+    return [float(x) for x in spec.split(",") if x]
+
+
+def make_engine(model, tokenizer, iv_weight, wald_scale):
+    class _BoundClarinetEngine(ClarinetEngine):
+        def generate(self, *args, **kwargs):
+            kwargs.setdefault("iv_weight", iv_weight)
+            kwargs.setdefault("wald_scale", wald_scale)
+            yield from super().generate(*args, **kwargs)
+    return _BoundClarinetEngine(model, tokenizer)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="IV guidance weight sweep")
+    parser.add_argument("-i", "--source", type=str, required=True, help="Model source: base|sft|rl")
+    parser.add_argument("-a", "--task-names", type=str, default="GSM8K,ARC-Easy,ARC-Challenge,MMLU,HumanEval,SpellingBee",
+                        help="Comma-separated task names from chat_eval's task registry.")
+    parser.add_argument("--weights", type=str, default="0,0.5,1.0,1.5,2.0,3.0,5.0",
+                        help="Comma-separated IV guidance weights to sweep.")
+    parser.add_argument("--wald-scale", type=float, default=1.0)
+    parser.add_argument("-t", "--temperature", type=float, default=0.0)
+    parser.add_argument("-m", "--max-new-tokens", type=int, default=512)
+    parser.add_argument("-n", "--num-samples", type=int, default=1)
+    parser.add_argument("-k", "--top-k", type=int, default=50)
+    parser.add_argument("-b", "--batch-size", type=int, default=8)
+    parser.add_argument("-g", "--model-tag", type=str, default=None)
+    parser.add_argument("-s", "--step", type=int, default=None)
+    parser.add_argument("-x", "--max-problems", type=int, default=None)
+    parser.add_argument("--device-type", type=str, default="", choices=["", "cuda", "cpu", "mps"])
+    args = parser.parse_args()
+
+    device_type = autodetect_device_type() if args.device_type == "" else args.device_type
+    _ddp, _rank, _local, _world, device = compute_init(device_type)
+
+    model, tokenizer, _meta = load_model(args.source, device, phase="eval",
+                                         model_tag=args.model_tag, step=args.step)
+
+    weights = parse_weights(args.weights)
+    task_names = [t for t in args.task_names.split(",") if t]
+
+    # results[task][weight] = accuracy
+    results = {t: {} for t in task_names}
+
+    for w in weights:
+        print0(f"\n========== IV weight w = {w} ==========")
+        engine = make_engine(model, tokenizer, iv_weight=w, wald_scale=args.wald_scale)
+        for task in task_names:
+            acc = run_chat_eval(
+                task,
+                model, tokenizer, engine,
+                batch_size=args.batch_size,
+                num_samples=args.num_samples,
+                max_new_tokens=args.max_new_tokens,
+                temperature=args.temperature,
+                top_k=args.top_k,
+                max_problems=args.max_problems,
+            )
+            results[task][w] = acc
+            print0(f"  w={w:.2f}  {task}: {100*acc:.2f}%")
+
+    print0("\n========== Summary (rows=task, cols=w) ==========")
+    header = "task".ljust(18) + "".join(f"{w:>9.2f}" for w in weights)
+    print0(header)
+    for task in task_names:
+        row = task.ljust(18) + "".join(f"{100*results[task][w]:>8.2f}%" for w in weights)
+        print0(row)
+
+    compute_cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_clarinet_dataloader.py
+++ b/tests/test_clarinet_dataloader.py
@@ -2,7 +2,7 @@
 Hermetic tests for clarinet's source-marker-aware dataloader.
 
 Uses a mock tokenizer and synthetic parquet files in tmp_path so nothing
-depends on a real model, real climbmix, or real proof-pile-2 download.
+depends on a real model, real climbmix, or real reasoning-corpus download.
 
 Run: python -m pytest tests/test_clarinet_dataloader.py -v
 """

--- a/tests/test_clarinet_dataloader.py
+++ b/tests/test_clarinet_dataloader.py
@@ -1,0 +1,216 @@
+"""
+Hermetic tests for clarinet's source-marker-aware dataloader.
+
+Uses a mock tokenizer and synthetic parquet files in tmp_path so nothing
+depends on a real model, real climbmix, or real proof-pile-2 download.
+
+Run: python -m pytest tests/test_clarinet_dataloader.py -v
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import torch
+
+import clarinet.dataloader as dl
+from clarinet.dataloader import (
+    SRC_GENERAL,
+    SRC_REASONING,
+    SRC_UNKNOWN,
+    _interleave_sources,
+    clarinet_data_loader,
+)
+
+
+class MockTokenizer:
+    """
+    Minimal interface match for clarinet_data_loader.
+    Tokens 0-999 are unused; specials live at 1000+.
+    encode() treats input chars as their ord() (no BPE — we just need the
+    invariants around marker insertion and BOS-target masking, not real text).
+    """
+    BOS = 1000
+    SRC_REASONING_ID = 1001
+    SRC_GENERAL_ID = 1002
+    SRC_UNKNOWN_ID = 1003
+
+    SPECIALS = {
+        "<|bos|>": BOS,
+        SRC_REASONING: SRC_REASONING_ID,
+        SRC_GENERAL: SRC_GENERAL_ID,
+        SRC_UNKNOWN: SRC_UNKNOWN_ID,
+    }
+    MARKER_IDS = {SRC_REASONING_ID, SRC_GENERAL_ID, SRC_UNKNOWN_ID}
+
+    def get_bos_token_id(self):
+        return self.BOS
+
+    def encode_special(self, name):
+        return self.SPECIALS[name]
+
+    def encode(self, text, prepend=None, append=None, num_threads=4):
+        def one(s):
+            ids = [ord(c) for c in s]
+            if prepend is not None:
+                ids = [prepend] + ids
+            if append is not None:
+                ids = ids + [append]
+            return ids
+
+        if isinstance(text, str):
+            return one(text)
+        return [one(t) for t in text]
+
+
+def _write_shard(path, n_docs, doc_len=8, prefix=""):
+    docs = [f"{prefix}{i:03d}".ljust(doc_len, "x") for i in range(n_docs)]
+    table = pa.table({"text": docs})
+    # One row group per file keeps the DDP-rank math trivial in single-process tests.
+    pq.write_table(table, path, row_group_size=n_docs)
+
+
+@pytest.fixture
+def fake_paths(tmp_path, monkeypatch):
+    climbmix = tmp_path / "climbmix"
+    reasoning = tmp_path / "reasoning"
+    climbmix.mkdir()
+    reasoning.mkdir()
+    for shard_idx in range(3):
+        _write_shard(climbmix / f"shard_{shard_idx:05d}.parquet", n_docs=30, prefix="c")
+        _write_shard(reasoning / f"shard_{shard_idx:05d}.parquet", n_docs=30, prefix="r")
+    climbmix_paths = sorted(str(p) for p in climbmix.glob("*.parquet"))
+    reasoning_paths = sorted(str(p) for p in reasoning.glob("*.parquet"))
+
+    paths_with_source = [(p, False) for p in climbmix_paths] + [(p, True) for p in reasoning_paths]
+    monkeypatch.setattr(dl, "list_parquet_files_with_source", lambda split: paths_with_source)
+    return climbmix_paths, reasoning_paths
+
+
+def _first_batch(tok, **kwargs):
+    """Convenience: build a loader, pull one batch, return (inputs, targets) on CPU."""
+    loader = clarinet_data_loader(
+        tok, B=4, T=64, split="train",
+        tokenizer_threads=1,
+        tokenizer_batch_size=8,
+        device="cpu",
+        buffer_size=20,
+        **kwargs,
+    )
+    inputs, targets, _state = next(loader)
+    return inputs, targets
+
+
+def test_interleave_sources_50_50():
+    paths = [(f"c{i}", False) for i in range(6)] + [(f"r{i}", True) for i in range(6)]
+    out = _interleave_sources(paths, 0.5)
+    assert len(out) == 12
+    n_reasoning = sum(1 for _, r in out if r)
+    assert n_reasoning == 6
+    # No long run of either source — alternation should be tight at 0.5
+    for i in range(len(out) - 2):
+        window = [out[i][1], out[i + 1][1], out[i + 2][1]]
+        assert not all(window), "three consecutive reasoning files at ratio 0.5"
+        assert not all(not w for w in window), "three consecutive climbmix files at ratio 0.5"
+
+
+def test_interleave_sources_30_70():
+    paths = [(f"c{i}", False) for i in range(7)] + [(f"r{i}", True) for i in range(3)]
+    out = _interleave_sources(paths, 0.3)
+    assert len(out) == 10
+    n_reasoning = sum(1 for _, r in out if r)
+    assert n_reasoning == 3
+
+
+def test_interleave_sources_empty_one_side():
+    paths = [(f"c{i}", False) for i in range(3)]
+    out = _interleave_sources(paths, 0.5)
+    assert out == paths  # no reasoning -> passthrough
+
+
+def test_marker_always_follows_bos(fake_paths):
+    tok = MockTokenizer()
+    inputs, _ = _first_batch(tok, reasoning_mix_ratio=0.5, p_uncond=0.5, seed=0)
+    bos_positions = (inputs == tok.BOS).nonzero(as_tuple=False)
+    assert len(bos_positions) > 0, "expected at least one BOS in the packed batch"
+    for row, col in bos_positions.tolist():
+        if col + 1 >= inputs.size(1):
+            continue  # BOS at the very last position — no room for a marker
+        next_tok = inputs[row, col + 1].item()
+        assert next_tok in tok.MARKER_IDS, (
+            f"position ({row},{col+1}) after BOS holds {next_tok}, expected one of "
+            f"{tok.MARKER_IDS}"
+        )
+
+
+def test_p_uncond_one_yields_only_unknown_markers(fake_paths):
+    tok = MockTokenizer()
+    inputs, _ = _first_batch(tok, reasoning_mix_ratio=0.5, p_uncond=1.0, seed=0)
+    bos_positions = (inputs == tok.BOS).nonzero(as_tuple=False)
+    markers = [inputs[r, c + 1].item() for r, c in bos_positions.tolist() if c + 1 < inputs.size(1)]
+    assert markers, "no markers found"
+    assert all(m == tok.SRC_UNKNOWN_ID for m in markers), (
+        f"p_uncond=1.0 should override every marker to SRC_UNKNOWN, got {set(markers)}"
+    )
+
+
+def test_p_uncond_zero_yields_no_unknown_markers(fake_paths):
+    tok = MockTokenizer()
+    inputs, _ = _first_batch(tok, reasoning_mix_ratio=0.5, p_uncond=0.0, seed=0)
+    bos_positions = (inputs == tok.BOS).nonzero(as_tuple=False)
+    markers = [inputs[r, c + 1].item() for r, c in bos_positions.tolist() if c + 1 < inputs.size(1)]
+    assert markers, "no markers found"
+    assert all(m != tok.SRC_UNKNOWN_ID for m in markers), (
+        f"p_uncond=0.0 should never emit SRC_UNKNOWN, got {[m for m in markers if m == tok.SRC_UNKNOWN_ID]}"
+    )
+
+
+def test_marker_matches_source_at_extreme_mix_ratios(fake_paths):
+    tok = MockTokenizer()
+
+    # mix_ratio=0.0 → all docs from climbmix → all markers SRC_GENERAL (with p_uncond=0)
+    inputs_general, _ = _first_batch(tok, reasoning_mix_ratio=0.0, p_uncond=0.0, seed=1)
+    bos_positions = (inputs_general == tok.BOS).nonzero(as_tuple=False)
+    markers = [inputs_general[r, c + 1].item() for r, c in bos_positions.tolist() if c + 1 < inputs_general.size(1)]
+    assert markers and all(m == tok.SRC_GENERAL_ID for m in markers), (
+        f"mix_ratio=0 should produce only SRC_GENERAL markers, got {set(markers)}"
+    )
+
+    # mix_ratio=1.0 → all reasoning → all markers SRC_REASONING (with p_uncond=0)
+    inputs_reasoning, _ = _first_batch(tok, reasoning_mix_ratio=1.0, p_uncond=0.0, seed=2)
+    bos_positions = (inputs_reasoning == tok.BOS).nonzero(as_tuple=False)
+    markers = [inputs_reasoning[r, c + 1].item() for r, c in bos_positions.tolist() if c + 1 < inputs_reasoning.size(1)]
+    assert markers and all(m == tok.SRC_REASONING_ID for m in markers), (
+        f"mix_ratio=1 should produce only SRC_REASONING markers, got {set(markers)}"
+    )
+
+
+def test_targets_masked_at_bos_input_positions(fake_paths):
+    tok = MockTokenizer()
+    inputs, targets = _first_batch(tok, reasoning_mix_ratio=0.5, p_uncond=0.1, seed=3)
+    # Wherever input is BOS, the corresponding target (next-token) is the marker —
+    # the dataloader must mask those targets to -1 so the model doesn't train to
+    # predict the source.
+    bos_input_mask = inputs == tok.BOS
+    assert bos_input_mask.any(), "expected at least one BOS position in inputs"
+    assert (targets[bos_input_mask] == -1).all(), (
+        "every target at a BOS-input position must be -1, but some leaked through"
+    )
+    # Sanity: non-BOS-input positions should overwhelmingly have valid targets.
+    non_bos = targets[~bos_input_mask]
+    assert (non_bos != -1).any(), "no non-masked targets — something is wrong"
+
+
+def test_loader_produces_correct_tensor_shapes(fake_paths):
+    tok = MockTokenizer()
+    loader = clarinet_data_loader(
+        tok, B=3, T=32, split="train",
+        reasoning_mix_ratio=0.5, p_uncond=0.1,
+        tokenizer_threads=1, tokenizer_batch_size=8,
+        device="cpu", buffer_size=10, seed=0,
+    )
+    inputs, targets, state = next(loader)
+    assert inputs.shape == (3, 32)
+    assert targets.shape == (3, 32)
+    assert inputs.dtype == torch.long
+    assert targets.dtype == torch.long
+    assert {"pq_idx", "rg_idx", "epoch"} <= set(state.keys())

--- a/tests/test_clarinet_dataloader.py
+++ b/tests/test_clarinet_dataloader.py
@@ -100,10 +100,20 @@ def _first_batch(tok, **kwargs):
     return inputs, targets
 
 
+def _assert_path_str_bool_pairs(out):
+    """Guard against the regression where interleave returned ((str, bool), bool)."""
+    for entry in out:
+        assert isinstance(entry, tuple) and len(entry) == 2, f"bad shape: {entry!r}"
+        path, is_r = entry
+        assert isinstance(path, str), f"path should be str, got {type(path).__name__}: {path!r}"
+        assert isinstance(is_r, bool), f"is_reasoning should be bool, got {type(is_r).__name__}"
+
+
 def test_interleave_sources_50_50():
     paths = [(f"c{i}", False) for i in range(6)] + [(f"r{i}", True) for i in range(6)]
     out = _interleave_sources(paths, 0.5)
     assert len(out) == 12
+    _assert_path_str_bool_pairs(out)
     n_reasoning = sum(1 for _, r in out if r)
     assert n_reasoning == 6
     # No long run of either source — alternation should be tight at 0.5
@@ -117,6 +127,7 @@ def test_interleave_sources_30_70():
     paths = [(f"c{i}", False) for i in range(7)] + [(f"r{i}", True) for i in range(3)]
     out = _interleave_sources(paths, 0.3)
     assert len(out) == 10
+    _assert_path_str_bool_pairs(out)
     n_reasoning = sum(1 for _, r in out if r)
     assert n_reasoning == 3
 

--- a/tests/test_clarinet_engine.py
+++ b/tests/test_clarinet_engine.py
@@ -1,0 +1,246 @@
+"""
+Hermetic tests for clarinet's dual-pass IV engine.
+
+Uses the existing MockModel/ByteTokenizer scaffolding pattern from
+tests/test_engine.py, extended with a counting wrapper that lets us verify the
+dual-cache mechanics. The IV combine formula is unit-tested directly via the
+static method extracted from generate().
+
+Run: python -m pytest tests/test_clarinet_engine.py -v
+"""
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from clarinet.engine import ClarinetEngine
+
+
+@dataclass
+class MockConfig:
+    n_kv_head: int = 4
+    n_head: int = 4
+    n_embd: int = 64
+    n_layer: int = 2
+    sequence_len: int = 128
+
+
+class CountingMockModel:
+    """
+    Returns uniform logits and records every forward call's kv_cache identity
+    + input length. Lets us assert that the dual-pass engine does in fact
+    issue two forward calls per decode step against two distinct KV caches.
+    """
+
+    def __init__(self, vocab_size=2048):
+        self.vocab_size = vocab_size
+        self.config = MockConfig()
+        self._device = torch.device("cpu")
+        self.forward_calls = []  # list of (id(kv_cache), T)
+
+    def get_device(self):
+        return self._device
+
+    def forward(self, ids, kv_cache=None):
+        B, T = ids.shape
+        if kv_cache is not None:
+            kv_cache.advance(T)
+            self.forward_calls.append((id(kv_cache), T))
+        else:
+            self.forward_calls.append((None, T))
+        return torch.zeros(B, T, self.vocab_size)
+
+
+class ClarinetByteTokenizer:
+    """Byte tokenizer with the clarinet source-marker specials wired in."""
+
+    def __init__(self):
+        self._special_tokens = {
+            "<|python_start|>": 256,
+            "<|python_end|>": 257,
+            "<|output_start|>": 258,
+            "<|output_end|>": 259,
+            "<|assistant_end|>": 260,
+            "<|bos|>": 261,
+            "<|src_reasoning|>": 262,
+            "<|src_general|>": 263,
+            "<|src_unknown|>": 264,
+        }
+        self._bos = 261
+
+    def encode_special(self, s):
+        return self._special_tokens[s]
+
+    def get_bos_token_id(self):
+        return self._bos
+
+    def encode(self, s, prepend=None):
+        tokens = list(s.encode("utf-8"))
+        if prepend is not None:
+            tokens = [prepend] + tokens
+        return tokens
+
+    def decode(self, tokens):
+        return bytes(t for t in tokens if t < 256).decode("utf-8", errors="replace")
+
+
+# -----------------------------------------------------------------------------
+# combine_logits: pure formula
+
+
+def test_combine_w_zero_returns_uncond():
+    lc = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    lu = torch.tensor([0.5, 1.0, 1.5, 2.0])
+    out = ClarinetEngine.combine_logits(lc, lu, iv_weight=0.0, wald_scale=1.0)
+    assert torch.allclose(out, lu)
+
+
+def test_combine_w_one_s_one_returns_cond():
+    lc = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    lu = torch.tensor([0.5, 1.0, 1.5, 2.0])
+    out = ClarinetEngine.combine_logits(lc, lu, iv_weight=1.0, wald_scale=1.0)
+    assert torch.allclose(out, lc)
+
+
+def test_combine_overguided_extrapolates_past_cond():
+    # w=2, s=1 should push 2x past cond in the cond-uncond direction
+    lc = torch.tensor([1.0, 2.0, 3.0])
+    lu = torch.tensor([0.5, 1.0, 1.5])
+    out = ClarinetEngine.combine_logits(lc, lu, iv_weight=2.0, wald_scale=1.0)
+    expected = lu + 2.0 * (lc - lu)
+    assert torch.allclose(out, expected)
+    # Sanity: each component is on the cond side of uncond and further away
+    assert torch.all((out - lu).abs() >= (lc - lu).abs())
+
+
+def test_combine_wald_scale_multiplies_step():
+    lc = torch.tensor([1.0, 2.0])
+    lu = torch.tensor([0.0, 0.0])
+    # w=1, s=2 => uncond + 1*2*(cond-uncond) = 2*cond when uncond=0
+    out = ClarinetEngine.combine_logits(lc, lu, iv_weight=1.0, wald_scale=2.0)
+    assert torch.allclose(out, 2.0 * lc)
+
+
+# -----------------------------------------------------------------------------
+# _prefix_with_marker: prompt splicing
+
+
+def _engine():
+    return ClarinetEngine(CountingMockModel(), ClarinetByteTokenizer())
+
+
+def test_prefix_with_marker_when_bos_already_present():
+    eng = _engine()
+    tokens = [261, 100, 101, 102]  # [BOS, ...]
+    out = eng._prefix_with_marker(tokens, marker_id=262, bos_id=261)
+    assert out == [261, 262, 100, 101, 102]
+
+
+def test_prefix_with_marker_when_bos_missing():
+    eng = _engine()
+    tokens = [100, 101, 102]
+    out = eng._prefix_with_marker(tokens, marker_id=263, bos_id=261)
+    assert out == [261, 263, 100, 101, 102]
+
+
+def test_prefix_with_marker_does_not_mutate_input():
+    eng = _engine()
+    tokens = [261, 50]
+    snapshot = list(tokens)
+    eng._prefix_with_marker(tokens, marker_id=264, bos_id=261)
+    assert tokens == snapshot
+
+
+# -----------------------------------------------------------------------------
+# Dual-pass mechanics
+
+
+def _consume(generator, n):
+    for _ in range(n):
+        try:
+            next(generator)
+        except StopIteration:
+            break
+
+
+def test_two_caches_used_during_prefill():
+    model = CountingMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    prompt = [261, 72, 101, 108, 108, 111]  # <bos> Hello
+
+    gen = eng.generate(prompt, num_samples=1, max_tokens=1, temperature=0.0,
+                       iv_weight=1.0, wald_scale=1.0)
+    _consume(gen, 1)
+
+    # Prefill: 2 calls on the small prefill caches (one per condition).
+    # Decode step 1: 2 calls on the decode caches (one per condition).
+    # That's 4 forward calls total for max_tokens=1.
+    assert len(model.forward_calls) == 4, (
+        f"expected 4 forward calls (2 prefill + 2 decode), got {len(model.forward_calls)}"
+    )
+
+    # The 4 calls hit at most 4 distinct cache identities, and they come in
+    # cond/uncond pairs by construction. Specifically: 2 prefill caches (held
+    # briefly then deleted) and 2 decode caches.
+    cache_ids = [cid for cid, _ in model.forward_calls]
+    assert len(set(cache_ids)) >= 2, "engine should use more than one KV cache"
+
+
+def test_decode_caches_advance_in_lockstep():
+    model = CountingMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    prompt = [261, 72, 105]  # <bos> Hi
+
+    gen = eng.generate(prompt, num_samples=1, max_tokens=4, temperature=0.0,
+                       iv_weight=0.5, wald_scale=1.0)
+    _consume(gen, 4)
+
+    # Per decode step there are exactly 2 forward calls (one cond, one uncond),
+    # each consuming 1 token. After prefill (2 calls, each consuming len(prompt) tokens),
+    # we should see 2*max_tokens=8 single-token forward calls.
+    decode_calls = [(cid, T) for cid, T in model.forward_calls if T == 1]
+    assert len(decode_calls) == 2 * 4, (
+        f"expected 8 single-token decode forward calls (4 steps * 2 conditions), "
+        f"got {len(decode_calls)}"
+    )
+
+    # The decode forward calls should split evenly between two cache identities
+    from collections import Counter
+    counts = Counter(cid for cid, _ in decode_calls)
+    assert len(counts) == 2, f"expected exactly 2 distinct decode caches, got {len(counts)}"
+    assert all(c == 4 for c in counts.values()), (
+        f"each decode cache should see 4 advances, got {dict(counts)}"
+    )
+
+
+def test_generate_yields_max_tokens(monkeypatch):
+    model = CountingMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    prompt = [261, 72]
+
+    yielded = []
+    for token_col, _mask in eng.generate(prompt, num_samples=2, max_tokens=3,
+                                          temperature=0.0, iv_weight=1.5, wald_scale=1.0):
+        yielded.append(token_col)
+
+    # max_tokens=3 with non-terminating uniform logits → exactly 3 yields.
+    assert len(yielded) == 3
+    # Each yield is one token per sample (num_samples=2).
+    for col in yielded:
+        assert len(col) == 2
+
+
+def test_iv_weight_zero_matches_unconditional_only_sampling():
+    """
+    With iv_weight=0, the combined logits equal the unconditional logits.
+    Since the mock model returns identical (uniform) logits regardless of
+    cache, cond/uncond combine is a no-op and the run should complete cleanly.
+    This is mostly a smoke test that w=0 doesn't crash.
+    """
+    model = CountingMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    prompt = [261, 72, 105]
+    out = list(eng.generate(prompt, num_samples=1, max_tokens=2, temperature=0.0,
+                            iv_weight=0.0, wald_scale=1.0))
+    assert len(out) == 2

--- a/tests/test_clarinet_engine.py
+++ b/tests/test_clarinet_engine.py
@@ -123,6 +123,76 @@ def test_combine_wald_scale_multiplies_step():
 
 
 # -----------------------------------------------------------------------------
+# l1_adaptive_scale: content-adaptive guidance schedule
+
+
+def test_l1_scale_constant_when_lo_equals_hi():
+    # scale_lo == scale_hi short-circuits to a constant base_scale*scale_lo,
+    # regardless of the logits (no softmax, exact vanilla-CFG behavior).
+    lc = torch.tensor([[1.0, 5.0, -3.0, 0.0]])
+    lu = torch.tensor([[-2.0, 0.0, 4.0, 1.0]])
+    s = ClarinetEngine.l1_adaptive_scale(lc, lu, base_scale=1.5, scale_lo=1.0, scale_hi=1.0)
+    assert s == 1.5
+
+
+def test_l1_scale_zero_divergence_hits_floor():
+    # Identical distributions => TV distance 0 => s == base_scale * scale_lo.
+    lc = torch.tensor([[1.0, 2.0, 3.0]])
+    lu = torch.tensor([[1.0, 2.0, 3.0]])
+    s = ClarinetEngine.l1_adaptive_scale(lc, lu, base_scale=2.0, scale_lo=0.5, scale_hi=2.0)
+    assert torch.allclose(s, torch.tensor([[1.0]]))  # 2.0 * 0.5
+
+
+def test_l1_scale_max_divergence_hits_ceiling():
+    # Disjoint support => TV distance ~1 => s ~ base_scale * scale_hi.
+    big = 50.0
+    lc = torch.tensor([[big, -big]])
+    lu = torch.tensor([[-big, big]])
+    s = ClarinetEngine.l1_adaptive_scale(lc, lu, base_scale=1.0, scale_lo=0.5, scale_hi=2.0)
+    assert torch.allclose(s, torch.tensor([[2.0]]), atol=1e-4)
+
+
+def test_l1_scale_monotone_and_bounded():
+    # As divergence grows, s grows monotonically and stays within
+    # [base*lo, base*hi]. Build three cond logits at increasing distance from a
+    # fixed uncond.
+    lu = torch.tensor([[0.0, 0.0, 0.0, 0.0]])
+    near = torch.tensor([[0.1, 0.0, 0.0, 0.0]])
+    mid = torch.tensor([[2.0, 0.0, 0.0, 0.0]])
+    far = torch.tensor([[20.0, 0.0, 0.0, 0.0]])
+    lo, hi, base = 0.5, 2.0, 1.0
+    f = lambda lc: ClarinetEngine.l1_adaptive_scale(lc, lu, base, lo, hi).item()
+    s_near, s_mid, s_far = f(near), f(mid), f(far)
+    assert s_near < s_mid < s_far
+    assert base * lo <= s_near and s_far <= base * hi
+
+
+def test_l1_scale_is_per_row():
+    # Row 0 identical (floor), row 1 disjoint (ceiling): scale is per-row.
+    big = 50.0
+    lc = torch.tensor([[1.0, 2.0], [big, -big]])
+    lu = torch.tensor([[1.0, 2.0], [-big, big]])
+    s = ClarinetEngine.l1_adaptive_scale(lc, lu, base_scale=1.0, scale_lo=0.5, scale_hi=2.0)
+    assert s.shape == (2, 1)
+    assert torch.allclose(s[0], torch.tensor([0.5]), atol=1e-4)
+    assert torch.allclose(s[1], torch.tensor([2.0]), atol=1e-4)
+
+
+def test_generate_with_adaptive_scale_smoke():
+    # End-to-end: enabling the adaptive schedule doesn't crash and still yields
+    # max_tokens tokens. (Mock model returns uniform logits so divergence is 0,
+    # i.e. the schedule sits at its floor, but the code path is exercised.)
+    model = CountingMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    prompt = [261, 72, 105]
+    out = list(eng.generate(prompt, num_samples=2, max_tokens=3, temperature=0.0,
+                            iv_weight=2.0, wald_scale=1.0, scale_lo=0.5, scale_hi=2.0))
+    assert len(out) == 3
+    for col in out:
+        assert len(col) == 2
+
+
+# -----------------------------------------------------------------------------
 # _prefix_with_marker: prompt splicing
 
 

--- a/tests/test_clarinet_engine.py
+++ b/tests/test_clarinet_engine.py
@@ -298,3 +298,116 @@ def test_iv_weight_zero_matches_unconditional_only_sampling():
     out = list(eng.generate(prompt, num_samples=1, max_tokens=2, temperature=0.0,
                             iv_weight=0.0, wald_scale=1.0))
     assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# categorical_logits_at: batch forward with IV combine for categorical eval
+
+
+class PositionAwareMockModel:
+    """
+    Returns logits that depend on position AND the marker token at index 1,
+    so we can verify both position extraction and dual-pass combination.
+
+    - If marker at index 1 is <|src_reasoning|> (262): logit at pos t = t + 1.0
+    - If marker at index 1 is <|src_unknown|> (264): logit at pos t = 0.0
+    - Otherwise (base Engine path): logit at pos t = t + 1.0
+    """
+
+    def __init__(self, vocab_size=8):
+        self.vocab_size = vocab_size
+        self.config = MockConfig()
+        self._device = torch.device("cpu")
+        self.forward_count = 0
+
+    def get_device(self):
+        return self._device
+
+    def forward(self, ids, kv_cache=None):
+        B, T = ids.shape
+        self.forward_count += 1
+        logits = torch.zeros(B, T, self.vocab_size)
+        for b in range(B):
+            if T > 1 and ids[b, 1].item() == 262:  # reasoning marker
+                for t in range(T):
+                    logits[b, t, :] = float(t + 1)
+            elif T > 1 and ids[b, 1].item() == 264:  # unknown marker
+                pass  # zeros
+            else:
+                # Base engine path (no marker): position-based logits
+                for t in range(T):
+                    logits[b, t, :] = float(t + 1)
+        return logits
+
+
+def test_base_engine_categorical_logits_at():
+    """Engine.categorical_logits_at extracts logits at the correct positions."""
+    from nanochat.engine import Engine
+    model = PositionAwareMockModel()
+    eng = Engine(model, ClarinetByteTokenizer())
+    # Two sequences of different lengths
+    seq1 = [261, 10, 20, 30]       # answer at position 3
+    seq2 = [261, 10, 20, 30, 40]   # answer at position 4
+    logits = eng.categorical_logits_at([seq1, seq2], [3, 4])
+    assert logits.shape == (2, model.vocab_size)
+    # Position 3 -> value 4.0 (t+1), Position 4 -> value 5.0
+    assert torch.allclose(logits[0], torch.full((model.vocab_size,), 4.0))
+    assert torch.allclose(logits[1], torch.full((model.vocab_size,), 5.0))
+
+
+def test_categorical_logits_at_dual_pass_combine():
+    """ClarinetEngine.categorical_logits_at applies dual-pass IV combine."""
+    model = PositionAwareMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    # Input: [BOS, t1, t2] — BOS present, marker inserts at pos 1 -> offset +1
+    # After marker: [BOS, marker, t1, t2] — answer originally at pos 2, now at 3
+    seq = [261, 10, 20]  # answer at position 2 (last position)
+    logits = eng.categorical_logits_at([seq], [2], iv_weight=2.0, wald_scale=1.0)
+    assert logits.shape == (1, model.vocab_size)
+    # Adjusted position 3: cond = 4.0 (3+1), uncond = 0.0
+    # combine: 0.0 + 2.0 * 1.0 * (4.0 - 0.0) = 8.0
+    assert torch.allclose(logits, torch.full((1, model.vocab_size), 8.0))
+
+
+def test_categorical_logits_at_w_zero_recovers_uncond():
+    """iv_weight=0 returns the unconditional logits (zeros from unknown marker)."""
+    model = PositionAwareMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    seq = [261, 10, 20]
+    logits = eng.categorical_logits_at([seq], [2], iv_weight=0.0, wald_scale=1.0)
+    assert torch.allclose(logits, torch.zeros(1, model.vocab_size))
+
+
+def test_categorical_logits_at_w_one_recovers_cond():
+    """iv_weight=1, wald_scale=1 returns the conditional logits exactly."""
+    model = PositionAwareMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    seq = [261, 10, 20]
+    logits = eng.categorical_logits_at([seq], [2], iv_weight=1.0, wald_scale=1.0)
+    # Adjusted position 3: cond = 4.0
+    assert torch.allclose(logits, torch.full((1, model.vocab_size), 4.0))
+
+
+def test_categorical_logits_at_issues_two_forwards():
+    """Verifies exactly two forward calls (cond + uncond) per batch."""
+    model = PositionAwareMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    seq = [261, 10, 20]
+    eng.categorical_logits_at([seq], [2], iv_weight=1.5, wald_scale=1.0)
+    assert model.forward_count == 2
+
+
+def test_categorical_logits_at_multi_element_batch():
+    """Dual-pass works correctly with multiple sequences of different lengths."""
+    model = PositionAwareMockModel()
+    eng = ClarinetEngine(model, ClarinetByteTokenizer())
+    seq1 = [261, 10, 20]           # answer at pos 2, adjusted to 3
+    seq2 = [261, 10, 20, 30, 40]   # answer at pos 4, adjusted to 5
+    logits = eng.categorical_logits_at(
+        [seq1, seq2], [2, 4], iv_weight=1.5, wald_scale=1.0
+    )
+    assert logits.shape == (2, model.vocab_size)
+    # seq1: cond@3 = 4.0, uncond@3 = 0.0 -> 0 + 1.5*(4-0) = 6.0
+    # seq2: cond@5 = 6.0, uncond@5 = 0.0 -> 0 + 1.5*(6-0) = 9.0
+    assert torch.allclose(logits[0], torch.full((model.vocab_size,), 6.0))
+    assert torch.allclose(logits[1], torch.full((model.vocab_size,), 9.0))

--- a/tests/test_clarinet_engine.py
+++ b/tests/test_clarinet_engine.py
@@ -156,33 +156,21 @@ def test_prefix_with_marker_does_not_mutate_input():
 # Dual-pass mechanics
 
 
-def _consume(generator, n):
-    for _ in range(n):
-        try:
-            next(generator)
-        except StopIteration:
-            break
-
-
 def test_two_caches_used_during_prefill():
     model = CountingMockModel()
     eng = ClarinetEngine(model, ClarinetByteTokenizer())
     prompt = [261, 72, 101, 108, 108, 111]  # <bos> Hello
 
-    gen = eng.generate(prompt, num_samples=1, max_tokens=1, temperature=0.0,
-                       iv_weight=1.0, wald_scale=1.0)
-    _consume(gen, 1)
+    # list() drives the generator to StopIteration. After the single yield at
+    # max_tokens=1, the engine still runs one post-yield decode forward (to
+    # prepare logits for what would be the next step) before the loop breaks.
+    list(eng.generate(prompt, num_samples=1, max_tokens=1, temperature=0.0,
+                      iv_weight=1.0, wald_scale=1.0))
 
-    # Prefill: 2 calls on the small prefill caches (one per condition).
-    # Decode step 1: 2 calls on the decode caches (one per condition).
-    # That's 4 forward calls total for max_tokens=1.
+    # 2 prefill forwards (one per condition) + 2 post-yield decode forwards = 4.
     assert len(model.forward_calls) == 4, (
         f"expected 4 forward calls (2 prefill + 2 decode), got {len(model.forward_calls)}"
     )
-
-    # The 4 calls hit at most 4 distinct cache identities, and they come in
-    # cond/uncond pairs by construction. Specifically: 2 prefill caches (held
-    # briefly then deleted) and 2 decode caches.
     cache_ids = [cid for cid, _ in model.forward_calls]
     assert len(set(cache_ids)) >= 2, "engine should use more than one KV cache"
 
@@ -192,20 +180,16 @@ def test_decode_caches_advance_in_lockstep():
     eng = ClarinetEngine(model, ClarinetByteTokenizer())
     prompt = [261, 72, 105]  # <bos> Hi
 
-    gen = eng.generate(prompt, num_samples=1, max_tokens=4, temperature=0.0,
-                       iv_weight=0.5, wald_scale=1.0)
-    _consume(gen, 4)
+    list(eng.generate(prompt, num_samples=1, max_tokens=4, temperature=0.0,
+                      iv_weight=0.5, wald_scale=1.0))
 
-    # Per decode step there are exactly 2 forward calls (one cond, one uncond),
-    # each consuming 1 token. After prefill (2 calls, each consuming len(prompt) tokens),
-    # we should see 2*max_tokens=8 single-token forward calls.
+    # 4 yields → 4 post-yield decode steps → 2*4 single-token forwards.
     decode_calls = [(cid, T) for cid, T in model.forward_calls if T == 1]
     assert len(decode_calls) == 2 * 4, (
         f"expected 8 single-token decode forward calls (4 steps * 2 conditions), "
         f"got {len(decode_calls)}"
     )
 
-    # The decode forward calls should split evenly between two cache identities
     from collections import Counter
     counts = Counter(cid for cid, _ in decode_calls)
     assert len(counts) == 2, f"expected exactly 2 distinct decode caches, got {len(counts)}"

--- a/uv.lock
+++ b/uv.lock
@@ -2,31 +2,31 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 conflicts = [[
-    { package = "nanochat", extra = "cpu" },
-    { package = "nanochat", extra = "gpu" },
+    { package = "clarinet", extra = "cpu" },
+    { package = "clarinet", extra = "gpu" },
 ]]
 
 [[package]]
@@ -45,7 +45,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
-    { name = "async-timeout", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "async-timeout", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
@@ -130,7 +130,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -151,10 +151,10 @@ name = "anyio"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
@@ -211,7 +211,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -353,11 +353,77 @@ wheels = [
 ]
 
 [[package]]
+name = "clarinet"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "datasets" },
+    { name = "fastapi" },
+    { name = "kernels" },
+    { name = "psutil" },
+    { name = "rustbpe" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu')" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-clarinet-gpu'" },
+    { name = "uvicorn" },
+    { name = "wandb" },
+]
+
+[package.optional-dependencies]
+cpu = [
+    { name = "setuptools" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+]
+gpu = [
+    { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipykernel" },
+    { name = "matplotlib" },
+    { name = "pytest" },
+    { name = "python-dotenv" },
+    { name = "transformers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "datasets", specifier = ">=4.0.0" },
+    { name = "fastapi", specifier = ">=0.117.1" },
+    { name = "kernels", specifier = ">=0.11.7" },
+    { name = "psutil", specifier = ">=7.1.0" },
+    { name = "rustbpe", specifier = ">=0.1.0" },
+    { name = "setuptools", marker = "extra == 'cpu'", specifier = ">=65.0.0" },
+    { name = "tiktoken", specifier = ">=0.11.0" },
+    { name = "tokenizers", specifier = ">=0.22.0" },
+    { name = "torch", specifier = "==2.9.1" },
+    { name = "torch", marker = "extra == 'cpu'", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "clarinet", extra = "cpu" } },
+    { name = "torch", marker = "extra == 'gpu'", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "clarinet", extra = "gpu" } },
+    { name = "uvicorn", specifier = ">=0.36.0" },
+    { name = "wandb", specifier = ">=0.21.3" },
+]
+provides-extras = ["cpu", "gpu"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipykernel", specifier = ">=7.1.0" },
+    { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "transformers", specifier = ">=4.57.3" },
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -387,16 +453,16 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "numpy", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -463,23 +529,23 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "numpy", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -641,7 +707,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -900,7 +966,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -935,11 +1001,11 @@ name = "ipykernel"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "ipython", version = "9.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "ipython", version = "9.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -960,26 +1026,26 @@ name = "ipython"
 version = "8.37.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform != 'win32' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'emscripten' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'win32' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "colorama", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version >= '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform != 'win32' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "decorator", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "jedi", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "pexpect", marker = "(python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version >= '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'emscripten' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'win32' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "stack-data", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "traitlets", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -991,33 +1057,33 @@ name = "ipython"
 version = "9.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform != 'win32' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "decorator", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'emscripten' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'win32' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform != 'win32' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "decorator", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "jedi", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "pexpect", marker = "(python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version < '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'emscripten' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'win32' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "stack-data", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/51/a703c030f4928646d390b4971af4938a1b10c9dfce694f0d99a0bb073cb2/ipython-9.8.0.tar.gz", hash = "sha256:8e4ce129a627eb9dd221c41b1d2cdaed4ef7c9da8c17c63f6f578fe231141f83", size = 4424940, upload-time = "2025-12-03T10:18:24.353Z" }
 wheels = [
@@ -1029,7 +1095,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1097,7 +1163,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/c8/2d4fea16366d34069af6d4c4f61218f55e5d0daea5d4c24d58849e9fd626/kernels-0.11.7.tar.gz", hash = "sha256:99c3aa518965518902f4dc26053d6051f06abc904ae33d9486c28674a2ea0fa5", size = 50282, upload-time = "2026-01-08T15:41:57.383Z" }
 wheels = [
@@ -1275,8 +1341,8 @@ name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
@@ -1370,7 +1436,7 @@ name = "multidict"
 version = "6.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/7f/0652e6ed47ab288e3756ea9c0df8b14950781184d4bd7883f4d87dd41245/multidict-6.6.4.tar.gz", hash = "sha256:d2d4e4787672911b48350df02ed3fa3fffdc2f2e8ca06dd6afdf34189b76a9dd", size = 101843, upload-time = "2025-08-11T12:08:48.217Z" }
 wheels = [
@@ -1486,72 +1552,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nanochat"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "kernels" },
-    { name = "psutil" },
-    { name = "rustbpe" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
-    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-nanochat-gpu'" },
-    { name = "uvicorn" },
-    { name = "wandb" },
-]
-
-[package.optional-dependencies]
-cpu = [
-    { name = "setuptools" },
-    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-]
-gpu = [
-    { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "ipykernel" },
-    { name = "matplotlib" },
-    { name = "pytest" },
-    { name = "python-dotenv" },
-    { name = "transformers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "datasets", specifier = ">=4.0.0" },
-    { name = "fastapi", specifier = ">=0.117.1" },
-    { name = "kernels", specifier = ">=0.11.7" },
-    { name = "psutil", specifier = ">=7.1.0" },
-    { name = "rustbpe", specifier = ">=0.1.0" },
-    { name = "setuptools", marker = "extra == 'cpu'", specifier = ">=65.0.0" },
-    { name = "tiktoken", specifier = ">=0.11.0" },
-    { name = "tokenizers", specifier = ">=0.22.0" },
-    { name = "torch", specifier = "==2.9.1" },
-    { name = "torch", marker = "extra == 'cpu'", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "nanochat", extra = "cpu" } },
-    { name = "torch", marker = "extra == 'gpu'", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "nanochat", extra = "gpu" } },
-    { name = "uvicorn", specifier = ">=0.36.0" },
-    { name = "wandb", specifier = ">=0.21.3" },
-]
-provides-extras = ["cpu", "gpu"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "ipykernel", specifier = ">=7.1.0" },
-    { name = "matplotlib", specifier = ">=3.10.8" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "transformers", specifier = ">=4.57.3" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1565,13 +1565,13 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -1583,20 +1583,20 @@ name = "networkx"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version >= '3.12' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -1680,7 +1680,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -1693,7 +1693,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -1725,9 +1725,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
+    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -1740,7 +1740,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -2316,13 +2316,13 @@ name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -2408,7 +2408,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -2702,7 +2702,7 @@ version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
@@ -2831,23 +2831,23 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (python_full_version >= '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (python_full_version < '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (python_full_version < '3.12' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (python_full_version >= '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (python_full_version < '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (python_full_version < '3.12' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:bf1e68cfb935ae2046374ff02a7aa73dda70351b46342846f557055b3a540bf0" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:a52952a8c90a422c14627ea99b9826b7557203b46b4d0772d3ca5c7699692425" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:287242dd1f830846098b5eca847f817aa5c6015ea57ab4c1287809efea7b77eb" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8924d10d36eac8fe0652a060a03fc2ae52980841850b9a1a2ddb0f27a4f181cd" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:bcee64ae7aa65876ceeae6dcaebe75109485b213528c74939602208a20706e3f" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:defadbeb055cfcf5def58f70937145aecbd7a4bc295238ded1d0e85ae2cf0e1d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:886f84b181f766f53265ba0a1d503011e60f53fff9d569563ef94f24160e1072" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:bf1e68cfb935ae2046374ff02a7aa73dda70351b46342846f557055b3a540bf0", upload-time = "2026-01-23T15:12:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:a52952a8c90a422c14627ea99b9826b7557203b46b4d0772d3ca5c7699692425", upload-time = "2026-01-23T15:12:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:287242dd1f830846098b5eca847f817aa5c6015ea57ab4c1287809efea7b77eb", upload-time = "2026-01-23T15:12:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8924d10d36eac8fe0652a060a03fc2ae52980841850b9a1a2ddb0f27a4f181cd", upload-time = "2026-01-23T15:12:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:bcee64ae7aa65876ceeae6dcaebe75109485b213528c74939602208a20706e3f", upload-time = "2026-01-23T15:12:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:defadbeb055cfcf5def58f70937145aecbd7a4bc295238ded1d0e85ae2cf0e1d", upload-time = "2026-01-23T15:12:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:886f84b181f766f53265ba0a1d503011e60f53fff9d569563ef94f24160e1072", upload-time = "2026-01-23T15:12:50Z" },
 ]
 
 [[package]]
@@ -2863,14 +2863,30 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
-    { name = "fsspec", marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
-    { name = "jinja2", marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "sympy", marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
-    { name = "typing-extensions", marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
+    { name = "filelock", marker = "(extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu')" },
+    { name = "fsspec", marker = "(extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu')" },
+    { name = "jinja2", marker = "(extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "sympy", marker = "(extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu')" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "(extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (extra != 'extra-8-clarinet-cpu' and extra != 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/56/9577683b23072075ed2e40d725c52c2019d71a972fab8e083763da8e707e/torch-2.9.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:1cc208435f6c379f9b8fdfd5ceb5be1e3b72a6bdf1cb46c0d2812aa73472db9e", size = 104207681, upload-time = "2025-11-12T15:19:56.48Z" },
@@ -2916,40 +2932,40 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (python_full_version >= '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (python_full_version < '3.11' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (python_full_version < '3.12' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (python_full_version >= '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (python_full_version < '3.11' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (python_full_version < '3.12' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu') or (sys_platform == 'darwin' and extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:10866c8a48c4aa5ae3f48538dc8a055b99c57d9c6af2bf5dd715374d9d6ddca3" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7210713b66943fdbfcc237b2e782871b649123ac5d29f548ce8c85be4223ab38" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:d6e8441453dc27524e3f1037fbf27b90a02644b84e42944b9354b4024cb51cc1" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0e611cfb16724e62252b67d31073bc5c490cb83e92ecdc1192762535e0e44487" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3de2adb9b4443dc9210ef1f1b16da3647ace53553166d6360bbbd7edd6f16e4d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:69b3785d28be5a9c56ab525788ec5000349ec59132a74b7d5e954b905015b992" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:15b4ae6fe371d96bffb8e1e9af62164797db20a0dc1337345781659cfd0b8bb1" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3bf9b442a51a2948e41216a76d7ab00f0694cfcaaa51b6f9bcab57b7f89843e6" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7417d8c565f219d3455654cb431c6d892a3eb40246055e14d645422de13b9ea1" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a4e06b4f441675d26b462123c8a83e77c55f1ec8ebc081203be2db1ea8054add" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:1abe31f14b560c1f062699e966cb08ef5b67518a1cfac2d8547a3dbcd8387b06" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3e532e553b37ee859205a9b2d1c7977fd6922f53bbb1b9bfdd5bdc00d1a60ed4" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:39b3dff6d8fba240ae0d1bede4ca11c2531ae3b47329206512d99e17907ff74b" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:404a7ab2fffaf2ca069e662f331eb46313692b2f1630df2720094284f390ccef" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:161decbff26a33f13cb5ba6d2c8f458bbf56193bcc32ecc70be6dd4c7a3ee79d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:01b1884f724977a20c7da2f640f1c7b37f4a2c117a7f4a6c1c0424d14cb86322" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:031a597147fa81b1e6d79ccf1ad3ccc7fafa27941d6cf26ff5caaa384fb20e92" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:e586ab1363e3f86aa4cc133b7fdcf98deb1d2c13d43a7a6e5a6a18e9c5364893" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:65010ab4aacce6c9a1ddfc935f986c003ca8638ded04348fd326c3e74346237c" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:88adf5157db5da1d54b1c9fe4a6c1d20ceef00e75d854e206a87dbf69e3037dc" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:f60e2565f261542efac07e25208fb3fc55c6fe82314a5a9cbee971edb5f27713" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3ac2b8df2c55430e836dcda31940d47f1f5f94b8731057b6f20300ebea394dd9" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:5b688445f928f13563b7418b17c57e97bf955ab559cf73cd8f2b961f8572dbb3" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:cf9c3e50b595721ca6b488bdcc326e0f1af73ed28b9b66eff504a96649bb5c96" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:10866c8a48c4aa5ae3f48538dc8a055b99c57d9c6af2bf5dd715374d9d6ddca3", upload-time = "2026-01-23T15:12:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7210713b66943fdbfcc237b2e782871b649123ac5d29f548ce8c85be4223ab38", upload-time = "2026-01-23T15:12:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:d6e8441453dc27524e3f1037fbf27b90a02644b84e42944b9354b4024cb51cc1", upload-time = "2026-01-23T15:12:53Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0e611cfb16724e62252b67d31073bc5c490cb83e92ecdc1192762535e0e44487", upload-time = "2026-01-23T15:12:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3de2adb9b4443dc9210ef1f1b16da3647ace53553166d6360bbbd7edd6f16e4d", upload-time = "2026-01-23T15:12:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:69b3785d28be5a9c56ab525788ec5000349ec59132a74b7d5e954b905015b992", upload-time = "2026-01-23T15:12:59Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:15b4ae6fe371d96bffb8e1e9af62164797db20a0dc1337345781659cfd0b8bb1", upload-time = "2026-01-23T15:13:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3bf9b442a51a2948e41216a76d7ab00f0694cfcaaa51b6f9bcab57b7f89843e6", upload-time = "2026-01-23T15:13:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7417d8c565f219d3455654cb431c6d892a3eb40246055e14d645422de13b9ea1", upload-time = "2026-01-23T15:13:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a4e06b4f441675d26b462123c8a83e77c55f1ec8ebc081203be2db1ea8054add", upload-time = "2026-01-23T15:13:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:1abe31f14b560c1f062699e966cb08ef5b67518a1cfac2d8547a3dbcd8387b06", upload-time = "2026-01-23T15:13:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3e532e553b37ee859205a9b2d1c7977fd6922f53bbb1b9bfdd5bdc00d1a60ed4", upload-time = "2026-01-23T15:13:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:39b3dff6d8fba240ae0d1bede4ca11c2531ae3b47329206512d99e17907ff74b", upload-time = "2026-01-23T15:13:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:404a7ab2fffaf2ca069e662f331eb46313692b2f1630df2720094284f390ccef", upload-time = "2026-01-23T15:13:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:161decbff26a33f13cb5ba6d2c8f458bbf56193bcc32ecc70be6dd4c7a3ee79d", upload-time = "2026-01-23T15:13:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:01b1884f724977a20c7da2f640f1c7b37f4a2c117a7f4a6c1c0424d14cb86322", upload-time = "2026-01-23T15:13:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:031a597147fa81b1e6d79ccf1ad3ccc7fafa27941d6cf26ff5caaa384fb20e92", upload-time = "2026-01-23T15:13:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:e586ab1363e3f86aa4cc133b7fdcf98deb1d2c13d43a7a6e5a6a18e9c5364893", upload-time = "2026-01-23T15:13:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:65010ab4aacce6c9a1ddfc935f986c003ca8638ded04348fd326c3e74346237c", upload-time = "2026-01-23T15:13:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:88adf5157db5da1d54b1c9fe4a6c1d20ceef00e75d854e206a87dbf69e3037dc", upload-time = "2026-01-23T15:13:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:f60e2565f261542efac07e25208fb3fc55c6fe82314a5a9cbee971edb5f27713", upload-time = "2026-01-23T15:13:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3ac2b8df2c55430e836dcda31940d47f1f5f94b8731057b6f20300ebea394dd9", upload-time = "2026-01-23T15:13:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:5b688445f928f13563b7418b17c57e97bf955ab559cf73cd8f2b961f8572dbb3", upload-time = "2026-01-23T15:13:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:cf9c3e50b595721ca6b488bdcc326e0f1af73ed28b9b66eff504a96649bb5c96", upload-time = "2026-01-23T15:13:32Z" },
 ]
 
 [[package]]
@@ -2965,53 +2981,53 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "extra == 'extra-8-nanochat-gpu'" },
-    { name = "fsspec", marker = "extra == 'extra-8-nanochat-gpu'" },
-    { name = "jinja2", marker = "extra == 'extra-8-nanochat-gpu'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "sympy", marker = "extra == 'extra-8-nanochat-gpu'" },
-    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-8-nanochat-gpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
-    { name = "typing-extensions", marker = "extra == 'extra-8-nanochat-gpu'" },
+    { name = "filelock", marker = "extra == 'extra-8-clarinet-gpu'" },
+    { name = "fsspec", marker = "extra == 'extra-8-clarinet-gpu'" },
+    { name = "jinja2", marker = "extra == 'extra-8-clarinet-gpu'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "sympy", marker = "extra == 'extra-8-clarinet-gpu'" },
+    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-8-clarinet-gpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-clarinet-gpu'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:72f0f096475e8095a6bea3fba75bd3b46cf42c761b29588f7599314e67a32661" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c8d670aa0be6fbecd2b0e7b7d514a104dbdefcc3786ca446cf0c3415043ea40a" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:64399adaa8ea0896d02cf844cba3c5dd77e769520a1af73572599e0eaa2cf551" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cf4ad82430824a80a9f398e29369524ed26c152cf00c2c12002e5400b35e260d" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:2a1da940f0757621d098c9755f7504d791a72a40920ec85a4fd98b20253fca4e" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:633005a3700e81b5be0df2a7d3c1d48aced23ed927653797a3bd2b144a3aeeb6" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1176f250311fa95cc3bca8077af323e0d73ea385ba266e096af82e7e2b91f256" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7cb4018f4ce68b61fd3ef87dc1c4ca520731c7b5b200e360ad47b612d7844063" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:3a01f0b64c10a82d444d9fd06b3e8c567b1158b76b2764b8f51bfd8f535064b0" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0b80b7555dcd0a75b7b06016991f01281a0bb078cf28fa2d1dfb949fad2fbd07" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:63381a109a569b280ed3319da89d3afe5cf9ab5c879936382a212affb5c90552" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:ad9183864acdd99fc5143d7ca9d3d2e7ddfc9a9600ff43217825d4e5e9855ccc" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2314521c74d76e513c53bb72c0ce3511ef0295ff657a432790df6c207e5d7962" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4454a4faca31af81566e3a4208f10f20b8a6d9cfe42791b0ca7ff134326468fc" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:24420e430e77136f7079354134b34e7ba9d87e539f5ac84c33b08e5c13412ebe" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32c036296c557f19a1537ce981c40533650097114e1720a321a39a3b08d9df56" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:7788d3d03d939cf00f93ac0da5ab520846f66411e339cfbf519a806e8facf519" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:7bcd40cbffac475b478d6ce812f03da84e9a4894956efb89c3b7bcca5dbd4f91" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e88c78e5b08ae9303aa15da43b68b44287ecbec16d898d9fad6998832fe626a5" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7d8769bdf3200ca16a92f14df404c3370171ac3732996528a8973d753eac562f" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:0c784b600959ec70ee01cb23e8bc870a0e0475af30378ff5e39f4abed8b7c1cc" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:72f0f096475e8095a6bea3fba75bd3b46cf42c761b29588f7599314e67a32661", upload-time = "2026-01-26T16:53:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c8d670aa0be6fbecd2b0e7b7d514a104dbdefcc3786ca446cf0c3415043ea40a", upload-time = "2026-01-26T16:53:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:64399adaa8ea0896d02cf844cba3c5dd77e769520a1af73572599e0eaa2cf551", upload-time = "2026-01-26T16:53:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cf4ad82430824a80a9f398e29369524ed26c152cf00c2c12002e5400b35e260d", upload-time = "2026-01-26T16:53:53Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:2a1da940f0757621d098c9755f7504d791a72a40920ec85a4fd98b20253fca4e", upload-time = "2026-01-26T16:53:57Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:633005a3700e81b5be0df2a7d3c1d48aced23ed927653797a3bd2b144a3aeeb6", upload-time = "2026-01-26T16:54:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1176f250311fa95cc3bca8077af323e0d73ea385ba266e096af82e7e2b91f256", upload-time = "2026-01-26T16:54:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7cb4018f4ce68b61fd3ef87dc1c4ca520731c7b5b200e360ad47b612d7844063", upload-time = "2026-01-26T16:54:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:3a01f0b64c10a82d444d9fd06b3e8c567b1158b76b2764b8f51bfd8f535064b0", upload-time = "2026-01-26T16:54:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0b80b7555dcd0a75b7b06016991f01281a0bb078cf28fa2d1dfb949fad2fbd07", upload-time = "2026-01-26T16:54:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:63381a109a569b280ed3319da89d3afe5cf9ab5c879936382a212affb5c90552", upload-time = "2026-01-26T16:54:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:ad9183864acdd99fc5143d7ca9d3d2e7ddfc9a9600ff43217825d4e5e9855ccc", upload-time = "2026-01-26T16:55:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2314521c74d76e513c53bb72c0ce3511ef0295ff657a432790df6c207e5d7962", upload-time = "2026-01-26T16:55:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4454a4faca31af81566e3a4208f10f20b8a6d9cfe42791b0ca7ff134326468fc", upload-time = "2026-01-26T16:55:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:24420e430e77136f7079354134b34e7ba9d87e539f5ac84c33b08e5c13412ebe", upload-time = "2026-01-26T16:55:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32c036296c557f19a1537ce981c40533650097114e1720a321a39a3b08d9df56", upload-time = "2026-01-26T16:55:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:7788d3d03d939cf00f93ac0da5ab520846f66411e339cfbf519a806e8facf519", upload-time = "2026-01-26T16:56:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:7bcd40cbffac475b478d6ce812f03da84e9a4894956efb89c3b7bcca5dbd4f91", upload-time = "2026-01-26T16:56:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e88c78e5b08ae9303aa15da43b68b44287ecbec16d898d9fad6998832fe626a5", upload-time = "2026-01-26T16:56:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7d8769bdf3200ca16a92f14df404c3370171ac3732996528a8973d753eac562f", upload-time = "2026-01-26T16:56:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.9.1%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:0c784b600959ec70ee01cb23e8bc870a0e0475af30378ff5e39f4abed8b7c1cc", upload-time = "2026-01-26T16:56:38Z" },
 ]
 
 [[package]]
@@ -3038,7 +3054,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
@@ -3142,7 +3158,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/5e/f0cd46063a02fd8515f0e880c37d2657845b7306c16ce6c4ffc44afd9036/uvicorn-0.36.0.tar.gz", hash = "sha256:527dc68d77819919d90a6b267be55f0e76704dca829d34aea9480be831a9b9d9", size = 80032, upload-time = "2025-09-20T01:07:14.418Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -633,12 +633,13 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "4.0.0"
+version = "4.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
     { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
     { name = "numpy" },
@@ -650,9 +651,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/9d/348ed92110ba5f9b70b51ca1078d4809767a835aa2b7ce7e74ad2b98323d/datasets-4.0.0.tar.gz", hash = "sha256:9657e7140a9050db13443ba21cb5de185af8af944479b00e7ff1e00a61c8dbf1", size = 569566, upload-time = "2025-07-09T14:35:52.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/34/14cd8e76f907f7d4dca2334cfeec9f81d30fd15c25a015f99aaea694eaed/datasets-4.8.5.tar.gz", hash = "sha256:0f0c1c3d56ffff2c93b2f4c63c95bac94f3d7e8621aea2a2a576275233bba772", size = 605649, upload-time = "2026-04-27T15:43:57.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/62/eb8157afb21bd229c864521c1ab4fa8e9b4f1b06bafdd8c4668a7a31b5dd/datasets-4.0.0-py3-none-any.whl", hash = "sha256:7ef95e62025fd122882dbce6cb904c8cd3fbc829de6669a5eb939c77d50e203d", size = 494825, upload-time = "2025-07-09T14:35:50.658Z" },
+    { url = "https://files.pythonhosted.org/packages/65/99/00f3196036501b53032c4b1ab8337a0b978dee832ed276dae3815df4e8b5/datasets-4.8.5-py3-none-any.whl", hash = "sha256:5079900781719c0e063a8efdd2cd95a31ad0c63209178669cd23cf1b926149ff", size = 528973, upload-time = "2026-04-27T15:43:53.702Z" },
 ]
 
 [[package]]
@@ -707,7 +708,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -957,6 +958,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/3c/28cc4db153a7601a996985bcb564f7b8f5b9e1a706c7537aad4b4809f358/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ad1022e9a998e784c97b2173965d07fe33ee26e4594770b7785a8cc8f922cd95", size = 3251429, upload-time = "2025-08-27T23:05:16.471Z" },
     { url = "https://files.pythonhosted.org/packages/84/17/7caf27a1d101bfcb05be85850d4aa0a265b2e1acc2d4d52a48026ef1d299/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86754c2d6d5afb11b0a435e6e18911a4199262fe77553f8c50d75e21242193ea", size = 3354643, upload-time = "2025-08-27T23:05:17.828Z" },
     { url = "https://files.pythonhosted.org/packages/cd/50/0c39c9eed3411deadcc98749a6699d871b822473f55fe472fad7c01ec588/hf_xet-1.1.9-cp37-abi3-win_amd64.whl", hash = "sha256:5aad3933de6b725d61d51034e04174ed1dce7a57c63d530df0014dea15a40127", size = 2804797, upload-time = "2025-08-27T23:05:20.77Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1680,7 +1709,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -1693,7 +1722,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -1725,9 +1754,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
-    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -1740,7 +1769,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-clarinet-gpu' or extra != 'extra-8-clarinet-cpu'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra != 'extra-8-clarinet-cpu') or (extra == 'extra-8-clarinet-cpu' and extra == 'extra-8-clarinet-gpu')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },


### PR DESCRIPTION
## Summary
- **Bug**: `run_categorical_eval` called `model(prompt_ids)` directly, completely bypassing the engine. ARC, ARC-Challenge, and MMLU produced identical results at every guidance weight during `iv_eval` sweeps — the dual-pass IV mechanism was never applied to categorical tasks (3 of 6 default sweep tasks).
- **Fix**: Add `Engine.categorical_logits_at()` (pad → forward → extract at answer positions) with a `ClarinetEngine` override that inserts source markers, adjusts positions for the offset, runs cond/uncond forward passes, and combines via the IV formula. Route `run_categorical_eval` through the engine.
- Also binds `iv_weight`/`wald_scale` in `iv_eval.py`'s `make_engine` so the guidance sweep applies to categorical tasks.
## Changes
| File | What |
|------|------|
| `nanochat/engine.py` | Add `Engine.categorical_logits_at()` — base method for batched categorical eval |
| `clarinet/engine.py` | Add `ClarinetEngine.categorical_logits_at()` — dual-pass override with marker insertion + IV combine |
| `scripts/chat_eval.py` | Route `run_categorical_eval` through the engine instead of raw `model()` |
| `scripts/iv_eval.py` | Bind `iv_weight`/`wald_scale` in `_BoundClarinetEngine.categorical_logits_at` |
| `tests/test_clarinet_engine.py` | 7 new tests: position extraction, dual-pass combine, w=0/w=1 recovery, forward count, multi-element batch |
## Test plan
- [ ] Run `python -m pytest tests/test_clarinet_engine.py -v` — 7 new tests cover position extraction, IV combine math (w=0 → uncond, w=1 → cond, w=2 → extrapolation), forward call count (exactly 2), and variable-length batches
- [ ] Run `python -m scripts.iv_eval -i sft -a ARC-Easy,MMLU --weights 0,1,2` and verify ARC/MMLU scores now vary with guidance weight
- [ ] Run `python -m scripts.chat_eval -i sft -a ARC-Easy` to verify the base Engine path (no guidance) still works