### PR TITLE
Speed up GPU/ROCm inference with fused QKV, last-token logits, and torch.compile

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -3,6 +3,8 @@ Common utilities for nanochat.
 """
 
 import os
+# Prefer hipBLASLt GEMMs on ROCm (MI300X). Harmless on NVIDIA. Set before HIP/CUDA init.
+os.environ.setdefault("TORCH_BLAS_PREFER_HIPBLASLT", "1")
 import re
 import logging
 import urllib.request
@@ -159,6 +161,10 @@ def compute_init(device_type="cuda"): # cuda|cpu|mps
     # Precision
     if device_type == "cuda":
         torch.set_float32_matmul_precision("high") # uses tf32 instead of fp32 for matmuls
+        # Flash / mem-efficient SDPA. On ROCm/MI300X this selects aotriton or CK when available.
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(True)
+        torch.backends.cuda.enable_math_sdp(True)
 
     # Distributed setup: Distributed Data Parallel (DDP), optional, and requires CUDA
     ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()

--- a/nanochat/engine.py
+++ b/nanochat/engine.py
@@ -167,6 +167,8 @@ def sample_next_token(logits, rng, temperature=1.0, top_k=None):
     assert temperature >= 0.0, "temperature must be non-negative"
     if temperature == 0.0:
         return torch.argmax(logits, dim=-1, keepdim=True)
+    # Autocast decode may pass bf16; softmax/multinomial want fp32. Cheap: this is (B, V).
+    logits = logits.float()
     if top_k is not None:
         k = min(top_k, logits.size(-1))
         vals, idx = torch.topk(logits, k, dim=-1)
@@ -192,15 +194,25 @@ class RowState:
 
 class Engine:
 
-    def __init__(self, model, tokenizer):
+    def __init__(self, model, tokenizer, compile_model=False, fuse_qkv=False):
+        # fuse_qkv copies Q/K/V into one GEMM. Do not enable on a module that will keep training
+        # (SFT/RL/base_train sampling): the packed weights would not track optimizer updates.
+        if (fuse_qkv or compile_model) and hasattr(model, "prepare_for_inference"):
+            model.prepare_for_inference()
+        if compile_model:
+            model = torch.compile(model, dynamic=True)
         self.model = model
         self.tokenizer = tokenizer # needed for tool use
+
+    def _raw_model(self):
+        # torch.compile wraps the module; config / get_device live on the original.
+        return getattr(self.model, "_orig_mod", self.model)
 
     @torch.inference_mode()
     def generate(self, tokens, num_samples=1, max_tokens=None, temperature=1.0, top_k=None, seed=42):
         """Same as generate, but does single prefill and then clones the KV cache."""
         assert isinstance(tokens, list) and isinstance(tokens[0], int), "expecting list of ints"
-        device = self.model.get_device()
+        device = self._raw_model().get_device()
         rng = torch.Generator(device=device)
         rng.manual_seed(seed)
 
@@ -214,7 +226,7 @@ class Engine:
         bos = self.tokenizer.get_bos_token_id() # if sampled, ends row
 
         # 1) Run a batch 1 prefill of the prompt tokens
-        m = self.model.config
+        m = self._raw_model().config
         kv_model_kwargs = {"num_heads": m.n_kv_head, "head_dim": m.n_embd // m.n_head, "num_layers": m.n_layer}
         kv_cache_prefill = KVCache(
             batch_size=1,
@@ -222,13 +234,13 @@ class Engine:
             **kv_model_kwargs,
         )
         ids = torch.tensor([tokens], dtype=torch.long, device=device)
-        logits = self.model.forward(ids, kv_cache=kv_cache_prefill)
+        logits = self.model(ids, kv_cache=kv_cache_prefill)
         logits = logits[:, -1, :]
         next_ids = sample_next_token(logits, rng, temperature, top_k)  # (B, 1)
         sampled_tokens = next_ids[:, 0].tolist()
 
         # 2) Replicate the KV cache for each sample/row
-        kv_length_hint = (len(tokens) + max_tokens) if max_tokens is not None else self.model.config.sequence_len
+        kv_length_hint = (len(tokens) + max_tokens) if max_tokens is not None else self._raw_model().config.sequence_len
         kv_cache_decode = KVCache(
             batch_size=num_samples,
             seq_len=kv_length_hint,
@@ -243,6 +255,7 @@ class Engine:
         # 4) Main generation loop
         num_generated = 0
         first_iteration = True
+        decode_ids = torch.empty((num_samples, 1), dtype=torch.long, device=device)
         while True:
             # Stop condition: we've reached max tokens
             if max_tokens is not None and num_generated >= max_tokens:
@@ -259,7 +272,7 @@ class Engine:
                 first_iteration = False
             else:
                 # Forward the model and get the next token for each row
-                logits = self.model.forward(ids, kv_cache=kv_cache_decode)  # (B, T, vocab_size)
+                logits = self.model(decode_ids, kv_cache=kv_cache_decode)  # (B, 1, vocab_size)
                 logits = logits[:, -1, :]  # (B, vocab_size) at last time step
                 next_ids = sample_next_token(logits, rng, temperature, top_k)  # (B, 1)
                 sampled_tokens = next_ids[:, 0].tolist()
@@ -299,8 +312,8 @@ class Engine:
             # Yield the token column
             yield token_column, token_masks
             num_generated += 1
-            # Prepare ids for next iteration
-            ids = torch.tensor(token_column, dtype=torch.long, device=device).unsqueeze(1)
+            # Reuse the decode buffer; avoid a fresh (B, 1) alloc each step
+            decode_ids[:, 0] = torch.tensor(token_column, dtype=torch.long, device=device)
 
     def generate_batch(self, tokens, num_samples=1, **kwargs):
         """
