### PR TITLE
Add counterfactual controls + response logging to the CORE eval

### DIFF
--- a/nanochat/core_eval.py
+++ b/nanochat/core_eval.py
@@ -5,7 +5,9 @@ https://arxiv.org/abs/2406.11794
 TODOs:
 - All tasks ~match except for squad. We get 31% reference is 37%. Figure out why.
 """
+import math
 import random
+import re
 
 from jinja2 import Template
 import torch
@@ -164,21 +166,99 @@ def forward_model(model, input_ids):
     return losses, predictions
 
 
+# -----------------------------------------------------------------------------
+# Counterfactual controls
+# After the normal pass, re-score with the part of the input a competent model must read corrupted
+# (swapped with another item's), keeping the few-shot examples intact. A model that actually reads
+# the input drops toward chance; one whose answer comes from a prior (boolq yes/no), an answer-position
+# bias, or just the more likely choice on its own does not -- so a larger clean->corrupted drop means
+# the score is more likely real. The control is auto-detected from each task's structure.
+
+_OPTION_LINE = re.compile(r"^\s*([A-Z])[.)]+\s+(.*)$")  # "A. <text>" / "A.) <text>" lettered-MC option lines
+
+
+def control_for_task(data, task_type):
+    """Return the counterfactual control that fits a task's structure, or None."""
+    if not data:
+        return None
+    item = data[0]
+    if task_type == 'multiple_choice':
+        choices = item['choices']
+        query = item.get('query', '')
+        if all(isinstance(c, str) and len(c.strip()) == 1 and c.strip().isalpha() for c in choices):
+            # lettered MC (csqa/language_id/lsat): the options are listed inside the query and the
+            # model picks a letter, so the stem to swap is the text before them. Only controllable if
+            # the option lines actually parse (else skip, rather than record a silent no-op).
+            n_opt = sum(1 for ln in query.split('\n') if _OPTION_LINE.match(ln))
+            return 'stem_swap' if n_opt == len(choices) else None
+        if 'Passage:' in query and 'Question:' in query:
+            return 'passage_swap'     # reading comprehension (e.g. boolq): swap the passage
+        return 'stem_swap'            # content MC (piqa/arc/hellaswag): the query is the stem
+    if task_type == 'language_modeling':
+        return 'context_swap'
+    return None                       # schema (and anything else): no control yet
+
+
+def apply_control(item, data, idx, control, rng):
+    """Corrupt the readable input of `item` (returning a copy) and return (item, gold).
+
+    No control remaps gold: each control keeps the options/choices in place, so the original gold
+    index stays valid -- it is returned (unchanged) only so callers have a uniform interface.
+    """
+    donor = data[rng.choice([i for i in range(len(data)) if i != idx])]
+    if control == 'context_swap':
+        return {**item, 'context': donor['context']}, item.get('gold')
+    if control == 'passage_swap':
+        # boolq-style: swap the passage but keep this item's question (the text after "\nQuestion:")
+        delim = '\nQuestion:'
+        if delim in item['query'] and delim in donor['query']:
+            new_query = donor['query'].split(delim, 1)[0] + delim + item['query'].split(delim, 1)[1]
+            return {**item, 'query': new_query}, item['gold']
+        return {**item, 'query': donor['query']}, item['gold']
+    if control == 'stem_swap':
+        # Swap the question/stem with another item's, keeping this item's choices + gold. Content MC
+        # keeps its choices in a separate field, so the query is just the stem -> swap it whole.
+        # Lettered MC lists the options inside the query ("A. ..."), so swap only the text before the
+        # first option line and keep this item's options. Either way the model can no longer match the
+        # question to its answer -- the same "reads -> drops" direction as the other controls.
+        lines = item['query'].split('\n')
+        first_opt = next((i for i, ln in enumerate(lines) if _OPTION_LINE.match(ln)), None)
+        if first_opt is None:
+            return {**item, 'query': donor['query']}, item['gold']        # content MC: swap whole query
+        donor_lines = donor['query'].split('\n')
+        donor_opt = next((i for i, ln in enumerate(donor_lines) if _OPTION_LINE.match(ln)), None)
+        if first_opt and donor_opt:  # lettered MC: a non-empty stem before parseable options
+            return {**item, 'query': '\n'.join(donor_lines[:donor_opt] + lines[first_opt:])}, item['gold']
+        return item, item['gold']
+    return item, item['gold']
+
+
 @torch.no_grad()
