### PR TITLE
Fix SDPA fallback: sliding window doesn't reduce memory (fixes #825)

### DIFF
--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -98,16 +98,66 @@ def _sdpa_attention(q, k, v, window_size, enable_gqa):
 
     # Need explicit mask for sliding window/chunk inference
     device = q.device
+
+    # Sliding window with multiple queries: block the query dimension so each
+    # block only ever sees its own windowed slice of k/v. Building a single
+    # (Tq, Tk) mask for the whole sequence forces SDPA onto its unfused math
+    # backend regardless of window size, so a small window still pays for a
+    # full-length score matrix. Slicing k/v per query block keeps the actual
+    # tensors SDPA sees proportional to the window instead of the full Tk.
+    if window >= 0 and window < Tk:
+        return _sdpa_windowed_blocked(q, k, v, window, enable_gqa)
+
     # For chunk inference (Tq != Tk), is_causal is not aligned to cache position => build an explicit bool mask
     row_idx = (Tk - Tq) + torch.arange(Tq, device=device).unsqueeze(1)
     col_idx = torch.arange(Tk, device=device).unsqueeze(0)
     mask = col_idx <= row_idx
 
-    # sliding window (left)
-    if window >= 0 and window < Tk:
+    return F.scaled_dot_product_attention(q, k, v, attn_mask=mask, enable_gqa=enable_gqa)
+
+
+def _sdpa_windowed_blocked(q, k, v, window, enable_gqa, block_size=256):
+    """
+    Blocked sliding-window attention for the SDPA fallback path.
+
+    Splits the query dimension into blocks and, for each block, slices k/v
+    down to only the range that block's window can see before calling SDPA.
+    This mirrors the block-skipping FlashAttention kernels do internally,
+    done at the tensor-slicing level since SDPA has no windowed mode to
+    call into directly on this fallback path.
+
+    q, k, v are (B, H, T, D) format. Mathematically equivalent to the
+    single-mask approach (same causal + window restriction), just computed
+    in smaller pieces so SDPA never sees more of k/v than the window needs.
+    """
+    device = q.device
+    Tq = q.size(2)
+    Tk = k.size(2)
+    offset = Tk - Tq  # where query positions start relative to key positions
+
+    outputs = []
+    for start in range(0, Tq, block_size):
+        end = min(start + block_size, Tq)
+        q_block = q[:, :, start:end, :]
+
+        # Earliest key any query in this block can see: (offset+start) - window.
+        # Latest key any query in this block can see: offset+end (causal, own position).
+        k_start = max(0, (offset + start) - window)
+        k_end = offset + end
+        k_block = k[:, :, k_start:k_end, :]
+        v_block = v[:, :, k_start:k_end, :]
+
+        block_q_len = end - start
+        block_k_len = k_end - k_start
+        row_idx = (offset + start - k_start) + torch.arange(block_q_len, device=device).unsqueeze(1)
+        col_idx = torch.arange(block_k_len, device=device).unsqueeze(0)
+        mask = col_idx <= row_idx
         mask = mask & ((row_idx - col_idx) <= window)
 
-    return F.scaled_dot_product_attention(q, k, v, attn_mask=mask, enable_gqa=enable_gqa)
+        out_block = F.scaled_dot_product_attention(q_block, k_block, v_block, attn_mask=mask, enable_gqa=enable_gqa)
+        outputs.append(out_block)
+
+    return torch.cat(outputs, dim=2)
 
 # =============================================================================
 # Public API: Same interface as FA3

--- a/tests/test_attention_fallback.py
+++ b/tests/test_attention_fallback.py
@@ -335,8 +335,121 @@ class TestSDPAOnly:
 
 
 # =============================================================================
-# Override mechanism tests
+# Windowed-blocked SDPA memory tests
 # =============================================================================
