### PR TITLE
Fix wrong worked example in short_window comment

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -299,7 +299,7 @@ class GPT(nn.Module):
         assert all(c in "SL" for c in pattern), f"Invalid window_pattern: {pattern}. Use only S and L."
         # Map characters to window sizes
         long_window = config.sequence_len
-        short_window = -(-long_window // 4 // 128) * 128  # ceil to FA3 tile size (2048 -> 768)
+        short_window = -(-long_window // 4 // 128) * 128  # ceil to FA3 tile size (2048 -> 512)
         char_to_window = {
             "L": (long_window, 0),
             "S": (short_window, 0),


### PR DESCRIPTION
## Problem

In `GPT._compute_window_sizes`, the docstring describes the short window as `S=short (quarter context)`, and the code computes:

```python
short_window = -(-long_window // 4 // 128) * 128  # ceil to FA3 tile size (2048 -> 768)
```

This is `ceil(long_window / 4)` rounded up to the FA3 tile size of 128. For the default `sequence_len = 2048` it evaluates to **512** — which correctly matches the docstring's "quarter context".

The inline comment's worked example `(2048 -> 768)` is wrong: 768 is 3/8 of 2048, not a quarter. (768 would be the result for `long_window = 3072`.) It contradicts both the code and the docstring.

## Fix

Correct the worked example to `(2048 -> 512)`. Comment-only change; no behavior difference.