-def evaluate_example(idx, model, tokenizer, data, device, task_meta):
-    """Evaluate a single example, return True if correct, False otherwise"""
+def evaluate_example(idx, model, tokenizer, data, device, task_meta, control=None):
+    """Evaluate a single example; return (is_correct, info).
+
+    If `control` is set (see control_for_task / apply_control) the test item's readable input is
+    corrupted (the original gold is kept), while the few-shot examples stay intact -- a counterfactual
+    a reading model should fail. `info` records the response for logging: multiple_choice/schema ->
+    {idx, gold, pred, scores}; language_modeling -> {idx, correct}.
+    """
     item = data[idx]
     task_type = task_meta['task_type']
     num_fewshot = task_meta['num_fewshot']
     continuation_delimiter = task_meta['continuation_delimiter']
 
-    # Sample few-shot examples (excluding current item)
+    # Sample few-shot examples (excluding current item), from the original (un-corrupted) data
     fewshot_examples = []
     if num_fewshot > 0:
         rng = random.Random(1234 + idx)
         available_indices = [i for i in range(len(data)) if i != idx]
         fewshot_indices = rng.sample(available_indices, num_fewshot)
         fewshot_examples = [data[i] for i in fewshot_indices]
+
+    # Counterfactual control: corrupt the test item's readable input (the original gold is kept)
+    gold = item.get('gold')
+    if control is not None:
+        item, gold = apply_control(item, data, idx, control, random.Random(99 + idx))
 
     # Render prompts and batch sequences based on task type
     if task_type == 'multiple_choice':
@@ -229,34 +309,42 @@ def evaluate_example(idx, model, tokenizer, data, device, task_meta):
         predicted_tokens = predictions[0, si-1:ei-1]
         actual_tokens = input_ids[0, si:ei]
         is_correct = torch.all(predicted_tokens == actual_tokens).item()
+        info = {'idx': idx, 'correct': bool(is_correct)}
     elif task_type in ['multiple_choice', 'schema']:
         # For MC/schema: find the option with lowest average loss
         mean_losses = [losses[i, si-1:ei-1].mean().item()
                         for i, (si, ei) in enumerate(zip(start_idxs, end_idxs))]
         pred_idx = mean_losses.index(min(mean_losses))
-        is_correct = pred_idx == item['gold']
+        is_correct = pred_idx == gold
+        info = {'idx': idx, 'gold': gold, 'pred': pred_idx,
+                'scores': [round(m, 5) if math.isfinite(m) else None for m in mean_losses]}
     else:
         raise ValueError(f"Unsupported task type: {task_type}")
 
-    return is_correct
+    return is_correct, info
 
 
-def evaluate_task(model, tokenizer, data, device, task_meta):
+def evaluate_task(model, tokenizer, data, device, task_meta, control=None, collect_responses=False):
     """
-    This function is responsible for evaluating one task across many examples.
-    It also handles dispatch to all processes if the script is run with torchrun.
+    Evaluate one task across many examples, dispatching to all processes under torchrun.
+    Returns (mean_correct, responses). `control` runs the counterfactual control (see
+    control_for_task); `collect_responses=True` additionally returns this rank's per-example `info`
+    records for logging (this rank's strided slice, not gathered across ranks).
     """
     rank = dist.get_rank() if dist.is_initialized() else 0
     world_size = dist.get_world_size() if dist.is_initialized() else 1
     correct = torch.zeros(len(data), dtype=torch.float32, device=device)
+    responses = []
     # stride the examples to each rank
     for idx in range(rank, len(data), world_size):
-        is_correct = evaluate_example(idx, model, tokenizer, data, device, task_meta)
+        is_correct, info = evaluate_example(idx, model, tokenizer, data, device, task_meta, control=control)
         correct[idx] = float(is_correct)
+        if collect_responses:
+            responses.append(info)
     # sync results across all the processes if running distributed
     if world_size > 1:
         dist.barrier()
         dist.all_reduce(correct, op=dist.ReduceOp.SUM)
     # compute the mean
     mean_correct = correct.mean().item()
