### PR TITLE
Match calculator tool output to training format (drop trailing .0)

### DIFF
--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -78,6 +78,19 @@ def use_calculator(expr):
     # Evaluate with timeout
     return eval_with_timeout(expr)
 
+def format_calculator_result(result):
+    """
+    Render a calculator result the same way it appears in training data.
+    GSM8K writes whole-number results as integers (e.g. "10", not "10.0"), but
+    eval returns a float for division and many products (0.2*50 -> 10.0). Without
+    this, the engine would inject "10.0" at inference while the model was trained
+    on "10", a train/inference mismatch on the tool-output tokens. Fractional
+    results are left unchanged.
+    """
+    if isinstance(result, float) and result.is_integer():
+        return str(int(result))
+    return str(result)
+
 # -----------------------------------------------------------------------------
 class KVCache:
     """
@@ -263,7 +276,7 @@ class Engine:
                         expr = self.tokenizer.decode(state.python_expr_tokens)
                         result = use_calculator(expr)
                         if result is not None:
-                            result_tokens = self.tokenizer.encode(str(result))
+                            result_tokens = self.tokenizer.encode(format_calculator_result(result))
                             state.forced_tokens.append(output_start)
                             state.forced_tokens.extend(result_tokens)
                             state.forced_tokens.append(output_end)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,7 +5,7 @@ python -m pytest tests/test_engine.py -v
 """
 
 import torch
-from nanochat.engine import KVCache, Engine
+from nanochat.engine import KVCache, Engine, use_calculator, format_calculator_result
 from dataclasses import dataclass
 
 
@@ -265,3 +265,19 @@ def test_different_seeds_introduce_variation_when_temperature_nonzero():
 
     # Sanity check: sampling actually introduces variation
     assert len(outputs) > 1, "All seeds produced the same output which is statistically highly improbable."
+
+
+def test_calculator_result_matches_training_format():
+    """The calculator result is injected as context the model was trained on.
+    GSM8K writes whole-number results as integers ("10", not "10.0"), but eval
+    returns a float for division and many products, so the injected output must
+    drop the trailing ".0" to match training. Genuine fractions are unchanged.
+    """
+    # The canonical GSM8K example: 0.2*50 evaluates to the float 10.0, annotated "10".
+    assert use_calculator("0.2*50") == 10.0
+    assert format_calculator_result(use_calculator("0.2*50")) == "10"
+    assert format_calculator_result(use_calculator("100/10")) == "10"
+    # Integer expressions and real fractions are rendered as before.
+    assert format_calculator_result(use_calculator("5*2")) == "10"
+    assert format_calculator_result(use_calculator("12/60")) == "0.2"
+    assert format_calculator_result(0.2) == "0.2"


### PR DESCRIPTION
## What

When the model calls the calculator tool, `Engine` injects the result back into the context between `<|output_start|>` / `<|output_end|>`. Those output tokens are unsupervised - the model only conditions its continuation on them - so their formatting needs to match what the model saw during training.

During SFT the calculator output comes from the GSM8K annotations (`tasks/gsm8k.py`), which write whole-number results as integers, e.g. `<<0.2*50=10>>` -> the output part is `"10"`.

At inference, `nanochat/engine.py` rendered the result with `str()`:

```python
result_tokens = self.tokenizer.encode(str(result))
```

`use_calculator("0.2*50")` returns the float `10.0`, and `str(10.0)` is `"10.0"`. So the model is conditioned on `"10"` during training but sees `"10.0"` at inference. This hits any expression that divides or multiplies to a whole number, which is very common in GSM8K.

## Fix

Render integer-valued floats without the trailing `.0` so the injected tool output matches the training annotations. Fractional results (e.g. `12/60 -> 0.2`) are unchanged.

```python
def format_calculator_result(result):
    if isinstance(result, float) and result.is_integer():
        return str(int(result))
    return str(result)
```

## Test

Added `test_calculator_result_matches_training_format` to `tests/test_engine.py`, covering the canonical `0.2*50 -> "10"` case, a division case, and unchanged fractional/integer results.
