### PR TITLE
Smooth the squared-ReLU activation

### DIFF
--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -136,7 +136,7 @@ class MLP(nn.Module):
 
     def forward(self, x):
         x = self.c_fc(x)
-        x = F.relu(x).square()
+        x = 0.5 * x * (x + torch.sqrt(x.square() + 0.04))
         x = self.c_proj(x)
         return x
 


### PR DESCRIPTION
This replaces the hard squared-ReLU in the MLP with a parameter-free algebraic smoothing:

$$
\phi_a(x) = \frac{1}{2}x\left(x + \sqrt{x^2 + a^2}\right), \qquad a = 0.2
$$

As $a \to 0$, it recovers squared-ReLU. The code change is deliberately one line: no new parameters, state, or configuration.

I ran a matched depth-12, 1000-step, seed-42 BF16 comparison on an RTX 4090. Source, data order, optimizer, batch schedule, and evaluation protocol were held fixed.

| step | squared-ReLU | smoothed squared-ReLU |
| ---: | ---: | ---: |
| 850 | 1.071650 | 1.071477 |
| 900 | 1.064026 | 1.063833 |
| 950 | 1.057777 | 1.057588 |
| 1000 | 1.053912 | 1.053747 |

The smoothed version was lower at all four preregistered late checkpoints. Median throughput was 87,876 vs. 88,235.5 tokens/s (99.59%), and peak memory was effectively unchanged (6297.46 vs. 6297.59 MiB).

This is still one seed at one depth, so I am opening it as a draft rather than treating it as a robust default-recipe win. The next useful check would be the reference miniseries / 8xH100 speedrun.

Disclosure: I used an LLM to help with experiment orchestration and the write-up; I reviewed the code and results.