-    return mean_correct
+    return mean_correct, responses

--- a/scripts/base_eval.py
+++ b/scripts/base_eval.py
@@ -27,11 +27,12 @@ import zipfile
 import tempfile
 import argparse
 import torch
+import torch.distributed as dist
 
 from nanochat.common import compute_init, compute_cleanup, print0, get_base_dir, autodetect_device_type, download_file_with_lock
 from nanochat.tokenizer import get_token_bytes
 from nanochat.checkpoint_manager import load_model
-from nanochat.core_eval import evaluate_task
+from nanochat.core_eval import evaluate_task, control_for_task
 from nanochat.dataloader import tokenizing_distributed_data_loader_bos_bestfit
 from nanochat.loss_eval import evaluate_bpb
 from nanochat.engine import Engine
@@ -54,10 +55,17 @@ def place_eval_bundle(file_path):
     print0(f"Placed eval_bundle directory at {eval_bundle_dir}")
 
 
-def evaluate_core(model, tokenizer, device, max_per_task=-1):
+def evaluate_core(model, tokenizer, device, max_per_task=-1, controls=False, control_samples=500, log_dir=None):
     """
     Evaluate a base model on the CORE benchmark.
-    Returns dict with results, centered_results, and core_metric.
+    Returns dict with results, centered_results, core_metric, and (if controls) control_results.
+
+    When `controls=True`, additionally (a) logs per-example responses to `log_dir` and (b) runs the
+    counterfactual controls (see nanochat.core_eval.control_for_task): per task, re-score a
+    `control_samples`-example subsample with the readable input corrupted and report both accuracies
+    CORE-centered (0 = chance). A corrupted-centered score near 0 means the model fell to chance without
+    the input (real reading); staying near the clean-centered score means its answer comes from a prior,
+    an answer-position bias, or just the more likely choice on its own.
     """
     base_dir = get_base_dir()
     eval_bundle_dir = os.path.join(base_dir, "eval_bundle")
@@ -83,8 +91,22 @@ def evaluate_core(model, tokenizer, device, max_per_task=-1):
             random_baselines[task_name] = float(random_baseline)
 
     # Evaluate each task
+    rank = dist.get_rank() if dist.is_initialized() else 0
     results = {}
     centered_results = {}
+    control_results = {}
+    resp_path = None
+    if controls and log_dir is not None:
+        os.makedirs(log_dir, exist_ok=True)
+        if rank == 0:
+            # remove stale response files (e.g. a prior run with more ranks) before any rank writes
+            import glob
+            for stale in glob.glob(os.path.join(log_dir, "responses.rank*.jsonl")):
+                os.remove(stale)
+        if dist.is_initialized():
+            dist.barrier()
+        resp_path = os.path.join(log_dir, f"responses.rank{rank}.jsonl")
+        open(resp_path, 'w', encoding='utf-8').close()
     for task in tasks:
         start_time = time.time()
         label = task['label']
@@ -106,19 +128,47 @@ def evaluate_core(model, tokenizer, device, max_per_task=-1):
         if max_per_task > 0:
             data = data[:max_per_task]
 
-        accuracy = evaluate_task(model, tokenizer, data, device, task_meta)
+        accuracy, responses = evaluate_task(model, tokenizer, data, device, task_meta, collect_responses=controls)
         results[label] = accuracy
         random_baseline = random_baselines[label]
         centered_result = (accuracy - 0.01 * random_baseline) / (1.0 - 0.01 * random_baseline)
         centered_results[label] = centered_result
+
+        # Log this rank's per-example responses (gold/pred/scores) for post-hoc analysis
+        if resp_path is not None:
+            with open(resp_path, 'a', encoding='utf-8') as rf:
+                for r in responses:
+                    rf.write(json.dumps({'task': label, **r}) + "\n")
+
+        # Counterfactual control: re-score a subsample with the readable input corrupted, and center
+        # both accuracies against the task's random baseline (0 = chance) so they compare across tasks.
+        # corrupted_centered near 0 => the score fell to chance without the input (real reading); near
+        # clean_centered => the input isn't needed (a prior/position bias or the more likely choice).
+        if controls:
+            control = control_for_task(data, task_meta['task_type'])
+            if control is not None:
+                subset = data[:control_samples]
+                clean_acc, _ = evaluate_task(model, tokenizer, subset, device, task_meta)
+                corrupt_acc, _ = evaluate_task(model, tokenizer, subset, device, task_meta, control=control)
+                rb = 0.01 * random_baselines[label]
+                control_results[label] = {'control': control, 'clean': clean_acc, 'corrupted': corrupt_acc,
+                                          'clean_centered': (clean_acc - rb) / (1.0 - rb),
+                                          'corrupted_centered': (corrupt_acc - rb) / (1.0 - rb),
+                                          'n': len(subset)}
+
         elapsed = time.time() - start_time