@@ -362,7 +375,7 @@ if __name__ == "__main__":
     reference_ids = generated_tokens
     # generate tokens with Engine
     generated_tokens = []
-    engine = Engine(model, tokenizer)
+    engine = Engine(model, tokenizer, fuse_qkv=True)
     stream = engine.generate(prompt_tokens, num_samples=1, **kwargs) # note: runs in fp32
     torch.cuda.synchronize()
     t0 = time.time()

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -63,13 +63,32 @@ class CausalSelfAttention(nn.Module):
         self.c_v = nn.Linear(self.n_embd, self.n_kv_head * self.head_dim, bias=False)
         self.c_proj = nn.Linear(self.n_embd, self.n_embd, bias=False)
 
+    def fuse_qkv(self):
+        """Pack Q/K/V into one GEMM. Cuts kernel launches on decode (important on MI300X)."""
+        if getattr(self, "_qkv_weight", None) is not None:
+            return
+        qkv_weight = torch.cat([self.c_q.weight, self.c_k.weight, self.c_v.weight], dim=0)
+        self.register_buffer("_qkv_weight", qkv_weight, persistent=False)
+        self._qkv_split = (
+            self.n_head * self.head_dim,
+            self.n_kv_head * self.head_dim,
+            self.n_kv_head * self.head_dim,
+        )
+
     def forward(self, x, cos_sin, kv_cache):
         B, T, C = x.size()
 
         # Project the input to get queries, keys, and values
-        q = self.c_q(x).view(B, T, self.n_head, self.head_dim)
-        k = self.c_k(x).view(B, T, self.n_kv_head, self.head_dim)
-        v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
+        qkv_weight = getattr(self, "_qkv_weight", None)
+        if qkv_weight is not None:
+            q, k, v = F.linear(x, qkv_weight).split(self._qkv_split, dim=-1)
+            q = q.view(B, T, self.n_head, self.head_dim)
+            k = k.view(B, T, self.n_kv_head, self.head_dim)
+            v = v.view(B, T, self.n_kv_head, self.head_dim)
+        else:
+            q = self.c_q(x).view(B, T, self.n_head, self.head_dim)
+            k = self.c_k(x).view(B, T, self.n_kv_head, self.head_dim)
+            v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
 
         # Apply Rotary Embeddings to queries and keys to get relative positional encoding
         cos, sin = cos_sin
@@ -244,7 +263,13 @@ class GPT(nn.Module):
                 group["initial_lr"] = group["lr"]
         return optimizers
 
