### PR TITLE
Fix SFT dataloader buffer clog that leads to NaN loss

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -206,6 +206,11 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
         while len(conv_buffer) < buffer_size:
             conversation = dataset[cursor]
             ids, mask = tokenizer.render_conversation(conversation)
+            # Crop oversized conversations: they can never be placed by best-fit
+            # and would clog the buffer forever (=> all-padding rows => NaN loss)
+            if len(ids) > row_capacity:
+                ids = ids[:row_capacity]
+                mask = mask[:row_capacity]
             conv_buffer.append((ids, mask))
             cursor += ddp_world_size
             if cursor >= dataset_size:
@@ -293,7 +298,8 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
         # For each row, positions >= (content_length - 1) in targets should be masked
         for i, content_len in enumerate(row_lengths):
             if content_len < row_capacity:
-                targets[i, content_len-1:] = -1
+                # max() guards content_len == 0, where the -1 index would wrap around
+                targets[i, max(content_len - 1, 0):] = -1
 
         yield inputs, targets
 


### PR DESCRIPTION
## Symptom

Running `chat_sft` on a model pretrained with a short `sequence_len` (e.g. 1024), the loss goes to NaN right after the first optimizer step and stays NaN, while throughput looks healthy:

```
Step 00000 | Validation bpb: 0.4337
step 00001 (0.32%) | loss: 0.887785 | ...
step 00002 (0.32%) | loss: nan | ...
step 00003 (0.32%) | loss: nan | ...
```

A telltale sign is that the progress percentage freezes (0.32% above) and the epoch never advances, so the run would also never terminate.

## Root cause

`sft_data_generator_bos_bestfit` packs conversations into rows of `row_capacity = max_seq_len + 1` tokens using best-fit, and pads a row instead of cropping when nothing fits. However, a conversation longer than `row_capacity` can **never** fit in any row, even an empty one. Such conversations are fetched into `conv_buffer` and then sit there forever, because best-fit can never place them.

The failure cascades:

1. Oversized conversations gradually accumulate in the buffer. With a 1024-token context a sizable fraction of SmolTalk conversations exceed `row_capacity`, so this happens within the first few steps.
2. Once all `buffer_size` (100) slots hold oversized conversations, `refill_buffer()` is a no-op (buffer is "full") and best-fit never finds a match, so **every subsequent row is 100% BOS padding** with every target masked to `-1`. Dataset consumption stalls, which is why the progress counter freezes and the `consumed >= dataset_size` stopping condition can never trigger.
3. A micro-batch consisting entirely of such rows has zero valid targets, so `F.cross_entropy(..., ignore_index=-1, reduction='mean')` averages over 0 elements and returns NaN.
4. The NaN loss produces NaN gradients, the next `optimizer.step()` corrupts every weight, and the loss is NaN for the remainder of the run. (The step 1 loss still prints as finite because only the last grad-accum micro-batch is logged.)

Models pretrained at the default `sequence_len=2048` are less likely to hit this, but any sufficiently long conversation relative to `max_seq_len` triggers the same cascade — it just takes longer to clog the buffer.

## Fix

Crop conversations to `row_capacity` at buffer-refill time, so every buffered conversation can always be placed. This restores the pre-bestfit behavior of cropping overlong conversations, while keeping the bestfit-pad packing for everything that fits.

Also fixes a small index bug in the padding mask: for a fully padded row (`content_len == 0`), `targets[i, content_len-1:]` wraps around to index `-1` and masks only the last position instead of the whole row. Currently harmless because the loss mask already covers padding, but wrong if the two masking steps ever diverge.