-        print0(f"accuracy: {accuracy:.4f} | centered: {centered_result:.4f} | time: {elapsed:.2f}s")
+        ctrl_str = ""
+        if label in control_results:
+            cr = control_results[label]
+            ctrl_str = f" | {cr['control']}: centered {cr['clean_centered']:.3f}->{cr['corrupted_centered']:.3f}"
+        print0(f"accuracy: {accuracy:.4f} | centered: {centered_result:.4f}{ctrl_str} | time: {elapsed:.2f}s")
 
     core_metric = sum(centered_results.values()) / len(centered_results)
     out = {
         "results": results,
         "centered_results": centered_results,
-        "core_metric": core_metric
+        "core_metric": core_metric,
+        "control_results": control_results,
     }
     return out
 
@@ -131,6 +181,8 @@ def main():
     parser.add_argument('--model-tag', type=str, default=None, help='nanochat model tag to identify the checkpoint directory')
     parser.add_argument('--step', type=int, default=None, help='Model step to load (default = last)')
     parser.add_argument('--max-per-task', type=int, default=-1, help='Max examples per CORE task (-1 = all)')
+    parser.add_argument('--controls', type=int, default=1, help='CORE counterfactual controls + per-example response logging (1=on default, 0=off)')
+    parser.add_argument('--control-samples', type=int, default=500, help='Examples per task for the counterfactual controls')
     parser.add_argument('--device-batch-size', type=int, default=32, help='Per-device batch size for BPB evaluation')
     parser.add_argument('--split-tokens', type=int, default=40*524288, help='Number of tokens to evaluate per split for BPB')
     parser.add_argument('--device-type', type=str, default='', help='cuda|cpu|mps (empty = autodetect)')
@@ -219,20 +271,27 @@ def main():
         print0("\n" + "="*80)
         print0("CORE Evaluation")
         print0("="*80)
-        core_results = evaluate_core(model, tokenizer, device, max_per_task=args.max_per_task)
+        core_results = evaluate_core(model, tokenizer, device, max_per_task=args.max_per_task,
+                                     controls=bool(args.controls), control_samples=args.control_samples,
+                                     log_dir=os.path.join(get_base_dir(), "base_eval"))
 
         # Write CSV output
         if ddp_rank == 0:
             base_dir = get_base_dir()
             output_csv_path = os.path.join(base_dir, "base_eval", f"{model_slug}.csv")
             os.makedirs(os.path.dirname(output_csv_path), exist_ok=True)
+            cres = core_results.get("control_results", {})
             with open(output_csv_path, 'w', encoding='utf-8', newline='') as f:
-                f.write(f"{'Task':<35}, {'Accuracy':<10}, {'Centered':<10}\n")
+                f.write(f"{'Task':<35}, {'Accuracy':<10}, {'Centered':<10}, {'Control':<14}, {'Clean':<8}, {'Corrupted':<10}, {'CleanCentered':<14}, {'CorrCentered':<13}, {'N':<6}\n")
                 for label in core_results["results"]:
                     acc = core_results["results"][label]
                     centered = core_results["centered_results"][label]
