### PR TITLE
fix(engine): allocate inference KV cache at COMPUTE_DTYPE (fixes bf16 on MPS)

### DIFF
--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -17,7 +17,7 @@ import signal
 import warnings
 from contextlib import contextmanager
 from collections import deque
-from nanochat.common import compute_init, autodetect_device_type
+from nanochat.common import compute_init, autodetect_device_type, COMPUTE_DTYPE
 from nanochat.checkpoint_manager import load_model
 
 # -----------------------------------------------------------------------------
@@ -177,13 +177,16 @@ class Engine:
         """Same as generate, but does single prefill and then clones the KV cache."""
         assert isinstance(tokens, list) and isinstance(tokens[0], int), "expecting list of ints"
         device = self.model.get_device()
-        # NOTE: setting the dtype here and in this way is an ugly hack.
-        # Currently the repo assumes that cuda -> bfloat16 and everything else -> float32.
-        # We need to know the dtype here to call __init__ on KVCache and pre-allocate its tensors.
-        # As a quick hack, we're making generate() function inherit and know about this repo-wise assumption.
-        # I think there has to be a bigger refactor to deal with device/dtype tracking across the codebase.
-        # In particular, the KVCache should allocate its tensors lazily
-        dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+        # Allocate the KV cache at the repo-wide compute dtype so it matches the
+        # dtype the model forward emits. The previous `cuda -> bf16 else fp32`
+        # heuristic ignored NANOCHAT_DTYPE: with NANOCHAT_DTYPE=bfloat16 on a
+        # non-CUDA device (e.g. MPS) the forward produces bf16 q against an fp32
+        # cache, and SDPA raises a mixed-dtype error on MPS (CUDA silently
+        # promotes). COMPUTE_DTYPE tracks NANOCHAT_DTYPE, so this also drops the
+        # inference cache footprint at bf16.
+        # TODO: the KVCache should allocate its tensors lazily rather than having
+        # generate() reach for the global dtype here.
+        dtype = COMPUTE_DTYPE
         rng = torch.Generator(device=device)
         rng.manual_seed(seed)
 


### PR DESCRIPTION
## What

`Engine.generate()` allocates the inference KV cache with `bfloat16 if device.type == "cuda" else float32`, which ignores `NANOCHAT_DTYPE`. On a non-CUDA device with `NANOCHAT_DTYPE=bfloat16` (the supported MPS bf16 path — see #741, #685), the model forward emits bf16 `q` against an fp32 cache, and `F.scaled_dot_product_attention` raises on MPS:

```
RuntimeError: Expected query, key, and value to have the same dtype,
but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float instead.
```

CUDA promotes mixed dtypes silently, so this never surfaced there.

## Fix

Allocate the cache at `COMPUTE_DTYPE` — the repo-wide compute dtype that already tracks `NANOCHAT_DTYPE` — so it matches the model's compute dtype. `generate_batch()` delegates to `generate()`, so this one site covers both paths.

This is the `COMPUTE_DTYPE` approach @missflash proposed in #695, narrowed to the single change that fixes this — no `chat_web.py` refactor.

## Behavior

| scenario | before | after |
|---|---|---|
| CUDA Ampere+, no override | bf16 | bf16 (unchanged) |
| CPU / MPS, no override | fp32 | fp32 (unchanged) |
| MPS + `NANOCHAT_DTYPE=bfloat16` | fp32 → crash | bf16 |
| CUDA pre-Ampere, no override | bf16 vs fp32 forward | fp32 |
| CUDA + `NANOCHAT_DTYPE=float32` | bf16 vs fp32 forward | fp32 |

Mainstream CUDA is unchanged. The last two rows were latent mismatches the old heuristic got away with only because CUDA promotes silently; aligning to `COMPUTE_DTYPE` corrects them and halves the cache footprint at bf16.

## Validation

On an M2 (MPS, torch 2.11), `NANOCHAT_DTYPE=bfloat16`, running `Engine.generate_batch`:

- with this change: generation completes
- reverting just this line to the old heuristic: the same run raises the SDPA dtype error above at the first decode step

The fix is weight-independent, so this was exercised with a small model on the current arch rather than a specific checkpoint.

## Related

- #741 — the `optim.py` MPS bf16 fix; this is the inference-side companion
- #685 — MPS bf16 support request
- #695 — prior art for the `COMPUTE_DTYPE` approach
