### PR TITLE
SFT: Fix NaN caused by conversations trimmed to hard-coded 2048

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -205,7 +205,7 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
         nonlocal cursor, epoch
         while len(conv_buffer) < buffer_size:
             conversation = dataset[cursor]
-            ids, mask = tokenizer.render_conversation(conversation)
+            ids, mask = tokenizer.render_conversation(conversation, max_tokens=row_capacity)
             conv_buffer.append((ids, mask))
             cursor += ddp_world_size
             if cursor >= dataset_size:


### PR DESCRIPTION
Long conversations are currently always trimmed to `max_tokens=2048`, regardless of the `--max-seq-len` parameter.

Relevant chunk in `sft_data_generator_bos_bestfit()`:

```python
...
row_capacity = args.max_seq_len + 1  # max_seq_len could be lower (e.g. 512), or higher (e.g. 4096)
...

def refill_buffer():
    nonlocal cursor, epoch
    while len(conv_buffer) < buffer_size:
        conversation = dataset[cursor]
        ids, mask = tokenizer.render_conversation(conversation)  # implicit max_tokens=2048 -> ids are always up to 2048 length
        conv_buffer.append((ids, mask))
        ...
```

### Issue 1 - NaNs if `max-seq-len < 2048`:

If `max_seq_len` is lower than 2048 (like 512 in `runcpu.sh`), the `conv_buffer` is populated with conversations up to length 2048. A batch row holds `row_capacity` (our 512+1), so conversations in `conv_buffer` longer than that are 'dead' in a sense they will never be fetched into actual batch because they won't fit. As training progresses their number grows, eventually filling whole `conv_buffer`. No conversation fits into data batch, which ends up being pure padding with all targets being `-1`. Cross-entropy over such batch becomes NaN, blowing up training. This also causes `consumed` to stop incrementing, so epoch runs freeze.

The NaN issue is likely what [#590](https://github.com/karpathy/nanochat/issues/590) encountered. 

Reproduce:

```bash
# Get pre-trained checkpoint
uv run python -m scripts.base_train --depth=4 --model-tag=d4-sft-bug --num-iterations=1 --total-batch-size=524288 --eval-every=-1 --core-metric-every=-1 --sample-every=-1

# Trigger NaNs with --max-seq-len=256, --total-batch-size=8192 to pin grad_accum=1
uv run python -m scripts.chat_sft --model-tag=d4-sft-bug --num-iterations=8 --max-seq-len=256 --total-batch-size=8192 --eval-every=-1 --chatcore-every=-1

# Output: NaNs by step 00002 (also tok/sec exploding because padding-only batches fly through)
step 00001 (25.00%) | loss: 5.467021 | lrm: 1.00 | dt: 2779.86ms | tok/sec: 2,946 | mfu: 0.33 | epoch: 1 | total time: 0.00m
step 00002 (37.50%) | loss: nan | lrm: 1.00 | dt: 24.50ms | tok/sec: 334,368 | mfu: 37.78 | epoch: 1 | total time: 0.00m
```

### Issue 2 - Needless truncation when `max-seq-len > 2048`:

In cases where `--max-seq-len` is higher than 2048, the batch is composed of rows that can fit longer conversations. Conversations are needlessly truncated to `2048` anyway, silently discarding tail of some conversations.

### Issue 3 - off-by-one by default

Default `row_capacity=2049`, while conversations are trimmed to `2048`. Long conversation loose one target token.

### See Also:

- Issue [#590](https://github.com/karpathy/nanochat/issues/590) - likely caused by issue 1 above
- PR [#486](https://github.com/karpathy/nanochat/pull/486) - identified the same failure, but handles it at packing time. This PR addresses the cause instead.