+class TestSDPAWindowedBlocked:
+    """
+    Sliding window on the SDPA fallback used to build one (Tq, Tk) mask
+    regardless of window size, so a small window paid the same memory cost
+    as unlimited attention. These tests check correctness of the blocked
+    fix against the brute-force definition, and that memory actually scales
+    down with window size on CUDA.
+    """
+
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+    DTYPE = torch.bfloat16 if torch.cuda.is_available() else torch.float32
+
+    def _reference(self, q, k, v, window, enable_gqa=False):
+        """Brute-force causal + sliding-window attention, independent of SDPA."""
+        q = q.float()
+        k = k.float()
+        v = v.float()
+        B, Hq, Tq, D = q.shape
+        Hkv = k.shape[1]
+        Tk = k.shape[2]
+        if enable_gqa and Hq != Hkv:
+            k = k.repeat_interleave(Hq // Hkv, dim=1)
+            v = v.repeat_interleave(Hq // Hkv, dim=1)
+        scale = 1.0 / (D ** 0.5)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        offset = Tk - Tq
+        row_idx = offset + torch.arange(Tq, device=q.device).unsqueeze(1)
+        col_idx = torch.arange(Tk, device=q.device).unsqueeze(0)
+        mask = col_idx <= row_idx
+        if window >= 0:
+            mask = mask & ((row_idx - col_idx) <= window)
+        scores = scores.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        return torch.matmul(torch.softmax(scores, dim=-1), v)
+
+    def test_blocked_matches_reference(self):
+        """Blocked windowed output matches brute-force reference for several window sizes."""
+        set_impl('sdpa')
+        B, T, H, D = 2, 256, 4, 32
+        for window in [0, 4, 31, 63, 100]:
+            q = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+            k = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+            v = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+            q_pub = q.transpose(1, 2).contiguous()
+            k_pub = k.transpose(1, 2).contiguous()
+            v_pub = v.transpose(1, 2).contiguous()
+            out = flash_attn.flash_attn_func(q_pub, k_pub, v_pub, causal=True, window_size=(window, 0))
+            out_bhtd = out.transpose(1, 2)
+            ref = self._reference(q, k, v, window)
+            max_diff, mean_diff = assert_close(out_bhtd, ref, f"window={window}", atol=0.05, rtol=0.05)
+            print(f"window={window}: max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+        set_impl(None)
+
+    def test_blocked_matches_reference_gqa(self):
+        """Blocked windowed output matches reference under GQA (fewer kv heads than q heads)."""
+        set_impl('sdpa')
+        B, T, D = 1, 256, 32
+        n_heads, n_kv_heads, window = 8, 2, 32
+        q = torch.randn(B, n_heads, T, D, device=self.DEVICE, dtype=self.DTYPE)
+        k = torch.randn(B, n_kv_heads, T, D, device=self.DEVICE, dtype=self.DTYPE)
+        v = torch.randn(B, n_kv_heads, T, D, device=self.DEVICE, dtype=self.DTYPE)
+        q_pub = q.transpose(1, 2).contiguous()
+        k_pub = k.transpose(1, 2).contiguous()
+        v_pub = v.transpose(1, 2).contiguous()
+        out = flash_attn.flash_attn_func(q_pub, k_pub, v_pub, causal=True, window_size=(window, 0))
+        out_bhtd = out.transpose(1, 2)
+        ref = self._reference(q, k, v, window, enable_gqa=True)
+        max_diff, mean_diff = assert_close(out_bhtd, ref, "gqa windowed", atol=0.05, rtol=0.05)
+        print(f"gqa windowed: max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+        set_impl(None)
+
+    def test_non_divisible_sequence_length(self):
+        """T not a multiple of block_size (trailing partial block) still runs and is close to reference."""
+        set_impl('sdpa')
+        B, T, H, D, window = 1, 513, 4, 32, 64
+        q = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+        k = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+        v = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+        q_pub = q.transpose(1, 2).contiguous()
+        k_pub = k.transpose(1, 2).contiguous()
+        v_pub = v.transpose(1, 2).contiguous()
+        out = flash_attn.flash_attn_func(q_pub, k_pub, v_pub, causal=True, window_size=(window, 0))
+        out_bhtd = out.transpose(1, 2)
+        ref = self._reference(q, k, v, window)
+        max_diff, mean_diff = assert_close(out_bhtd, ref, "T=513 trailing block", atol=0.05, rtol=0.05)
+        print(f"T=513 trailing block: max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}")
+        set_impl(None)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="memory measurement requires CUDA")
+    def test_memory_scales_with_window(self):
+        """Peak memory should drop as window shrinks, not stay flat like the old masked approach."""
+        set_impl('sdpa')
+        B, T, H, D = 1, 2048, 4, 64
+        peaks = {}
+        for window in [16, 256, 1024, -1]:
+            q = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+            k = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+            v = torch.randn(B, H, T, D, device=self.DEVICE, dtype=self.DTYPE)
+            q_pub = q.transpose(1, 2).contiguous()
+            k_pub = k.transpose(1, 2).contiguous()
+            v_pub = v.transpose(1, 2).contiguous()
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats()
+            flash_attn.flash_attn_func(q_pub, k_pub, v_pub, causal=True, window_size=(window, 0))
+            torch.cuda.synchronize()
+            peaks[window] = torch.cuda.max_memory_allocated() / 1e6
+            print(f"window={window}: peak_mem={peaks[window]:.1f}MB")
+        assert peaks[16] < peaks[-1] * 0.9, (
+            f"expected window=16 to use meaningfully less memory than unlimited, "
+            f"got {peaks[16]:.1f}MB vs {peaks[-1]:.1f}MB"
+        )
+        set_impl(None)
+
+
 class TestOverrideMechanism:
     """Test that the override mechanism works correctly."""
 


### PR DESCRIPTION
Fixes #825

The sliding-window branch in `_sdpa_attention` built a full `(Tq, Tk)`
mask regardless of window size, then narrowed it after the fact. Passing
an arbitrary `attn_mask=` also forces SDPA onto its unfused math backend,
so a window=16 layer paid the same memory cost as unlimited attention on
this fallback path.

This splits the query dimension into blocks and slices k/v down to only
the range each block's window can see before calling SDPA, so the actual
tensors SDPA processes shrink with the window instead of staying at full
sequence length. Same causal + window math, computed in smaller pieces.

Measured on a Tesla T4 (no FA2/FA3), T=2048, batch=1:

    window=16    296 MB -> 41 MB
    window=64    301 MB -> 43 MB
    window=256   300 MB -> 47 MB
    window=1024  300 MB -> 64 MB

Output verified against the old masked implementation (max abs diff 0.0)
and against an independent brute-force reference across several window
sizes, GQA, and a non-block-divisible sequence length (T=513 with
block_size=256). Added tests to test_attention_fallback.py covering all
of this plus a memory-scaling check.

Tq==1 (single-token decode) is untouched - that path already sliced k/v
by window before calling SDPA, so it wasn't affected by this issue.

block_size defaults to 256, picked as a reasonable middle ground rather
than tuned - happy to adjust if there's a preferred value or if you'd
rather it be configurable.