### PR TITLE
chat_sft: fix --num-iterations to count optimizer steps, not micro-batches

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -267,16 +267,19 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
             rows.append(row[:row_capacity])
             mask_rows.append(mask_row[:row_capacity])
 
-        # Stopping condition to respect num_iterations, if given
+        # Stopping condition to respect num_iterations, if given.
+        # num_iterations counts optimizer steps, but this generator yields micro-batches:
+        # grad_accum_steps of them per optimizer step.
         it += 1
-        if 0 < args.num_iterations <= it and split == "train":
+        target_micro_iters = args.num_iterations * grad_accum_steps
+        if 0 < target_micro_iters <= it and split == "train":
             last_step = True
 
         # Update progress tracking (based on consumed, not cursor, to account for buffering)
         if split == "train":
             current_epoch = epoch
             if args.num_iterations > 0:
-                approx_progress = it / args.num_iterations
+                approx_progress = it / target_micro_iters
             else:
                 approx_progress = consumed / dataset_size
             # Trigger last_step when we've consumed enough (instead of when cursor wraps)


### PR DESCRIPTION
## Bug

`--num-iterations` is documented as the number of **optimization steps**:

```python
parser.add_argument("--num-iterations", type=int, default=-1, help="number of optimization steps (-1 = full epoch)")
```

But the SFT dataloader counts **yielded micro-batches** and compares that count directly against `args.num_iterations`:

```python
it += 1
if 0 < args.num_iterations <= it and split == "train":
    last_step = True
...
approx_progress = it / args.num_iterations
```

The training loop calls `next(train_loader)` `grad_accum_steps` times per optimizer step, so whenever `grad_accum_steps > 1` two things go wrong:

1. **Training stops `grad_accum_steps`× too early** — `--num-iterations=N` yields N micro-batches, which is only ~N / grad_accum_steps optimizer steps.
2. **The LR multiplier goes negative and the loss goes NaN.** `approx_progress` advances `grad_accum_steps`× too fast and shoots past 1.0 during the *first* optimizer step. `get_lr_multiplier` doesn't clamp, so the warmdown branch extrapolates below zero: `lrm = 1 - (progress - 0.5) / 0.5` → e.g. **-127** at progress 64.5. One optimizer step at a large negative LR destroys the weights; `last_step` then fires and the run "completes", saving the ruined checkpoint.

### Observed

Single GPU, `total_batch_size=524288` inherited from the pretrained checkpoint, 4096-token micro-batches → `grad_accum_steps=128`, with `--num-iterations=2`. After the first optimizer step the generator has already yielded 129 micro-batches, so progress = 129/2 = 6450%:

```
step 00001 (6450.00%) | loss: nan | lrm: -127.00 | ...
```

### Why the official runs never hit it

- `runs/speedrun.sh` doesn't pass `--num-iterations` to chat_sft — it uses the epoch-driven stop (`-1`), where progress comes from dataset consumption instead of `it`.
- `runs/runcpu.sh` passes `--num-iterations=1500` but sets `total_batch_size = device_batch_size × max_seq_len` (16384 = 32 × 512), i.e. `grad_accum_steps == 1`, where micro-batches and optimizer steps coincide.

The natural way to hit it is any single-GPU run that inherits `total_batch_size=524288` from the checkpoint, uses a smaller device batch, and passes `--num-iterations` to shorten the run.

## Fix

Scale the generator-side stop/progress target by `grad_accum_steps`, so `--num-iterations` means optimizer steps, matching its help text and the meaning of an iteration in `base_train.py`. No behavior change when `grad_accum_steps == 1` (all official configs) or in the default `--num-iterations=-1` epoch mode.

(Not related to #590 — that NaN comes from fully-padded rows in the bestfit packer and reproduces regardless of `--num-iterations`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
