### PR TITLE
SFT: Fix off-by-one EMA debias

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -454,9 +454,6 @@ while True:
     dt = t1 - t0
     # -------------------------------------------------------------------------
 
-    # State
-    step += 1
-
     # logging
     smooth_train_loss = ema_beta * smooth_train_loss + (1 - ema_beta) * train_loss.item() # EMA the training loss
     debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1)) # debias the EMA
@@ -479,6 +476,9 @@ while True:
             "train/mfu": mfu,
             "train/epoch": current_epoch,
         })
+
+    # State update
+    step += 1
 
     # The garbage collector spends ~500ms scanning for cycles quite frequently.
     # We manually manage it to avoid these pauses during training.


### PR DESCRIPTION
In train loop, `step += 1` is before EMA debias, causing EMA to have wrong exponents. In `base_train.py` step is incremented correctly after EMA debias.

```python
# State
step += 1

# logging
# On the first logged step this divides by 1-beta^2 instead of 1-beta^1
debiased_smooth_loss = smooth_train_loss / (1 - ema_beta**(step + 1)) # debias the EMA
```

Reproduce:

```bash
# Get pre-trained checkpoint
uv run python -m scripts.base_train --depth=4 --model-tag=d4-sft-bug --num-iterations=1 --total-batch-size=524288 --eval-every=-1 --core-metric-every=-1 --sample-every=-1

# Run SFT num iterations 8
uv run python -m scripts.chat_sft --model-tag=d4-sft-bug --num-iterations=8 --total-batch-size=65536 --eval-every=-1 --chatcore-every=-1

# Output: Run step one prints loss 5.464422, while ln(32768) ~= 10.40 is expected
...
step 00001 (25.00%) | loss: 5.464422 | lrm: 1.00 | dt: 3335.99ms | tok/sec: 19,645 | mfu: 2.22 | epoch: 1 | total time: 0.00m
```

At step `00001` the model had a single optimizer step, so the loss is approx uniform CE, which should be roughly `ln(32768) ~= 10.40`

Side note, the incorrect progress percentage `25%` (1 of 8 requested iterations is 12.5% expected) is a separate bug (#816)

### Fix:

Moves `step += 1` to after logging, matching base_train.py, which fixes the EMA debias exponent.

### Related:

Split out of #816 per reviewer feedback. Found no other related Issues/PRs

EDIT 2026-09-17: My agent reports this issue is now addressed in the `experiment_refactor` branch (verified at commit `07620a2`).