### PR TITLE
Fix naive generate() crashing on single-token prompts

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -474,10 +474,12 @@ class GPT(nn.Module):
 
         # Smear: mix previous token's embedding into current position (cheap bigram info)
         if kv_cache is None:
-            # Training / naive generate: full sequence available, use fast slice
-            assert T > 1, "Training forward pass should have T > 1"
-            gate = self.smear_lambda.to(x.dtype) * torch.sigmoid(self.smear_gate(x[:, 1:, :24]))
-            x = torch.cat([x[:, :1], x[:, 1:] + gate * x[:, :-1]], dim=1)
+            # Training / naive generate: full sequence available, use fast slice.
+            # Guard T > 1 so a single-token prompt in naive generate is a no-op here
+            # (matching the KV cache decode path) instead of tripping the assert.
+            if T > 1:
+                gate = self.smear_lambda.to(x.dtype) * torch.sigmoid(self.smear_gate(x[:, 1:, :24]))
+                x = torch.cat([x[:, :1], x[:, 1:] + gate * x[:, :-1]], dim=1)
         else:
             # KV cache inference: read prev embedding from cache, store current for next step
             x_pre_smear = kv_cache.prev_embedding

--- a/tests/test_naive_generate.py
+++ b/tests/test_naive_generate.py
@@ -1,0 +1,20 @@
+"""
+Test the naive GPT.generate path. Example run:
+
+python -m pytest tests/test_naive_generate.py -v
+"""
+
+import torch
+from nanochat.gpt import GPT, GPTConfig
+
+
+def test_naive_generate_single_token_prompt():
+    # Naive generate should accept a single-token prompt (e.g. just BOS for
+    # unconditional sampling). The no-KV-cache smear path must treat T == 1 as a
+    # no-op rather than asserting T > 1.
+    torch.manual_seed(0)
+    cfg = GPTConfig(sequence_len=64, vocab_size=262, n_layer=2, n_head=4, n_kv_head=4, n_embd=64)
+    model = GPT(cfg)
+    model.eval()
+    tokens = list(model.generate([261], max_tokens=4, temperature=0.0))
+    assert len(tokens) == 4


### PR DESCRIPTION
### Problem

`GPT.generate()` (the naive autoregressive path) calls `self.forward(ids)` with `kv_cache=None`. The no-KV-cache branch of `forward()` asserts `T > 1` before applying the smear:

```python
if kv_cache is None:
    assert T > 1, "Training forward pass should have T > 1"
    ...
```

So generating from a single-token prompt - e.g. a lone BOS for unconditional sampling - crashes:

```python
model.generate([tokenizer.get_bos_token_id()], max_tokens=10)
# AssertionError: Training forward pass should have T > 1
```

The KV-cache decode branch already handles `T == 1` gracefully (the smear is a no-op when there is no cached predecessor), so the two paths are inconsistent.

### Fix

Guard the smear with `if T > 1` instead of asserting. The smear mixes the previous token's embedding into the current position, so at `T == 1` (no predecessor) it is a no-op. This makes the naive path consistent with the KV-cache path and leaves `T > 1` (training and multi-token prefill) completely unchanged.

### Verification

- Before: `model.generate([bos], max_tokens=4)` raises `AssertionError`.
- After: it returns the requested tokens.
- The smear output is byte-identical at `T == 1` (no-op) and identical to the previous code for `T > 1`, so there is no behavior change to training or normal generation.
- Added `tests/test_naive_generate.py` covering single-token naive generate.
