### PR TITLE
Fix incorrect timeout flag in execute_code when process returns no result

### DIFF
--- a/nanochat/execution.py
+++ b/nanochat/execution.py
@@ -334,7 +334,7 @@ def execute_code(
             stdout="",
             stderr="",
             error="Execution failed (no result returned)",
-            timeout=True,
+            timeout=False,
             memory_exceeded=False,
         )
 


### PR DESCRIPTION
## Problem

In `execute_code()`, when a subprocess completes but `result_dict` is empty (e.g. the process crashed before writing results back to the shared dict), the returned `ExecutionResult` incorrectly sets `timeout=True`.

This is misleading because the failure was not caused by a time limit being exceeded -- it was caused by the process not returning any result.

## Fix

Change `timeout=True` to `timeout=False` in the "no result returned" branch of `execute_code()`. The existing `p.is_alive()` branch above it already correctly handles the actual timeout case with `timeout=True`.

## Validation

- Verified normal execution: `execute_code("print('hello')")` returns `success=True, timeout=False`
- Verified crash handling: `execute_code("raise ValueError('test')")` returns `success=False, timeout=False`
- Verified actual timeout: `execute_code('while True: pass', timeout=1.0)` returns `success=False, timeout=True`
