### PR TITLE
Small typo: removing redundant head_dim from gpt file

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -195,7 +195,6 @@ class GPT(nn.Module):
         # so let's just over-compute them by 10X, but assert fail if we ever reach that amount.
         # In the future we can dynamically grow the cache, for now it's fine.
         self.rotary_seq_len = config.sequence_len * 10 # 10X over-compute should be enough, TODO make nicer?
-        head_dim = config.n_embd // config.n_head
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
         self.register_buffer("cos", cos, persistent=False) # persistent=False means it's not saved to the checkpoint
         self.register_buffer("sin", sin, persistent=False)


### PR DESCRIPTION
Just removing a redundant head dimension variable from gpt.py as I was looking through the code. 