### PR TITLE
Fix SFT packing NaNs on short contexts

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -22,6 +22,37 @@ import pyarrow.parquet as pq
 from nanochat.common import get_dist_info
 from nanochat.dataset import list_parquet_files
 
+
+def pop_best_fit_conversation(conversation_buffer, max_length, truncate_if_needed=False):
+    """Pop the largest conversation that fits, optionally truncating as a fallback."""
+    assert max_length > 0
+    if not conversation_buffer:
+        raise ValueError("Cannot select a conversation from an empty buffer")
+
+    best_idx = -1
+    best_len = 0
+    for i, (ids, _) in enumerate(conversation_buffer):
+        conversation_len = len(ids)
+        if conversation_len <= max_length and conversation_len > best_len:
+            best_idx = i
+            best_len = conversation_len
+
+    if best_idx < 0:
+        if not truncate_if_needed:
+            return None
+        # Minimize discarded tokens when every buffered conversation is too long.
+        best_idx = min(range(len(conversation_buffer)), key=lambda i: len(conversation_buffer[i][0]))
+
+    ids, mask = conversation_buffer.pop(best_idx)
+    return ids[:max_length], mask[:max_length]
+
+
+def has_sft_supervised_tokens(mask_rows):
+    """Return whether a packed SFT batch has at least one supervised target token."""
+    # Targets are shifted by one, so mask_rows[:, 0] can never contribute to loss.
+    return any(any(mask_row[1:]) for mask_row in mask_rows)
+
+
 def _document_batches(split, resume_state_dict, tokenizer_batch_size):
     """
     Infinite iterator over document batches (list of text strings) from parquet files.

--- a/runs/runcpu.sh
+++ b/runs/runcpu.sh
@@ -48,6 +48,7 @@ python -m scripts.base_eval --device-batch-size=1 --split-tokens=16384 --max-per
 python -m scripts.chat_sft \
     --eval-every=200 \
     --eval-tokens=524288 \
+    --chatcore-every=-1 \
     --num-iterations=1500 \
     --run=$WANDB_RUN
 

--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -23,6 +23,7 @@ from nanochat.loss_eval import evaluate_bpb
 import torch.distributed as dist
 from nanochat.flash_attention import HAS_FA3
 from nanochat.engine import Engine
+from nanochat.dataloader import pop_best_fit_conversation, has_sft_supervised_tokens
 from scripts.chat_eval import run_chat_eval
 
 from tasks.common import TaskMixture
@@ -183,7 +184,8 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
 
     Each row in the batch starts with BOS (beginning of a conversation).
     Conversations are packed using best-fit algorithm. When no conversation fits,
-    the row is padded (instead of cropping) to ensure no tokens are ever discarded.
+    a partially filled row is padded. If nothing fits into an empty row, the shortest
+    buffered conversation is truncated so the buffer cannot stall on oversized data.
     Padding positions have targets masked with -1 (ignore_index for cross-entropy).
     """
     global last_step, approx_progress, current_epoch
@@ -228,18 +230,16 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
 
                 remaining = row_capacity - len(row)
 
-                # Find largest conversation that fits entirely
-                best_idx = -1
-                best_len = 0
-                for i, (conv, _) in enumerate(conv_buffer):
-                    conv_len = len(conv)
-                    if conv_len <= remaining and conv_len > best_len:
-                        best_idx = i
-                        best_len = conv_len
-
-                if best_idx >= 0:
-                    # Found a conversation that fits - use it entirely
-                    conv, conv_mask = conv_buffer.pop(best_idx)
+                # Preserve best-fit behavior for normal rows. Only truncate when an
+                # empty row cannot fit any buffered conversation, which also removes
+                # oversized conversations instead of leaving them stuck forever.
+                selected = pop_best_fit_conversation(
+                    conv_buffer,
+                    remaining,
+                    truncate_if_needed=len(row) == 0,
+                )
+                if selected is not None:
+                    conv, conv_mask = selected
                     row.extend(conv)
                     mask_row.extend(conv_mask)
                     consumed += ddp_world_size  # Track actual consumption
@@ -259,6 +259,12 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
                 row_lengths.append(row_capacity)
             rows.append(row[:row_capacity])
             mask_rows.append(mask_row[:row_capacity])
+
+        # Mean cross-entropy over only ignore_index targets is 0/0 => NaN. Do not
+        # count or yield an all-masked batch; packing has still consumed its rows,
+        # so the next attempt can refill with usable conversations.
+        if not has_sft_supervised_tokens(mask_rows):
+            continue
 
         # Stopping condition to respect num_iterations, if given
         it += 1

--- a/tests/test_sft_packing.py
+++ b/tests/test_sft_packing.py
@@ -1,0 +1,47 @@
+"""Focused tests for SFT best-fit packing fallbacks."""
+
+from nanochat.dataloader import has_sft_supervised_tokens, pop_best_fit_conversation
+
+
+def conversation(length, supervised_positions=()):
+    mask = [0] * length
+    for position in supervised_positions:
+        mask[position] = 1
+    return list(range(length)), mask
+
+
+def test_best_fit_is_preferred_over_truncation():
+    oversized = conversation(8, supervised_positions=(6,))
+    exact_fit = conversation(5, supervised_positions=(4,))
+    buffer = [oversized, exact_fit]
+
+    selected = pop_best_fit_conversation(buffer, max_length=5, truncate_if_needed=True)
+
+    assert selected == exact_fit
+    assert buffer == [oversized]
+
+
+def test_shortest_oversized_conversation_is_truncated_and_removed():
+    longest = conversation(9, supervised_positions=(8,))
+    shortest = conversation(7, supervised_positions=(4, 6))
+    buffer = [longest, shortest]
+
+    ids, mask = pop_best_fit_conversation(buffer, max_length=5, truncate_if_needed=True)
+
+    assert ids == shortest[0][:5]
+    assert mask == shortest[1][:5]
+    assert buffer == [longest]
+
+
+def test_partial_row_does_not_truncate_oversized_conversation():
+    oversized = conversation(8)
+    buffer = [oversized]
+
+    assert pop_best_fit_conversation(buffer, max_length=3) is None
+    assert buffer == [oversized]
+
+
+def test_supervised_target_detection_accounts_for_shift():
+    assert not has_sft_supervised_tokens([[0, 0, 0], [0, 0, 0]])
+    assert not has_sft_supervised_tokens([[1, 0, 0]])
+    assert has_sft_supervised_tokens([[0, 0, 1]])


### PR DESCRIPTION
## Summary

- make SFT best-fit packing truncate the shortest oversized conversation when an empty row cannot otherwise make progress
- skip packed batches that have no supervised target tokens after the causal shift
- add focused regression coverage and disable ChatCORE evaluation in the CPU reference run

## Why

With short sequence lengths, every buffered conversation can be too large for an empty row. The previous packer left those conversations in the buffer and emitted fully padded rows. Since all targets were ignored, mean cross-entropy evaluated as `0 / 0` and produced NaN.

The fallback now removes and truncates one oversized conversation only when starting an empty row, preserving normal best-fit behavior while guaranteeing progress. An additional guard prevents any all-masked batch from reaching the loss.

## Impact

SFT runs with short contexts no longer stall on oversized conversations or train on NaN-producing batches. Conversations that fit continue to be packed without truncation.

## Validation

- `uv run --frozen --extra cpu --group dev python -m pytest -q tests/test_sft_packing.py` (4 passed)
- `uv run --frozen --extra cpu python -m py_compile nanochat/dataloader.py scripts/chat_sft.py`
- `bash -n runs/runcpu.sh`
- `git diff --check upstream/master...HEAD`