-    def forward(self, idx, targets=None, kv_cache=None, loss_reduction='mean'):
+    def prepare_for_inference(self):
+        """Eval-only tweaks: fuse QKV GEMMs. Idempotent. Safe for existing checkpoints."""
+        for block in self.transformer.h:
+            block.attn.fuse_qkv()
+        return self
+
+    def forward(self, idx, targets=None, kv_cache=None, loss_reduction='mean', last_logits_only=False):
         B, T = idx.size()
 
         # Grab the rotary embeddings for the current sequence length (they are of shape (1, seq_len, 1, head_dim/2))
@@ -262,21 +287,25 @@ class GPT(nn.Module):
             x = block(x, cos_sin, kv_cache)
         x = norm(x)
 
+        # Generation only needs the newest position. Skip the huge vocab GEMM on the prefix.
+        # CORE / categorical eval still need full-sequence logits (no kv_cache, no flag).
+        if last_logits_only or (targets is None and kv_cache is not None):
+            x = x[:, -1:]
+
         # Forward the lm_head (compute logits)
         softcap = 15 # smoothly cap the logits to the range [-softcap, softcap]
         logits = self.lm_head(x) # (B, T, padded_vocab_size) <- very big tensor, large amount of memory
         logits = logits[..., :self.config.vocab_size] # slice to remove padding
-        logits = logits.float() # switch to fp32 for logit softcap and loss computation
-        logits = softcap * torch.tanh(logits / softcap) # squash the logits
-
         if targets is not None:
             # training: given the targets, compute and return the loss
+            logits = logits.float() # switch to fp32 for logit softcap and loss computation
+            logits = softcap * torch.tanh(logits / softcap) # squash the logits
             # TODO experiment with chunked cross-entropy?
             loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1, reduction=loss_reduction)
             return loss
-        else:
-            # inference: just return the logits directly
-            return logits
+        # inference: keep autocast dtype (bf16 on MI300X); sampling upcasts the (B, V) row
+        logits = softcap * torch.tanh(logits / softcap)
+        return logits
 
     @torch.inference_mode()
     def generate(self, tokens, max_tokens, temperature=1.0, top_k=None, seed=42):
@@ -294,7 +323,7 @@ class GPT(nn.Module):
             rng.manual_seed(seed)
         ids = torch.tensor([tokens], dtype=torch.long, device=device) # add batch dim
         for _ in range(max_tokens):
-            logits = self.forward(ids) # (B, T, vocab_size)
+            logits = self.forward(ids, last_logits_only=True) # (B, 1, vocab_size)
             logits = logits[:, -1, :] # (B, vocab_size)
             if top_k is not None:
                 v, _ = torch.topk(logits, min(top_k, logits.size(-1)))

--- a/scripts/base_loss.py
+++ b/scripts/base_loss.py
@@ -56,7 +56,7 @@ if ddp_rank == 0:
         "My favorite color is",
         "If 5*x + 3 = 13, then x is",
     ]
-    engine = Engine(model, tokenizer)
+    engine = Engine(model, tokenizer, fuse_qkv=True)
     for prompt in prompts:
         tokens = tokenizer(prompt, prepend="<|bos|>")
         with autocast_ctx:

