### PR TITLE
fix(core_eval): clamp few-shot sample size to available population

### DIFF
--- a/nanochat/core_eval.py
+++ b/nanochat/core_eval.py
@@ -164,6 +164,25 @@ def forward_model(model, input_ids):
     return losses, predictions
 
 
+def sample_fewshot_indices(idx, num_fewshot, data_len):
+    """
+    Sample few-shot example indices for evaluation, excluding the current item.
+
+    The sample size is clamped to the available population so that restricted
+    evaluation runs (e.g. --core-metric-max-per-task smaller than a task's
+    num_fewshot) degrade gracefully instead of raising ValueError from
+    random.sample. Sampling is deterministic for a given idx (seeded with
+    1234 + idx) so that few-shot prompts are stable across runs.
+    """
+    if num_fewshot <= 0:
+        return []
+    available_indices = [i for i in range(data_len) if i != idx]
+    if not available_indices:
+        return []
+    rng = random.Random(1234 + idx)
+    return rng.sample(available_indices, min(num_fewshot, len(available_indices)))
+
+
 @torch.no_grad()
 def evaluate_example(idx, model, tokenizer, data, device, task_meta):
     """Evaluate a single example, return True if correct, False otherwise"""
@@ -173,12 +192,8 @@ def evaluate_example(idx, model, tokenizer, data, device, task_meta):
     continuation_delimiter = task_meta['continuation_delimiter']
 
     # Sample few-shot examples (excluding current item)
-    fewshot_examples = []
-    if num_fewshot > 0:
-        rng = random.Random(1234 + idx)
-        available_indices = [i for i in range(len(data)) if i != idx]
-        fewshot_indices = rng.sample(available_indices, num_fewshot)
-        fewshot_examples = [data[i] for i in fewshot_indices]
+    fewshot_indices = sample_fewshot_indices(idx, num_fewshot, len(data))
+    fewshot_examples = [data[i] for i in fewshot_indices]
 
     # Render prompts and batch sequences based on task type
     if task_type == 'multiple_choice':

--- a/tests/test_core_eval.py
+++ b/tests/test_core_eval.py
@@ -1,0 +1,46 @@
+"""
+Tests for few-shot index sampling in core_eval.
+
+Run: python -m pytest tests/test_core_eval.py -v
+"""
+
+from nanochat.core_eval import sample_fewshot_indices
+
+
+def test_returns_requested_count_when_population_is_large_enough():
+    indices = sample_fewshot_indices(idx=0, num_fewshot=3, data_len=10)
+    assert len(indices) == 3
+    assert len(set(indices)) == 3  # no duplicates
+    assert 0 not in indices  # current item is excluded
+
+
+def test_excludes_current_item_for_every_index():
+    for idx in range(5):
+        indices = sample_fewshot_indices(idx=idx, num_fewshot=2, data_len=5)
+        assert idx not in indices
+        assert all(0 <= i < 5 for i in indices)
+
+
+def test_clamps_when_population_smaller_than_num_fewshot():
+    # Reproduces #550: --core-metric-max-per-task restricts the task data below
+    # a task's hardcoded num_fewshot, which previously raised ValueError from
+    # random.sample("Sample larger than population").
+    indices = sample_fewshot_indices(idx=0, num_fewshot=10, data_len=3)
+    assert len(indices) == 2  # only two other examples available
+    assert set(indices) == {1, 2}
+    assert 0 not in indices
+
+
+def test_returns_empty_when_only_one_example_available():
+    indices = sample_fewshot_indices(idx=0, num_fewshot=5, data_len=1)
+    assert indices == []
+
+
+def test_is_deterministic_per_index():
+    a = sample_fewshot_indices(idx=4, num_fewshot=3, data_len=20)
+    b = sample_fewshot_indices(idx=4, num_fewshot=3, data_len=20)
+    assert a == b
+
+
+def test_zero_fewshot_returns_empty():
+    assert sample_fewshot_indices(idx=0, num_fewshot=0, data_len=10) == []


### PR DESCRIPTION
## Summary

Fixes #550.

`evaluate_example()` in `nanochat/core_eval.py` sampled few-shot examples with `random.sample(available_indices, num_fewshot)` and did not clamp the sample size to the available population. When a task's hardcoded `num_fewshot` exceeds the restricted task size (e.g. `--core-metric-max-per-task=1` while a task like Jeopardy uses `num_fewshot=10`), `random.sample` raises:

```
ValueError: Sample larger than population or is negative
```

This makes rapid smoke-test runs (`--core-metric-max-per-task` small) crash during CORE evaluation.

## Change

Extract the few-shot index sampling into `sample_fewshot_indices(idx, num_fewshot, data_len)` and clamp the sample size with `min(num_fewshot, len(available_indices))`. Restricted runs now degrade gracefully — they use all available other examples instead of crashing.

- Behavior for valid inputs is **unchanged**: the seed (`1234 + idx`), the available-index list, and the resulting indices are identical to the previous inline logic for every `num_fewshot < data_len` case (verified by exhaustive comparison).
- Edge cases handled: `num_fewshot <= 0` → `[]`; only one example in population → `[]`.

## Validation

Added `tests/test_core_eval.py` (pure-logic, no model/tokenizer required) covering:
- normal case (requested count available, current item excluded)
- exclusion of the current item for every index
- the bug case: `num_fewshot=10, data_len=3` → returns the 2 available others (previously raised `ValueError`)
- single-example population → `[]`
- determinism per `idx`
- zero few-shot → `[]`

```
python -m pytest tests/test_core_eval.py -v   # 6 passed
```

(The repo's `.venv` in this environment lacks `torch`/`jinja2`, which `core_eval` imports at module load. The same 6 test functions were run against the real `nanochat.core_eval.sample_fewshot_indices` by injecting lightweight stubs for `torch`/`jinja2` — the function under test only uses the stdlib `random` module. All 6 pass.)

Confirmed the pre-fix inline logic raises `ValueError('Sample larger than population or is negative')` for the bug case, and confirmed zero mismatches vs. the original sampling across `idx ∈ [0,50)`, `num_fewshot ∈ {1,2,3,5,8}`, `data_len ∈ {10,20,50,100}`.