### PR TITLE
Fix SDPA fallback to honor non-causal attention

### DIFF
--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -74,7 +74,7 @@ USE_FA3 = _resolve_use_fa3()
 # =============================================================================
 # SDPA helpers
 # =============================================================================
-def _sdpa_attention(q, k, v, window_size, enable_gqa):
+def _sdpa_attention(q, k, v, window_size, enable_gqa, causal=True):
     """
     SDPA attention with sliding window support.
     q, k, v are (B, H, T, D) format.
@@ -85,7 +85,7 @@ def _sdpa_attention(q, k, v, window_size, enable_gqa):
 
     # Full context, same length
     if (window < 0 or window >= Tq) and Tq == Tk:
-        return F.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa=enable_gqa)
+        return F.scaled_dot_product_attention(q, k, v, is_causal=causal, enable_gqa=enable_gqa)
 
     # Single token generation
     if Tq == 1:
@@ -132,7 +132,7 @@ def flash_attn_func(q, k, v, causal=False, window_size=(-1, -1)):
     k = k.transpose(1, 2)
     v = v.transpose(1, 2)
     enable_gqa = q.size(1) != k.size(1)
-    y = _sdpa_attention(q, k, v, window_size, enable_gqa)
+    y = _sdpa_attention(q, k, v, window_size, enable_gqa, causal=causal)
     return y.transpose(1, 2)  # back to (B, T, H, D)
 
 
@@ -180,7 +180,7 @@ def flash_attn_with_kvcache(q, k_cache, v_cache, k=None, v=None, cache_seqlens=N
     v_sdpa = v_full.transpose(1, 2)
 
     enable_gqa = q_sdpa.size(1) != k_sdpa.size(1)
-    y_sdpa = _sdpa_attention(q_sdpa, k_sdpa, v_sdpa, window_size, enable_gqa)
+    y_sdpa = _sdpa_attention(q_sdpa, k_sdpa, v_sdpa, window_size, enable_gqa, causal=causal)
 
     return y_sdpa.transpose(1, 2)  # back to (B, T, H, D)
 

--- a/tests/test_attention_fallback.py
+++ b/tests/test_attention_fallback.py
@@ -257,6 +257,25 @@ class TestSDPAOnly:
     DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
     DTYPE = torch.bfloat16 if torch.cuda.is_available() else torch.float32
 
+    def test_non_causal_full_context(self):
+        """The SDPA fallback must honor causal=False for full-context attention."""
+        set_impl('sdpa')
+        B, T, H, D = 2, 8, 4, 16
+        q = torch.randn(B, T, H, D, device=self.DEVICE, dtype=self.DTYPE)
+        k = torch.randn(B, T, H, D, device=self.DEVICE, dtype=self.DTYPE)
+        v = torch.randn(B, T, H, D, device=self.DEVICE, dtype=self.DTYPE)
+
+        actual = flash_attn.flash_attn_func(q, k, v, causal=False, window_size=(-1, -1))
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            is_causal=False,
+        ).transpose(1, 2)
+
+        assert_close(actual, expected, "non_causal_full_context")
+        set_impl(None)
+
     def test_basic_forward(self):
         """Test SDPA forward pass produces valid output."""
         set_impl('sdpa')


### PR DESCRIPTION
## Summary

- Forward the public causal flag through the SDPA fallback.
- Add a CPU regression test against PyTorch SDPA for full-context non-causal attention.

## Why

The public flash_attn_func API accepts causal=False, but the SDPA fallback hardcoded is_causal=True for full-context attention. On CPU, MPS, and GPUs using SDPA, this silently changed the requested attention semantics.

This addresses the causal correctness bug described in #752. The performance ideas in that issue are intentionally outside this focused patch.

## Validation

- Before the fix, the fallback did not match the non-causal PyTorch reference (maximum absolute difference: 1.999).
- python -m pytest tests/test_attention_fallback.py -q: 6 passed, 10 skipped (FA3/CUDA-only).
- python -m pytest -q -k not memory_limit: 44 passed, 14 skipped, 1 deselected.
- python -m compileall -q nanochat scripts tasks tests: passed.

The deselected test is the existing macOS sandbox memory-limit check; it is unrelated to this change.

## AI disclosure

This change was substantially developed with OpenAI Codex. I did not write the code by hand. The patch was kept deliberately small and was verified against PyTorch SDPA plus the repository CPU test suite.