### PR TITLE
Add optional Mixture of Experts (MoE) addon, distilled from the moe2 …

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -21,6 +21,7 @@ import torch.nn.functional as F
 
 from nanochat.common import get_dist_info, print0, COMPUTE_DTYPE
 from nanochat.optim import MuonAdamW, DistMuonAdamW
+from nanochat.moe import MoE, update_expert_biases, compute_moe_stats
 
 # Our custom Flash Attention module that automatically uses FA3 on Hopper+ and SDPA fallback elsewhere
 from nanochat.flash_attention import flash_attn
@@ -37,6 +38,9 @@ class GPTConfig:
     # Characters: L=long (full context), S=short (quarter context)
     # Examples: "L"=all full context, "SL"=alternating, "SSL"=two short then one long
     window_pattern: str = "SSSL"
+    # Mixture of Experts (see nanochat/moe.py). num_experts=0 => dense MLP (default)
+    num_experts: int = 0         # number of routed experts
+    top_k: int = 2               # active routed experts per token
 
 
 def norm(x):
@@ -143,7 +147,8 @@ class Block(nn.Module):
     def __init__(self, config, layer_idx):
         super().__init__()
         self.attn = CausalSelfAttention(config, layer_idx)
-        self.mlp = MLP(config)
+        # Keep the attribute name "mlp" in both cases so forward() and dense checkpoints are unaffected
+        self.mlp = MoE(config) if config.num_experts > 0 else MLP(config)
 
     def forward(self, x, ve, cos_sin, window_size, kv_cache):
         x = x + self.attn(norm(x), ve, cos_sin, window_size, kv_cache)
@@ -226,8 +231,21 @@ class GPT(nn.Module):
             torch.nn.init.uniform_(block.attn.c_k.weight, -s, s)
             torch.nn.init.uniform_(block.attn.c_v.weight, -s, s)
             torch.nn.init.zeros_(block.attn.c_proj.weight) # projections are zero
-            torch.nn.init.uniform_(block.mlp.c_fc.weight, -s * 0.4, s * 0.4)  # 0.4x init scale for c_fc
-            torch.nn.init.zeros_(block.mlp.c_proj.weight)
+            if isinstance(block.mlp, MoE):
+                # MoE: same scheme as the dense MLP, applied per expert
+                # (up-projections play the role of c_fc => 0.4x, down-projections are zero like c_proj)
+                moe = block.mlp
+                torch.nn.init.uniform_(moe.router.gate.weight, -s, s)
+                torch.nn.init.uniform_(moe.experts.w_up, -s * 0.4, s * 0.4)
+                torch.nn.init.zeros_(moe.experts.w_down)
+                torch.nn.init.uniform_(moe.shared_expert.w_up.weight, -s * 0.4, s * 0.4)
+                torch.nn.init.zeros_(moe.shared_expert.w_down.weight)
+                # Load balancing buffers contain garbage after to_empty() from meta device
+                moe.router.expert_bias.zero_()
+                moe.router.tokens_per_expert_counter.zero_()
+            else:
+                torch.nn.init.uniform_(block.mlp.c_fc.weight, -s * 0.4, s * 0.4)  # 0.4x init scale for c_fc
+                torch.nn.init.zeros_(block.mlp.c_proj.weight)
 
         # Per-layer scalars
         # Per-layer resid init: stronger residual at early layers, weaker at deep layers
@@ -314,6 +332,33 @@ class GPT(nn.Module):
     def get_device(self):
         return self.transformer.wte.weight.device
 