--- a/scripts/bench_infer.py
+++ b/scripts/bench_infer.py
@@ -1,0 +1,92 @@
+"""
+Benchmark Engine prefill + decode throughput.
+
+Example (AMD MI300X / CUDA / ROCm all use --device-type cuda):
+
+  python -m scripts.bench_infer --source sft --prompt-tokens 512 --max-tokens 128
+  python -m scripts.bench_infer --source sft --compile --max-tokens 256
+  python -m scripts.bench_infer --source sft --no-compile --num-samples 8
+"""
+
+import argparse
+import time
+from contextlib import nullcontext
+
+import torch
+
+from nanochat.checkpoint_manager import load_model
+from nanochat.common import autodetect_device_type, compute_init
+from nanochat.engine import Engine
+
+parser = argparse.ArgumentParser(description="Benchmark nanochat inference throughput")
+parser.add_argument("-i", "--source", type=str, default="sft", help="Source of the model: sft|mid|rl|base")
+parser.add_argument("-g", "--model-tag", type=str, default=None)
+parser.add_argument("-s", "--step", type=int, default=None)
+parser.add_argument("--device-type", type=str, default="", choices=["cuda", "cpu", "mps"])
+parser.add_argument("-d", "--dtype", type=str, default="bfloat16", choices=["float32", "bfloat16"])
+parser.add_argument("--compile", action=argparse.BooleanOptionalAction, default=None,
+                    help="torch.compile (default: on for CUDA/ROCm)")
+parser.add_argument("--prompt-tokens", type=int, default=512, help="Synthetic prompt length for prefill")
+parser.add_argument("--max-tokens", type=int, default=128, help="Decode tokens to generate")
+parser.add_argument("--num-samples", type=int, default=1, help="Parallel decode rows (batch)")
+parser.add_argument("--warmup", type=int, default=1, help="Warmup runs (use >=1 after --compile)")
+parser.add_argument("--repeats", type=int, default=3)
+args = parser.parse_args()
+
+device_type = autodetect_device_type() if args.device_type == "" else args.device_type
+_, _, _, _, device = compute_init(device_type)
+ptdtype = torch.float32 if args.dtype == "float32" else torch.bfloat16
+autocast_ctx = torch.amp.autocast(device_type=device_type, dtype=ptdtype) if device_type == "cuda" else nullcontext()
+synchronize = torch.cuda.synchronize if device_type == "cuda" else lambda: None
+
+model, tokenizer, meta = load_model(args.source, device, phase="eval", model_tag=args.model_tag, step=args.step)
+compile_model = args.compile if args.compile is not None else (device_type == "cuda")
+print(f"device={device} dtype={args.dtype} compile={compile_model} config={meta.get('model_config', {})}")
+if compile_model:
+    print("torch.compile is on: first warmup run can take minutes on MI300X.")
+engine = Engine(model, tokenizer, compile_model=compile_model, fuse_qkv=True)
+
+bos = tokenizer.get_bos_token_id()
+vocab = tokenizer.get_vocab_size()
+# Keep ids in-range and start with BOS so the engine sees a valid sequence
+prompt = [bos] + [((i * 17) % max(vocab - 1, 1)) + 1 for i in range(max(args.prompt_tokens - 1, 0))]
+
+kwargs = dict(
+    num_samples=args.num_samples,
+    max_tokens=args.max_tokens,
+    temperature=0.0,  # greedy: isolates kernel time from sampling RNG
+)
+
+
+def run_once():
+    ntok = 0
+    with autocast_ctx:
+        for token_column, _ in engine.generate(prompt, **kwargs):
+            ntok += len(token_column)
+    return ntok
+
+
+for i in range(args.warmup):
+    print(f"warmup {i + 1}/{args.warmup}...")
+    synchronize()
+    run_once()
+    synchronize()
+
+times = []
+toks = []
+for i in range(args.repeats):
+    synchronize()
+    t0 = time.perf_counter()
+    ntok = run_once()
+    synchronize()
+    dt = time.perf_counter() - t0
+    times.append(dt)
+    toks.append(ntok)
+    print(f"repeat {i + 1}/{args.repeats}: {ntok} tokens in {dt:.3f}s ({ntok / dt:.1f} tok/s)")
+
+avg_t = sum(times) / len(times)
+avg_n = sum(toks) / len(toks)
+print("---")
+print(f"prompt_tokens={len(prompt)} decode_tokens={args.max_tokens} batch={args.num_samples}")
+print(f"avg wall {avg_t:.3f}s  avg throughput {avg_n / avg_t:.1f} tok/s")
+print("Note: tok/s includes prefill + decode. Raise --num-samples to fill MI300X on decode.")

