### PR TITLE
fix: count Float8Linear in num_matmul_params (--fp8 understates FLOPs/token and MFU ~12x)

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -345,7 +345,7 @@ class GPT(nn.Module):
         matmul in this model goes through the Linear class, while non-matmul params
         (embeddings = lookups, per-layer scalars) are nn.Embedding or raw Parameters.
         """
-        matmul_params = sum(m.weight.numel() for m in self.modules() if isinstance(m, Linear))
+        matmul_params = sum(m.weight.numel() for m in self.modules() if isinstance(m, nn.Linear))
         return matmul_params
 
     def estimate_decode_flops(self, context_len):

--- a/tests/test_flops_fp8.py
+++ b/tests/test_flops_fp8.py
@@ -1,0 +1,54 @@
+"""
+Test that FLOPs accounting is invariant to FP8 conversion.
+
+convert_to_float8_training() replaces nn.Linear submodules with Float8Linear.
+Because Float8Linear subclasses nn.Linear (and not nanochat's own Linear), an
+isinstance() check against the narrower class silently stops matching after
+conversion, zeroing the matmul term of estimate_flops().
+
+Runs on CPU: the conversion is pure module surgery, no FP8 kernel is launched.
+
+python -m pytest tests/test_flops_fp8.py -v
+"""
+
+import torch.nn as nn
+
+from nanochat.gpt import GPT, GPTConfig
+from nanochat.fp8 import Float8LinearConfig, convert_to_float8_training
+
+
+def _build_small_model():
+    config = GPTConfig(
+        sequence_len=128, vocab_size=256, n_layer=2,
+        n_head=2, n_kv_head=2, n_embd=256, window_pattern="L",
+    )
+    model = GPT(config)
+    model.to_empty(device="cpu")
+    model.init_weights()
+    return model
+
+
+def _fp8_filter(mod, fqn):
+    """Mirrors the filter in scripts/base_train.py."""
+    if not isinstance(mod, nn.Linear):
+        return False
+    if mod.in_features % 16 != 0 or mod.out_features % 16 != 0:
+        return False
+    return min(mod.in_features, mod.out_features) >= 128
+
+
+def test_flops_invariant_to_fp8_conversion():
+    model = _build_small_model()
+    params_before = model.num_matmul_params()
+    flops_before = model.estimate_flops()
+
+    convert_to_float8_training(
+        model,
+        config=Float8LinearConfig.from_recipe_name("tensorwise"),
+        module_filter_fn=_fp8_filter,
+    )
+    assert any("Float8" in type(m).__name__ for m in model.modules()), "no modules were converted"
+
+    assert model.num_matmul_params() == params_before, (
+        f"matmul params changed: {params_before:,} -> {model.num_matmul_params():,}")
+    assert model.estimate_flops() == flops_before


### PR DESCRIPTION
## Problem

With `--fp8`, the reported `bf16_mfu` and `Estimated FLOPs per token` are about 12x too low.

On an 8xH100 d24 speedrun I saw `bf16_mfu: 3.87`, which would imply 4% hardware
utilization at 771k tok/sec. The `chat_sft` stage, which does not use FP8, reported
`mfu: 44.53` on the same node minutes later, constituting a 11.5x discrepancy with no
corresponding change in the workload.

## Root cause

`num_matmul_params()` (nanochat/gpt.py:348) counts modules with
`isinstance(m, Linear)`, where `Linear` is nanochat's own subclass (gpt.py:45).

`Float8Linear` is declared `class Float8Linear(nn.Linear)` (nanochat/fp8.py:195),
making it a *sibling* of nanochat's `Linear` rather than a subclass. After
`convert_to_float8_training()` (scripts/base_train.py:189) the isinstance check
therefore matches nothing, and since that call runs *before*
`estimate_flops()` (scripts/base_train.py:257), the matmul term evaluates to ~0
and only `attn_flops` survives.

Confirmation from my run's log: `Estimated FLOPs per token: 3.963722e+08`, which
equals the attention term alone to five significant figures. The correct value for
that config is 4.775e9.

## Reproduction (CPU, no GPU required)

The conversion is pure module surgery, so this needs no FP8 kernel:

d2 model, n_embd=256: num_matmul_params() 1,638,448 -> 48
estimate_flops() 10,617,120 -> 786,720


(48 rather than 0 because `ve_gate` and `smear_gate` are below the filter's
128 threshold and so are never converted.)

## Impact

Cosmetic for the logged metric itself. But `--target-flops`
(scripts/base_train.py:346) computes `num_iterations` by dividing a compute budget
by this value, so combining `--target-flops` with `--fp8` yields a step count
~12x too large.

## Fix

Make the check shape-based rather than class-based. Both `Linear` and
`Float8Linear` inherit from `nn.Linear`, and embeddings do not, so this preserves
the docstring's stated intent. `nn` is already imported in gpt.py.

Verified that `num_matmul_params()` returns the identical value pre-conversion
before and after this change, so runs without `--fp8` are unaffected.

## Test

Adds `tests/test_flops_fp8.py`, asserting `num_matmul_params()` and
`estimate_flops()` are invariant across `convert_to_float8_training`. Fails on
current main (`matmul params changed: 1,638,448 -> 48`), passes with the fix, and
runs on CPU.

Full suite locally (macOS, CPU): 44 passed, 14 skipped (CUDA-gated), 1 failure in
`test_execution.py::test_memory_limit` that is pre-existing and unrelated to this
change. That specific test does not import the model code at all, and
`nanochat/execution.py:50` deliberately skips the `setrlimit` calls on macOS
(`sys.platform != "darwin"`) while the test has no corresponding platform gate.

---

Disclosure per the AI policy in README: I traced this with LLM assistance. I
independently verified the class hierarchy, reproduced the counter collapse on
CPU, and checked the arithmetic against my own training log. I understand the
change and can explain it in full.