+    def moe_routers(self):
+        """All MoE routers in the model (empty list for a dense model)."""
+        routers = [block.mlp.router for block in self.transformer.h if isinstance(block.mlp, MoE)]
+        return routers
+
+    def moe_inactive_params(self):
+        """Routed-expert params that are INACTIVE per token (not among the top_k).
+        These params exist (memory) but do no compute for a given token, so FLOPs
+        estimates and scaling laws should count only the active fraction."""
+        total = 0
+        for block in self.transformer.h:
+            if isinstance(block.mlp, MoE):
+                routed_params = block.mlp.experts.w_up.numel() + block.mlp.experts.w_down.numel()
+                inactive_fraction_num = self.config.num_experts - self.config.top_k
+                total += routed_params * inactive_fraction_num // self.config.num_experts
+        return total
+
+    def update_moe_balancing(self, coeff=1e-3):
+        """Aux-loss-free expert load balancing. Call once per step, before optimizer.step().
+        No-op for dense models."""
+        update_expert_biases(self.moe_routers(), coeff)
+
+    def get_moe_stats(self):
+        """MoE routing stats for logging. Call BEFORE update_moe_balancing (which
+        resets the token counters). Empty dict for dense models."""
+        return compute_moe_stats(self.moe_routers())
+
     def estimate_flops(self):
         """
         Return the estimated FLOPs per token for the model (forward + backward).
@@ -332,6 +377,8 @@ class GPT(nn.Module):
         nparams_exclude = (self.transformer.wte.weight.numel() + value_embeds_numel +
                           self.resid_lambdas.numel() + self.x0_lambdas.numel() +
                           self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel())
+        # MoE: routed experts not selected for a token do no work => count only active params
+        nparams_exclude += self.moe_inactive_params()
         h, q, t = self.config.n_head, self.config.n_embd // self.config.n_head, self.config.sequence_len
         # Sum attention FLOPs per layer, accounting for sliding window
         attn_flops = 0
@@ -362,28 +409,44 @@ class GPT(nn.Module):
         scalars = self.resid_lambdas.numel() + self.x0_lambdas.numel() + self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel()
         total = wte + value_embeds + lm_head + transformer_matrices + scalars
         assert total == sum(p.numel() for p in self.parameters()), "Parameter count mismatch"
+        # MoE: 'active_*' counts only the params active per token (top_k of num_experts
+        # routed experts + shared), following the DeepSeek convention of reporting both.
+        # For dense models moe_inactive is 0 and active_* == the plain counts.
+        moe_inactive = self.moe_inactive_params()
         return {
             'wte': wte,
             'value_embeds': value_embeds,
             'lm_head': lm_head,
             'transformer_matrices': transformer_matrices,
+            'active_transformer_matrices': transformer_matrices - moe_inactive,
             'scalars': scalars,
+            'moe_inactive': moe_inactive,
             'total': total,
+            'active_total': total - moe_inactive,
         }
 
-    def setup_optimizer(self, unembedding_lr=0.004, embedding_lr=0.2, matrix_lr=0.02, weight_decay=0.0, scalar_lr=0.5):
+    def setup_optimizer(self, unembedding_lr=0.004, embedding_lr=0.2, matrix_lr=0.02, weight_decay=0.0, scalar_lr=0.5, router_lr=0.005):
         model_dim = self.config.n_embd
         ddp, rank, local_rank, world_size = get_dist_info()
 
         # Separate out all parameters into groups
-        matrix_params = list(self.transformer.h.parameters())
+        # MoE router gates get their own AdamW group (dedicated LR): a tiny (num_experts, n_embd)
+        # classifier head feeding a sigmoid is not clearly analogous to any other group, and
+        # Muon's orthogonalized update semantics are a strange prior for routing directions.
+        router_params = [router.gate.weight for router in self.moe_routers()]
+        router_param_ids = {id(p) for p in router_params}
+        matrix_params = [p for p in self.transformer.h.parameters() if id(p) not in router_param_ids]
         value_embeds_params = list(self.value_embeds.parameters())
         embedding_params = list(self.transformer.wte.parameters())
         lm_head_params = list(self.lm_head.parameters())
         resid_params = [self.resid_lambdas]
         x0_params = [self.x0_lambdas]
         smear_params = [self.smear_gate.weight, self.smear_lambda, self.backout_lambda]
-        assert len(list(self.parameters())) == len(matrix_params) + len(embedding_params) + len(lm_head_params) + len(value_embeds_params) + len(resid_params) + len(x0_params) + len(smear_params)
+        assert len(list(self.parameters())) == len(matrix_params) + len(router_params) + len(embedding_params) + len(lm_head_params) + len(value_embeds_params) + len(resid_params) + len(x0_params) + len(smear_params)
+        # DistMuonAdamW shards large AdamW params along dim 0 across ranks
+        if ddp and router_params and router_params[0].numel() >= 1024:
+            assert self.config.num_experts % world_size == 0, \
+                f"num_experts ({self.config.num_experts}) must be divisible by world_size ({world_size}) for the router's reduce_scatter"
 
         # Scale the LR for the AdamW parameters by ∝1/√dmodel (tuned for 768 dim model)
         dmodel_lr_scale = (model_dim / 768) ** -0.5
@@ -399,6 +462,10 @@ class GPT(nn.Module):
             dict(kind='adamw', params=x0_params, lr=scalar_lr, betas=(0.96, 0.95), eps=1e-10, weight_decay=0.0),  # higher beta1 for x0
             dict(kind='adamw', params=smear_params, lr=0.2, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0),
         ]
+        if router_params:
+            # No weight decay: decaying gate weights pushes routing scores toward sigmoid(0)=0.5,
+            # a needless drift toward uniform routing.
+            param_groups.append(dict(kind='adamw', params=router_params, lr=router_lr * dmodel_lr_scale, betas=(0.8, 0.96), eps=1e-10, weight_decay=0.0))
         # Muon groups (matrix params, grouped by shape for stacking)
         for shape in sorted({p.shape for p in matrix_params}):
             group_params = [p for p in matrix_params if p.shape == shape]

--- a/nanochat/moe.py
+++ b/nanochat/moe.py
@@ -1,0 +1,270 @@
+"""
+Mixture of Experts (MoE) layer for nanochat.
+
+Drop-in replacement for the dense MLP in each transformer block: a learned
+sigmoid router sends each token to its top-K experts (out of num_experts),
+plus a shared expert that processes all tokens. (No knob for the shared
+expert: ablating it at d16 was the largest single-knob quality hit of the
+sweep, +0.0044 bpb, and the literature agrees — it is always on.) Total
+parameters scale with num_experts while per-token FLOPs stay constant
+(iso-FLOP with the dense MLP): expert_hidden = 4*dim/(top_k+1), rounded to 128.
+
+Design choices, benchmarked in dev/moe_bench.py (d24 shapes, H100):
+- Scores are applied AFTER the experts. ReLU^2 is homogeneous of degree 2
+  (expert(s*x) == s^2 * expert(x)), so pre-multiplying the input — what
+  torchtitan's score_before_experts does — would gate by the SQUARED score.
+  Applying to the output gates linearly, like DeepSeekV3.
+- The score multiply runs in bf16. Scores are gates in (0,1); the fp32
+  upcast/downcast round-trip tripled the memory traffic for no benefit.
+- Combine is scatter-into-zeros + sum over K slots. This beat index_add_
+  (atomics) by ~9% under torch.compile: scatter is a pure permutation (every
+  destination written once) and the K-way sum is a clean reduction.
+- Load balancing is DeepSeekV3's auxiliary-loss-free bias nudging, batched
+  across all layers into a single all_reduce with no CPU-GPU sync points.
+- Expert weights are 3D tensors (num_experts, hidden, dim). Muon's Polar
+  Express orthogonalization operates on the last two dims, so the expert dim
+  acts as a batch dim and each expert is independently orthogonalized.
+- The router gate gets its own optimizer group with a dedicated LR (see
+  GPT.setup_optimizer): it is a tiny classifier head feeding a sigmoid, not
+  clearly analogous to any other parameter group in the model. Swept at d16:
+  0.005 is best; at 0.02+ the learned routing is WORSE than a frozen random
+  router, and 0.0025-0.01 is a flat optimum (see dev/LOG.md).
+- An FP8 path for the routed experts (torch._scaled_grouped_mm, rowwise
+  scales) was implemented and removed: net wall-clock loss at nanochat scales
+  (per-microstep quantization overhead exceeds the GEMM savings) and slightly
+  worse quality. See dev/moe_fp8.md and dev/LOG.md before re-attempting.
+
+References:
+- DeepSeekV3: https://arxiv.org/abs/2412.19437
+- Aux-loss-free balancing: https://arxiv.org/abs/2408.15664
+- torchtitan MoE (implementation reference): torchtitan/models/moe/moe.py
+"""
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Linear(nn.Linear):
+    """Same as gpt.py's Linear (duplicated here to avoid a circular import):
+    master weights stay fp32, cast to the activation dtype in forward."""
+    def forward(self, x):
+        return F.linear(x, self.weight.to(dtype=x.dtype))
+
+
+class TopKRouter(nn.Module):
+    """Sigmoid-gated top-K router. Each token independently picks K experts.
+
+    Sigmoid (not softmax) so each expert's score is independent — no
+    competition across experts — following DeepSeekV3. The expert_bias buffer
+    implements aux-loss-free load balancing: it is added to the scores for the
+    top-k SELECTION only, while the returned gating weights use the raw scores,
+    so balancing steers which experts fire but never distorts their output.
+    """
+    def __init__(self, dim, num_experts, top_k):
+        super().__init__()
+        self.gate = Linear(dim, num_experts, bias=False)  # weight: (E, dim)
+        self.num_experts = num_experts
+        self.top_k = top_k
+        # Load balancing state (persistent buffers => saved in checkpoints)
+        self.register_buffer("expert_bias", torch.zeros(num_experts))
+        self.register_buffer("tokens_per_expert_counter", torch.zeros(num_experts))
+
+    def forward(self, x):
+        """
+        Args:
+            x: (T, dim) flattened token representations
+        Returns:
+            top_scores:            (T, K)  gating weights of the selected experts, fp32 in (0,1)
+            selected_experts:      (T, K)  indices of the selected experts
+            num_tokens_per_expert: (E,)    how many (token, slot) pairs each expert received
+        """
+        scores = self.gate(x)                    # (T, E)
+        scores = torch.sigmoid(scores.float())   # fp32: routing decisions are cheap (T*E) and tie-prone, keep them exact
+        # Bias affects expert SELECTION but not the gating weights
+        biased_scores = scores + self.expert_bias
+        # sorted=False: we don't care about the order of the K winners, skip the sort
+        _, selected_experts = torch.topk(biased_scores, k=self.top_k, dim=-1, sorted=False)
+        top_scores = scores.gather(dim=-1, index=selected_experts)  # (T, K)
+        # Histogram of assignments, stays on GPU (no CPU sync); sums to T*K
+        num_tokens_per_expert = torch.histc(
+            selected_experts.float().view(-1),
+            bins=self.num_experts, min=0, max=self.num_experts,
+        )
+        # Accumulate token counts for the balancing update (training only, so
+        # that val/inference forwards don't contaminate the balancing signal)
+        if self.training:
+            self.tokens_per_expert_counter += num_tokens_per_expert
+        return top_scores, selected_experts, num_tokens_per_expert
+
+
+def run_experts_grouped_mm(w_up, w_down, x, num_tokens_per_expert):
+    """All experts in one kernel per projection via torch._grouped_mm.
+
+    x must be sorted by expert: rows [0, offsets[0]) belong to expert 0, etc.
+    The token distribution lives in the VALUES of offsets, not in any tensor
+    shape, so all shapes are static and torch.compile(dynamic=False) is happy.
+
+    Args:
+        w_up:   (E, H, D) stacked up-projections (fp32 master weights)
+        w_down: (E, D, H) stacked down-projections
+        x:      (R, D) expert-sorted rows, R = T * top_k
+        num_tokens_per_expert: (E,) rows per expert, sums to R
+    Returns:
+        (R, D) in x's dtype
+    """
+    offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)  # (E,)
+    # grouped_mm is bf16-only and wants the right operand column-major over the
+    # last two dims — transpose of a contiguous tensor gives exactly that view.
+    h = torch._grouped_mm(x.bfloat16(), w_up.bfloat16().transpose(-2, -1), offs=offsets)  # (R, H)
+    h = F.relu(h).square()
+    out = torch._grouped_mm(h, w_down.bfloat16().transpose(-2, -1), offs=offsets)  # (R, D)
+    return out.type_as(x)
+
+
+@torch.compiler.disable
+def run_experts_for_loop(w_up, w_down, x, num_tokens_per_expert):
+    """Fallback for CPU/MPS where grouped_mm isn't available. The .tolist()
+    is a device sync, hence @torch.compiler.disable; only used off-CUDA."""
+    token_counts = [int(c) for c in num_tokens_per_expert.tolist()]
+    chunks = torch.split(x, token_counts, dim=0)
+    outputs = []
+    for i, chunk in enumerate(chunks):
+        # No empty-chunk skip: matmul with (0, dim) tensors is valid and produces
+        # zero gradients (vs None), which the optimizer needs for stacking.
+        h = chunk @ w_up[i].to(chunk.dtype).T
+        h = F.relu(h).square()
+        h = h @ w_down[i].to(chunk.dtype).T
+        outputs.append(h)
+    return torch.cat(outputs, dim=0)
+
+
+class ExpertGroup(nn.Module):
+    """N independent expert MLPs stored as stacked 3D weight tensors."""
+    def __init__(self, dim, expert_hidden_dim, num_experts):
+        super().__init__()
+        self.num_experts = num_experts
+        self.w_up = nn.Parameter(torch.empty(num_experts, expert_hidden_dim, dim))
+        self.w_down = nn.Parameter(torch.empty(num_experts, dim, expert_hidden_dim))
+
+    def forward(self, x, num_tokens_per_expert):
+        if x.is_cuda:
+            return run_experts_grouped_mm(self.w_up, self.w_down, x, num_tokens_per_expert)
+        return run_experts_for_loop(self.w_up, self.w_down, x, num_tokens_per_expert)
+
+
+class SharedExpert(nn.Module):
+    """Dense MLP shared expert — processes ALL tokens, no routing (DeepSeekV3).
+    Provides baseline capacity for every token; the routed experts specialize."""
+    def __init__(self, dim, expert_hidden_dim):
+        super().__init__()
+        self.w_up = Linear(dim, expert_hidden_dim, bias=False)
+        self.w_down = Linear(expert_hidden_dim, dim, bias=False)
+
+    def forward(self, x):
+        h = F.relu(self.w_up(x)).square()
+        return self.w_down(h)
+
+
+class MoE(nn.Module):
+    """Mixture of Experts layer — iso-FLOP replacement for the dense MLP.
+
+    Per token: shared expert + top_k routed experts, outputs summed.
+    """
+    def __init__(self, config):
+        super().__init__()
+        dim = config.n_embd
+        self.top_k = config.top_k
+        # Iso-FLOP sizing: active experts per token = top_k routed + 1 shared,
+        # each with hidden H = 4*dim / active, rounded to 128 for tensor cores.
+        # (At d24: 4*1536/3 = 2048 exactly, the rounding is a no-op.)
+        active_experts = config.top_k + 1
+        expert_hidden_dim = round(4 * dim / active_experts / 128) * 128
+        self.expert_hidden_dim = expert_hidden_dim
+        self.router = TopKRouter(dim, config.num_experts, config.top_k)
+        self.experts = ExpertGroup(dim, expert_hidden_dim, config.num_experts)
+        self.shared_expert = SharedExpert(dim, expert_hidden_dim)
+
+    def forward(self, x):
+        # x: (B, S, D). Notation: T = B*S tokens, K = top_k, E = num_experts.
+        B, S, D = x.shape
+        x_flat = x.view(-1, D)  # (T, D)
+
+        # Route: each token picks its top-K experts
+        top_scores, selected_experts, num_tokens_per_expert = self.router(x_flat)
+
+        # Permute: sort the T*K (token, slot) assignments by expert id so each
+        # expert's tokens form one contiguous block for grouped_mm.
+        # stable=True keeps original token order within each expert's block.
+        token_indices_sorted = torch.argsort(selected_experts.view(-1), stable=True)  # (T*K,)
+        scores_sorted = top_scores.view(-1)[token_indices_sorted]                     # (T*K,)
+        # The flat index enumerates (token 0 slot 0), (token 0 slot 1), (token 1 slot 0), ...
+        # so integer-dividing by K recovers the original token id.
+        token_ids = token_indices_sorted // self.top_k                                # (T*K,)
+        routed_input = x_flat[token_ids]                                              # (T*K, D)
+
+        # Shared expert: launched before the routed experts since it has no
+        # data dependency on the routing — the kernels can overlap on the GPU
+        shared_output = self.shared_expert(x_flat)
+
+        # Expert MLPs on the expert-sorted rows, gated by their scores on the way out
+        routed_output = self.experts(routed_input, num_tokens_per_expert)  # (T*K, D)
+        routed_output = routed_output * scores_sorted.unsqueeze(-1).to(routed_output.dtype)
+
+        # Combine: un-permute the rows back to their original (token, slot)
+        # positions in a zeros buffer, then sum the K contributions per token.
+        # (Not index_add_: every destination here is written exactly once, so this
+        # scatter + clean sum reduction beats atomics by ~9% compiled, see dev/moe_bench.py)
+        combined = torch.zeros(B * S * self.top_k, D, dtype=routed_output.dtype, device=routed_output.device)
+        combined[token_indices_sorted] = routed_output       # (T*K, D)
+        output = combined.view(B * S, self.top_k, D).sum(dim=1)  # (T, D)
+
+        output = output + shared_output
+        return output.view(B, S, D)
+
+
+@torch.no_grad()
+def update_expert_biases(routers, coeff=1e-3):
+    """Auxiliary-loss-free load balancing update (DeepSeekV3), batched over layers.
+
+    Underloaded experts get +coeff on their selection bias, overloaded -coeff.
+    sign() makes the update discrete, avoiding drift; centering keeps the bias
+    zero-mean. One stacked all_reduce for all layers, and no CPU-GPU syncs
+    (sign(0) = 0 handles the counters-are-all-zero case for free).
+
+    Call once per training step, before optimizer.step().
+    """
+    if len(routers) == 0:
+        return
+    counters = torch.stack([r.tokens_per_expert_counter for r in routers])  # (L, E)
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(counters)  # sum token counts across ranks, one op for all layers
+    mean_counts = counters.mean(dim=-1, keepdim=True)                       # (L, 1)
+    biases = torch.stack([r.expert_bias for r in routers])                  # (L, E)
+    biases = biases + coeff * torch.sign(mean_counts - counters)
+    biases = biases - biases.mean(dim=-1, keepdim=True)  # center to prevent drift
+    for i, router in enumerate(routers):
+        router.expert_bias.copy_(biases[i])
+        router.tokens_per_expert_counter.zero_()
+
+
+@torch.no_grad()
+def compute_moe_stats(routers):
+    """Routing statistics for logging. Uses this rank's local counts.
+    Call BEFORE update_expert_biases (which resets the counters).
+    Contains .item() calls (CPU syncs) — call sparingly, e.g. every 100 steps."""
+    if len(routers) == 0:
+        return {}
+    counters = torch.stack([r.tokens_per_expert_counter for r in routers]).float()  # (L, E)
+    biases = torch.stack([r.expert_bias for r in routers]).float()                  # (L, E)
+    # Load imbalance: coefficient of variation (std/mean) per layer, averaged.
+    # 0 = perfectly balanced; 1 = std as large as the mean (severe imbalance).
+    counts_mean = counters.mean(dim=-1).clamp(min=1)
+    load_imbalance = (counters.std(dim=-1) / counts_mean).mean().item()
+    stats = {
+        "moe/load_imbalance": load_imbalance,
+        "moe/expert_bias_std": biases.std().item(),
+        "moe/expert_bias_absmax": biases.abs().max().item(),
+    }
+    return stats

--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -266,9 +266,14 @@ class MuonAdamW(torch.optim.Optimizer):
             state["momentum_buffer"] = torch.zeros(num_params, *shape, dtype=dtype, device=device)
         momentum_buffer = state["momentum_buffer"]
 
-        # Second momentum buffer is factored, either per-row or per-column
+        # Second momentum buffer is factored, either per-row or per-column.
+        # Preserves any leading dims (e.g. the expert dim of 3D MoE params) — the
+        # factoring is over the last two (matrix) dims only.
         if "second_momentum_buffer" not in state:
-            state_shape = (num_params, shape[-2], 1) if shape[-2] >= shape[-1] else (num_params, 1, shape[-1])
+            if shape[-2] >= shape[-1]:
+                state_shape = (num_params, *shape[:-1], 1)
+            else:
+                state_shape = (num_params, *shape[:-2], 1, shape[-1])
             state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)
         second_momentum_buffer = state["second_momentum_buffer"]
         red_dim = -1 if shape[-2] >= shape[-1] else -2
@@ -483,8 +488,12 @@ class DistMuonAdamW(torch.optim.Optimizer):
         state = self.state[p]
         if "momentum_buffer" not in state:
             state["momentum_buffer"] = torch.zeros(chunk_size, *shape, dtype=dtype, device=device)
+        # Second momentum buffer: preserve leading dims (e.g. expert dim of 3D MoE params)
         if "second_momentum_buffer" not in state:
-            state_shape = (chunk_size, shape[-2], 1) if shape[-2] >= shape[-1] else (chunk_size, 1, shape[-1])
+            if shape[-2] >= shape[-1]:
+                state_shape = (chunk_size, *shape[:-1], 1)
+            else:
+                state_shape = (chunk_size, *shape[:-2], 1, shape[-1])
             state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)
         red_dim = -1 if shape[-2] >= shape[-1] else -2
 

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -52,6 +52,10 @@ parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = de
 parser.add_argument("--head-dim", type=int, default=128, help="target head dimension for attention")
 parser.add_argument("--max-seq-len", type=int, default=2048, help="max context length")
 parser.add_argument("--window-pattern", type=str, default="SSSL", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
+# Mixture of Experts (see nanochat/moe.py)
+parser.add_argument("--num-experts", type=int, default=0, help="MoE: number of routed experts (0 = dense MLP)")
+parser.add_argument("--top-k", type=int, default=2, help="MoE: active routed experts per token")
+parser.add_argument("--moe-balance-coeff", type=float, default=1e-3, help="MoE: expert bias update speed for aux-loss-free balancing (DeepSeekV3's gamma). At 1e-3 the d16 sweep showed imbalance growing with num_experts (CV 0.16/0.40/1.27 at e8/e16/e32)")
 # Training horizon (only one used, in order of precedence)
 parser.add_argument("--num-iterations", type=int, default=-1, help="explicit number of optimization steps (-1 = disable)")
 parser.add_argument("--target-flops", type=float, default=-1.0, help="calculate num_iterations to reach target_flops (-1 = disable)")
@@ -64,6 +68,7 @@ parser.add_argument("--unembedding-lr", type=float, default=0.008, help="learnin
 parser.add_argument("--weight-decay", type=float, default=0.28, help="cautious weight decay for the Muon optimizer (for weights)")
 parser.add_argument("--matrix-lr", type=float, default=0.02, help="learning rate for matrix parameters (Muon)")
 parser.add_argument("--scalar-lr", type=float, default=0.5, help="learning rate for scalars (resid_lambdas, x0_lambdas)")
+parser.add_argument("--router-lr", type=float, default=0.005, help="learning rate for the MoE router gate (Adam). Swept at d16: flat optimum around 0.0025-0.01, sharply worse >= 0.04")
 parser.add_argument("--warmup-steps", type=int, default=40, help="number of steps for LR warmup")
 parser.add_argument("--warmdown-ratio", type=float, default=0.65, help="ratio of iterations for LR warmdown")
 parser.add_argument("--final-lr-frac", type=float, default=0.05, help="final LR as fraction of initial LR")
@@ -137,6 +142,7 @@ def build_model_meta(depth):
         sequence_len=args.max_seq_len, vocab_size=vocab_size,
         n_layer=depth, n_head=num_heads, n_kv_head=num_heads, n_embd=model_dim,
         window_pattern=args.window_pattern,
+        num_experts=args.num_experts, top_k=args.top_k,
     )
     with torch.device("meta"):
         model_meta = GPT(config)
@@ -243,6 +249,9 @@ def disable_fp8(model):
 # Compile the model
 
 orig_model = model # original, uncompiled model, for saving raw model state_dict and for inference/evaluation (because the shapes may change shape)
+# MoE routing does arithmetic on tensor-valued counts (histc -> cumsum offsets); this dynamo
+# flag lets torch.compile trace through it without graph breaks (harmless for dense models)
+torch._dynamo.config.capture_scalar_outputs = True
 model = torch.compile(model, dynamic=False) # the inputs to model will never change shape so dynamic=False is safe
 
 # -----------------------------------------------------------------------------
@@ -262,8 +271,10 @@ print0(f"Estimated FLOPs per token: {num_flops_per_token:e}")
 # We've already initialized the model so we have Params. Optimal Tokens is now simply target-param-data-ratio * Params
 def get_scaling_params(m):
     # As for which params to use exactly, transformer matrices + lm_head gives cleanest scaling laws (see dev/LOG.md Jan 27, 2026)
+    # For MoE, use active params (top_k routed experts + shared, not all num_experts);
+    # for dense models active_transformer_matrices == transformer_matrices.
     params_counts = m.num_scaling_params()
-    scaling_params = params_counts['transformer_matrices'] + params_counts['lm_head']
+    scaling_params = params_counts['active_transformer_matrices'] + params_counts['lm_head']
     return scaling_params
 num_scaling_params = get_scaling_params(model)
 target_tokens = int(args.target_param_data_ratio * num_scaling_params) # optimal tokens for the model we are about to train
@@ -310,6 +321,7 @@ optimizer = model.setup_optimizer(
     unembedding_lr=args.unembedding_lr * batch_lr_scale,
     embedding_lr=args.embedding_lr * batch_lr_scale,
     scalar_lr=args.scalar_lr * batch_lr_scale,
+    router_lr=args.router_lr * batch_lr_scale,
     # Muon hyperparameters
     matrix_lr=args.matrix_lr * batch_lr_scale,
     weight_decay=weight_decay_scaled,
@@ -525,6 +537,10 @@ while True:
         if group['kind'] == 'muon':
             group["momentum"] = muon_momentum
             group["weight_decay"] = muon_weight_decay
+    # MoE: log routing stats (sparingly, they sync) and update the balancing biases.
+    # Stats are read BEFORE the balancing update, which resets the token counters.
+    moe_stats = orig_model.get_moe_stats() if step % 100 == 0 else {}
+    orig_model.update_moe_balancing(args.moe_balance_coeff)
     if scaler is not None:
         scaler.unscale_(optimizer)
         # In distributed training, all ranks must agree on whether to skip the step.
@@ -577,6 +593,7 @@ while True:
             "train/mfu": mfu,
             "train/epoch": epoch,
         }
+        log_data.update(moe_stats)
         wandb_run.log(log_data)
 
     # state update

--- a/scripts/chat_rl.py
+++ b/scripts/chat_rl.py
@@ -297,6 +297,7 @@ for step in range(num_steps):
     lrm = get_lr_multiplier(step)
     for group in optimizer.param_groups:
         group["lr"] = group["initial_lr"] * lrm
+    model.update_moe_balancing() # no-op for dense models
     optimizer.step()
     model.zero_grad(set_to_none=True)
     wandb_run.log({

--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -117,6 +117,8 @@ for name, fallback, source in [
         print0(f"Using {name}={arg_val}")
 
 orig_model = model
+# MoE routing does arithmetic on tensor-valued counts; lets dynamo trace through (harmless for dense)
+torch._dynamo.config.capture_scalar_outputs = True
 model = torch.compile(model, dynamic=False)
 depth = model.config.n_layer
 num_flops_per_token = model.estimate_flops()
@@ -446,6 +448,7 @@ while True:
         group["lr"] = group["initial_lr"] * lrm
         if group['kind'] == 'muon':
             group["momentum"] = muon_momentum
+    orig_model.update_moe_balancing() # no-op for dense models
     if scaler is not None:
         scaler.unscale_(optimizer)
         if is_ddp_initialized():


### PR DESCRIPTION
…branch

DeepSeekV3-style MoE as a drop-in replacement for the MLP: sigmoid top-k router, one always-on shared expert, aux-loss-free load balancing via bias nudging, grouped-GEMM expert execution, 3D expert params trained with Muon. Off by default (--num-experts=0 keeps the exact dense model); enable with e.g. --num-experts=8 --top-k=1. Experts are sized iso-FLOP with the dense MLP so quality comparisons are compute-fair.

Defaults are the winners of the d16 sweep (see dev/LOG.md on moe2): router LR 0.005, balance coeff 1e-3, k+1 iso-FLOP sizing. Verdict from that investigation: at nanochat's ratio-8 speedrun horizon MoE improves bpb-per-FLOP but loses on wall clock (the ~1.3-1.6x memory-traffic tax of sparse experts exceeds the ~1.1x compute multiplier), hence an optional addon branch rather than a default.