### PR TITLE
Fix Task slice index bounds

### DIFF
--- a/tasks/common.py
+++ b/tasks/common.py
@@ -43,6 +43,8 @@ class Task:
 
     def __getitem__(self, index: int):
         assert isinstance(index, int), f"Index must be an integer, got {type(index)}"
+        num = len(self)
+        assert 0 <= index < num, f"Index {index} out of range for task with {num} examples"
         physical_index = self.start + index * self.step
         conversation = self.get_example(physical_index)
         return conversation

--- a/tests/test_tasks_common.py
+++ b/tests/test_tasks_common.py
@@ -1,0 +1,38 @@
+import unittest
+
+from tasks.common import Task
+
+
+class ListTask(Task):
+
+    def __init__(self, examples, **kwargs):
+        super().__init__(**kwargs)
+        self.examples = examples
+
+    @property
+    def eval_type(self):
+        return "generative"
+
+    def num_examples(self):
+        return len(self.examples)
+
+    def get_example(self, index):
+        return self.examples[index]
+
+
+class TestTaskIndexing(unittest.TestCase):
+
+    def test_getitem_respects_logical_slice_bounds(self):
+        task = ListTask(["a", "b", "c", "d"], start=1, stop=3)
+
+        self.assertEqual(len(task), 2)
+        self.assertEqual(task[0], "b")
+        self.assertEqual(task[1], "c")
+        with self.assertRaises(AssertionError):
+            _ = task[-1]
+        with self.assertRaises(AssertionError):
+            _ = task[2]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Add logical bounds checking in Task.__getitem__.
- Prevent negative or out-of-range indexes from accessing examples outside a sliced Task view.
- Add a lightweight regression test for sliced task indexing.

Validation:
- python3 -m unittest tests.test_tasks_common
- git diff --check

Disclosure:
- This small fix and test were generated with AI assistance and reviewed locally.