### PR TITLE
read-arxiv-paper skill: handle the URL and archive shapes arxiv actually serves

### DIFF
--- a/.claude/skills/read-arxiv-paper/SKILL.md
+++ b/.claude/skills/read-arxiv-paper/SKILL.md
@@ -9,21 +9,34 @@ https://www.arxiv.org/abs/2601.07372
 
 ### Part 1: Normalize the URL
 
-The goal is to fetch the TeX Source of the paper (not the PDF!), the URL always looks like this:
+The goal is to fetch the TeX Source of the paper (not the PDF!), which lives at:
 
 https://www.arxiv.org/src/2601.07372
 
-Notice the /src/ in the url. Once you have the URL:
+Notice the /src/ in the url. Don't assume the URL you were handed is an `/abs/` one — pull the bare
+id out of it and rebuild. The forms that show up in practice are `/abs/{id}`, `/pdf/{id}`,
+`/html/{id}`, any of those with a version suffix (`2601.07372v2`), with or without a trailing
+slash, and old-style ids (`math/0211159`). So: strip the leading `arxiv.org/<section>/`, strip any
+trailing slash or query string, keep the version suffix if one was given (it pins what you read),
+and use `{arxiv_id}` for both the URL and the local paths below. Once you have the URL:
 
 ### Part 2: Download the paper source
 
-Fetch the url to a local .tar.gz file. A good location is `~/.cache/nanochat/knowledge/{arxiv_id}.tar.gz`.
+Fetch the url to a local file. A good location is `~/.cache/nanochat/knowledge/{arxiv_id}.tar.gz`.
 
 (If the file already exists, there is no need to re-download it).
+
+If this 404s, there is no TeX source for that paper (some submissions are PDF-only). Don't quietly read
+the PDF instead and write a summary that looks like all the others: say so, and if you do fall back
+to the PDF or the abstract, put that in the summary header from Part 6 so the next reader knows the
+source was not the TeX.
 
 ### Part 3: Unpack the file in that folder
 
 Unpack the contents into `~/.cache/nanochat/knowledge/{arxiv_id}` directory.
+
+Note the download is not always a tarball: single-file submissions come back as one gzipped `.tex`,
+so if `tar` rejects it, `gunzip` it and treat the result as the entrypoint.
 
 ### Part 4: Locate the entrypoint
 
@@ -35,6 +48,16 @@ Once you've found the entrypoint, Read the contents and then recurse through all
 
 ### Part 6: Report
 
-Once you've read the paper, produce a summary of the paper into a markdown file at `./knowledge/summary_{tag}.md`. Notice that 1) use the local knowledge directory here (it's easier for me to open and reference here), not in `~/.cache`, and 2) generate some reasonable `tag` like e.g. `conditional_memory` or whatever seems appropriate given the paper. Probably make sure that the tag doesn't exist yet so you're not overwriting files.
+Once you've read the paper, produce a summary of the paper into a markdown file at `./knowledge/summary_{tag}.md`. Notice that 1) use the local knowledge directory here (it's easier for me to open and reference here), not in `~/.cache`, and 2) generate some reasonable `tag` like e.g. `conditional_memory` or whatever seems appropriate given the paper. Check that `./knowledge/summary_{tag}.md` does not exist before writing; if it does, pick another tag rather than overwriting.
+
+Start the file with a few lines saying where it came from, so a summary found six months later can be
+traced back and re-read against the source:
+
+```
+arxiv: 2601.07372v2
+title: <title as it appears in the source>
+source: tex   # or: pdf / abstract-only, if Part 2 fell back
+read: <date>
+```
 
 As for the summary itself, remember that you're processing this paper within the context of the nanochat repository, so most often we will be interested in how to apply the paper and its lessons to the nanochat project. Therefore, you should feel free to "remind yourself" of the related nanochat code by reading the relevant parts, and then explicitly make the connection of how this paper might relate to nanochat or what are things we might be inspired about or try.


### PR DESCRIPTION
Small hardening of `.claude/skills/read-arxiv-paper`. Docs only, no code touched.

The skill states the URL "always looks like" `/abs/{id}` and that the download is a `.tar.gz`. Both are true most of the time, and the cases where they aren't fail quietly — the agent improvises and the summary it writes looks exactly like a correct one.

Checked live against arxiv before writing this, rather than assuming:

```
$ curl -sIL https://arxiv.org/src/1706.03762   | grep -i 'content-disposition\|^HTTP'
HTTP/2 200
content-disposition: attachment; filename="arXiv-1706.03762v7.tar.gz"

$ curl -sIL https://arxiv.org/src/math/0211159 | grep -i 'content-disposition\|^HTTP'
HTTP/2 200
content-disposition: attachment; filename="arXiv-math0211159v1.gz"
```

The second one is a single gzipped `.tex`, not a tarball — `tar` rejects it and Part 3 has nothing to unpack. It also shows old-style ids resolve fine at `/src/`, so they're worth naming as an input shape.

What the diff changes:

- **Part 1** — extract the bare id and rebuild the URL, instead of assuming the input was `/abs/`. Names the shapes people actually paste: `/pdf/`, `/html/`, version suffixes, trailing slashes, old-style ids. Keeps a given version suffix, since that's what pins the thing being read.
- **Part 2** — says what to do on a 404 (no TeX source for that paper). The point isn't the fallback, it's that the fallback must be *visible* in the output: a summary written from a PDF or an abstract shouldn't be indistinguishable from one written from the source.
- **Part 3** — one line on the single-file `.gz` case above.
- **Part 6** — "probably make sure the tag doesn't exist" becomes an instruction, and the summary starts with four lines of provenance (`arxiv`, `title`, `source: tex|pdf|abstract-only`, `read`). A file in `./knowledge/` outlives the session that wrote it; without those lines you can't re-read it against the source, and you can't tell which version it summarized.

Nothing here changes what the skill does on the happy path.

*Disclosure, matching the convention used in the repo's own PR bodies: authored by an AI agent (Claude) contributing as Palo Alto AI Research Lab. The curl output above is real and was run before opening this PR.*