--- a/scripts/chat_cli.py
+++ b/scripts/chat_cli.py
@@ -20,6 +20,7 @@ parser.add_argument('-t', '--temperature', type=float, default=0.6, help='Temper
 parser.add_argument('-k', '--top-k', type=int, default=50, help='Top-k sampling parameter')
 parser.add_argument('--device-type', type=str, default='', choices=['cuda', 'cpu', 'mps'], help='Device type for evaluation: cuda|cpu|mps. empty => autodetect')
 parser.add_argument('-d', '--dtype', type=str, default='bfloat16', choices=['float32', 'bfloat16'])
+parser.add_argument('--compile', action=argparse.BooleanOptionalAction, default=None, help='torch.compile the model (default: on for CUDA/ROCm)')
 args = parser.parse_args()
 
 # Init the model and tokenizer
@@ -36,7 +37,10 @@ user_start, user_end = tokenizer.encode_special("<|user_start|>"), tokenizer.enc
 assistant_start, assistant_end = tokenizer.encode_special("<|assistant_start|>"), tokenizer.encode_special("<|assistant_end|>")
 
 # Create Engine for efficient generation
-engine = Engine(model, tokenizer)
+compile_model = args.compile if args.compile is not None else (device_type == "cuda")
+if compile_model:
+    print("Compiling model with torch.compile (first tokens will be slower)...")
+engine = Engine(model, tokenizer, compile_model=compile_model, fuse_qkv=True)
 
 print("\nNanoChat Interactive Mode")
 print("-" * 50)

--- a/scripts/chat_eval.py
+++ b/scripts/chat_eval.py
@@ -195,6 +195,7 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--step', type=int, default=None, help='Step to load')
     parser.add_argument('-x', '--max-problems', type=int, default=None, help='Max problems to evaluate')
     parser.add_argument('--device-type', type=str, default='', choices=['cuda', 'cpu', 'mps'], help='Device type for evaluation: cuda|cpu|mps. empty => autodetect')
+    parser.add_argument('--compile', action=argparse.BooleanOptionalAction, default=False, help='torch.compile the generation engine')
     args = parser.parse_args()
 
     device_type = autodetect_device_type() if args.device_type == "" else args.device_type
@@ -203,7 +204,7 @@ if __name__ == "__main__":
     autocast_ctx = torch.amp.autocast(device_type=device_type, dtype=ptdtype) if device_type == "cuda" else nullcontext()
 
     model, tokenizer, meta = load_model(args.source, device, phase="eval", model_tag=args.model_tag, step=args.step)
-    engine = Engine(model, tokenizer)
+    engine = Engine(model, tokenizer, compile_model=args.compile, fuse_qkv=True)
 
     # Get the tasks to evaluate on
     all_tasks = ['ARC-Easy', 'ARC-Challenge', 'MMLU', 'GSM8K', 'HumanEval', 'SpellingBee']

--- a/scripts/chat_web.py
+++ b/scripts/chat_web.py
@@ -72,6 +72,7 @@ parser.add_argument('-p', '--port', type=int, default=8000, help='Port to run th
 parser.add_argument('-d', '--dtype', type=str, default='bfloat16', choices=['float32', 'bfloat16'])
 parser.add_argument('--device-type', type=str, default='', choices=['cuda', 'cpu', 'mps'], help='Device type for evaluation: cuda|cpu|mps. empty => autodetect')
 parser.add_argument('--host', type=str, default='0.0.0.0', help='Host to bind the server to')
+parser.add_argument('--compile', action=argparse.BooleanOptionalAction, default=None, help='torch.compile the model (default: on for CUDA/ROCm)')
 args = parser.parse_args()
 
 # Configure logging for conversation traffic
@@ -124,7 +125,10 @@ class WorkerPool:
                 print(f"Loading model on {device_type}...")
 
             model, tokenizer, _ = load_model(source, device, phase="eval", model_tag=model_tag, step=step)
-            engine = Engine(model, tokenizer)
+            compile_model = args.compile if args.compile is not None else (device_type == "cuda")
+            if compile_model:
+                print(f"Compiling model on {device} with torch.compile...")
+            engine = Engine(model, tokenizer, compile_model=compile_model, fuse_qkv=True)
             autocast_ctx = torch.amp.autocast(device_type=device_type, dtype=ptdtype) if device_type == "cuda" else nullcontext()
 
             worker = Worker(

--- a/tests/test_inference_opt.py
+++ b/tests/test_inference_opt.py
@@ -1,0 +1,88 @@
+"""
+Tests for inference-path optimizations (last-token logits, fused QKV, RoPE).
+"""
+
+import torch
+
+from nanochat.engine import KVCache, sample_next_token
+from nanochat.gpt import GPT, GPTConfig, apply_rotary_emb
+
+
+def _tiny_model():
+    config = GPTConfig(
+        sequence_len=32,
+        vocab_size=128,
+        n_layer=2,
+        n_head=2,
+        n_kv_head=2,
+        n_embd=32,
+    )
+    model = GPT(config, pad_vocab_size_to=64)
+    model.init_weights()
+    model.eval()
+    return model
+
+
+@torch.no_grad()
+def test_apply_rotary_emb_matches_cat_reference():
+    B, T, H, D = 2, 5, 3, 8
+    x = torch.randn(B, T, H, D)
+    cos = torch.randn(1, T, 1, D // 2)
+    sin = torch.randn(1, T, 1, D // 2)
+    d = D // 2
+    x1, x2 = x[..., :d], x[..., d:]
+    y1 = x1 * cos + x2 * sin
+    y2 = x1 * (-sin) + x2 * cos
+    expected = torch.cat([y1, y2], 3).to(x.dtype)
+    actual = apply_rotary_emb(x, cos, sin)
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.no_grad()
+def test_last_logits_only_matches_full_forward():
+    model = _tiny_model()
+    idx = torch.randint(0, model.config.vocab_size, (2, 7))
+    full = model.forward(idx)
+    last = model.forward(idx, last_logits_only=True)
+    assert last.shape == (2, 1, model.config.vocab_size)
+    torch.testing.assert_close(last, full[:, -1:, :])
+
+
+@torch.no_grad()
+def test_kv_cache_prefill_returns_last_token_logits():
+    model = _tiny_model()
+    B, T = 2, 6
+    idx = torch.randint(0, model.config.vocab_size, (B, T))
+    full = model.forward(idx)
+    kv = KVCache(
+        batch_size=B,
+        num_heads=model.config.n_kv_head,
+        seq_len=T,
+        head_dim=model.config.n_embd // model.config.n_head,
+        num_layers=model.config.n_layer,
+    )
+    cached = model.forward(idx, kv_cache=kv)
+    assert cached.shape == (B, 1, model.config.vocab_size)
+    torch.testing.assert_close(cached, full[:, -1:, :], atol=1e-4, rtol=1e-4)
+
+
+@torch.no_grad()
+def test_fuse_qkv_matches_unfused_logits():
+    model = _tiny_model()
+    idx = torch.randint(0, model.config.vocab_size, (2, 5))
+    before = model.forward(idx)
+    model.prepare_for_inference()
+    after = model.forward(idx)
+    torch.testing.assert_close(after, before, atol=1e-5, rtol=1e-5)
+
+
+@torch.no_grad()
+def test_sample_next_token_accepts_bf16_logits():
+    logits = torch.randn(3, 32, dtype=torch.bfloat16)
+    rng = torch.Generator()
+    rng.manual_seed(0)
+    greedy = sample_next_token(logits, rng, temperature=0.0)
+    assert greedy.shape == (3, 1)
+    sampled = sample_next_token(logits, rng, temperature=0.8, top_k=8)
+    assert sampled.shape == (3, 1)
+    assert sampled.min() >= 0 and sampled.max() < 32


### PR DESCRIPTION
## Summary
- Skip the full-vocab `lm_head` on prompt prefixes during generation (last-token logits only); CORE / categorical eval still get full-sequence logits.
- Pack Q/K/V into one GEMM for decode (`fuse_qkv`, off by default on training Engine paths so packed weights cannot go stale).
- Keep decode logits in autocast dtype (bf16), enable hipBLASLt + Flash/mem-efficient SDPA, and optionally `torch.compile` on CUDA/ROCm chat serving.
- Add `python -m scripts.bench_infer` and unit tests for last-token logits / fused QKV numerics.

## Test plan
- [ ] `python -m pytest tests/test_inference_opt.py tests/test_engine.py -v`
- [ ] On GPU/ROCm (e.g. MI300X): `python -m scripts.bench_infer --source sft --prompt-tokens 512 --max-tokens 128 --warmup 2`
- [ ] Compare `--compile` vs `--no-compile` tok/s
- [ ] Smoke chat: `python -m scripts.chat_cli -i sft --no-compile` then with default compile
- [ ] Confirm SFT/RL/base_train still construct `Engine(...)` without `fuse_qkv` so training weights are not packed