-                    f.write(f"{label:<35}, {acc:<10.6f}, {centered:<10.6f}\n")
-                f.write(f"{'CORE':<35}, {'':<10}, {core_results['core_metric']:<10.6f}\n")
+                    cr = cres.get(label)
+                    if cr:
+                        f.write(f"{label:<35}, {acc:<10.6f}, {centered:<10.6f}, {cr['control']:<14}, {cr['clean']:<8.4f}, {cr['corrupted']:<10.4f}, {cr['clean_centered']:<14.4f}, {cr['corrupted_centered']:<13.4f}, {cr['n']:<6}\n")
+                    else:
+                        f.write(f"{label:<35}, {acc:<10.6f}, {centered:<10.6f}, {'':<14}, {'':<8}, {'':<10}, {'':<14}, {'':<13}, {'':<6}\n")
+                f.write(f"{'CORE':<35}, {'':<10}, {core_results['core_metric']:<10.6f}, {'':<14}, {'':<8}, {'':<10}, {'':<14}, {'':<13}, {'':<6}\n")
             print0(f"\nResults written to: {output_csv_path}")
             print0(f"CORE metric: {core_results['core_metric']:.4f}")
 


### PR DESCRIPTION
## Problem
CORE reports per-task accuracy, but accuracy alone can't tell whether a score reflects the model using the passage or question it's given, or reaching the answer without it — a yes/no prior on boolq, an answer-position bias on the lettered-MC tasks, or a correct answer that's already the more likely choice on its own (partial-input artifact). When comparing models or tweaking the recipe, a CORE delta can come from real comprehension or from one of these artifacts, and the number alone can't tell you which — especially when it's small.

## Solution
Make the CORE eval show whether a score depends on the input the model should read, and log what the model predicted — so a delta can be attributed, not just observed. Provide this using two opt-out (default-on) additions to `base_eval`, both surfaced in stdout and the `base_eval` CSV:

**1. Counterfactual controls.** After each task's normal pass, re-score a subsample (`--control-samples`, default 500) with the readable input corrupted, and report both accuracies **CORE-centered** (0 = chance). Which part to corrupt is picked from the task's structure — MC swaps the question/stem (`stem_swap`), boolq swaps the passage (`passage_swap`), LM swaps the context (`context_swap`). A corrupted-centered score near 0 means the model fell to chance without the input (real reading); staying near the clean-centered score means the input isn't needed. Centering (0 = chance for every task) makes the numbers comparable across tasks — raw accuracies aren't, since "chance" is a different accuracy for each task (0.5 for a 2-choice task, ~0 for a generative one).

**2. Per-example response logging** → `responses.rank<r>.jsonl` (`{task, idx, gold, pred, scores}`) for post-hoc inspection without a re-run.

One flag, `--controls` (default 1). The in-training CORE metric (`base_train`) is untouched (default `controls=False`).

## Example — d24 base model (nanochat @ `dc54a1a`)
A real eval of a vanilla d24 base model: nanochat @ `dc54a1a`, ClimbMix, step 5568 — 24 layers, n_embd 1536, 12 heads, vocab 32768, seq 2048, 1,384,122,122 params. CORE 0.2673. Five of the 22 CORE tasks — both columns are CORE-centered accuracy (0 = chance) on a 500-example subsample, before and after corrupting the readable input:

| task | control | clean | corrupted |
|---|---|---:|---:|
| squad | context_swap | 0.464 | 0.000 |
| arc_easy | stem_swap | 0.659 | 0.083 |
| piqa | stem_swap | 0.540 | 0.372 |
| commonsense_qa | stem_swap | 0.043 | 0.013 |
| boolq | passage_swap | −0.005 | −0.105 |

`corrupted` is how far above chance the model still scores once the input is swapped out. squad and arc_easy fall to ≈ 0 — no better than chance without the passage/stem, so their score was built on reading it. piqa only falls to 0.372: the swap replaced its question but kept the two answer options, so the accuracy that survives can't be coming from the question — it comes from the options themselves (one is simply the more plausible sentence); only the 0.540 → 0.372 part actually used the question. commonsense_qa and boolq are already at ≈ 0 when clean, so there was nothing to read either way. Because everything is centered, these compare directly across tasks — raw accuracies wouldn't (a 2-choice task floors at 0.5, a generative one near 0).

## Notes
- **Does not change reported CORE accuracy** — the controls are a separate pass; the normal scoring path is untouched (verified: a full re-eval reproduces the metric within FP noise). ~10–15% added eval time; disable with `--controls 0`.
- One internal change: `evaluate_example`/`evaluate_task` now return `(is_correct, info)`/`(mean, responses)`; the sole in-repo caller is updated.
- Schema tasks (winograd/winogrande) have no control yet.

🤖 Generated with Claude Code
