### PR TITLE
Speed up the 8xH100 GPT-2 run to 81.8 minutes

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -110,7 +110,7 @@ def tokenizing_distributed_data_loader_with_state_bos_bestfit(
 
     # Pre-allocate buffers once: layout is [inputs (B*T) | targets (B*T)]
     # This gives us contiguous views and a single HtoD transfer
-    use_cuda = device == "cuda"
+    use_cuda = torch.device(device).type == "cuda"
     row_buffer = torch.empty((B, row_capacity), dtype=torch.long) # for building rows without creating Python lists
     cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=use_cuda) # staging area (CPU)
     gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device) # on-device buffer

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -175,6 +175,7 @@ class GPT(nn.Module):
             "h": nn.ModuleList([Block(config, layer_idx) for layer_idx in range(config.n_layer)]),
         })
         self.lm_head = Linear(config.n_embd, padded_vocab_size, bias=False)
+        self._training_loss = None
         # Per-layer learnable scalars (inspired by modded-nanogpt)
         # resid_lambdas: scales the residual stream at each layer (init 1.0 = neutral)
         # x0_lambdas: blends initial embedding back in at each layer (init 0.0 = disabled)
@@ -199,6 +200,14 @@ class GPT(nn.Module):
         cos, sin = self._precompute_rotary_embeddings(self.rotary_seq_len, head_dim)
         self.register_buffer("cos", cos, persistent=False) # persistent=False means it's not saved to the checkpoint
         self.register_buffer("sin", sin, persistent=False)
+
+    def set_training_loss(self, loss):
+        """Install an optional fused mean loss without changing eval or inference."""
+        if not isinstance(loss, nn.Module):
+            raise TypeError("training loss must be an nn.Module")
+        if next(loss.parameters(), None) is not None or next(loss.buffers(), None) is not None:
+            raise ValueError("training loss must not own parameters or buffers")
+        self._training_loss = loss.to(device=self.get_device())
 
     @torch.no_grad()
     def init_weights(self):
@@ -509,6 +518,18 @@ class GPT(nn.Module):
 
         # Forward the lm_head (compute logits)
         softcap = 15 # smoothly cap the logits to the range [-softcap, softcap]
+        if (
+            self._training_loss is not None
+            and self.training
+            and targets is not None
+            and loss_reduction == "mean"
+        ):
+            logits = self.lm_head(x)[..., :self.config.vocab_size]
+            return self._training_loss(
+                logits.reshape(-1, logits.size(-1)),
+                targets.reshape(-1),
+            ).float()
+
         logits = self.lm_head(x) # (B, T, padded_vocab_size) <- very big tensor, large amount of memory
         logits = logits[..., :self.config.vocab_size] # slice to remove padding
         logits = logits.float() # switch to fp32 for logit softcap and loss computation

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -366,7 +366,9 @@ class GPT(nn.Module):
         matmul in this model goes through the Linear class, while non-matmul params
         (embeddings = lookups, per-layer scalars) are nn.Embedding or raw Parameters.
         """
-        matmul_params = sum(m.weight.numel() for m in self.modules() if isinstance(m, Linear))
+        # Count subclasses too: FP8 conversion replaces Linear with Float8Linear,
+        # which remains an nn.Linear but is no longer an instance of this class.
+        matmul_params = sum(m.weight.numel() for m in self.modules() if isinstance(m, nn.Linear))
         return matmul_params
 
     def estimate_decode_flops(self, context_len):

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -6,7 +6,7 @@ Notable features:
 - untied weights for token embedding and lm_head
 - relu^2 activation in MLP
 - norm after token embedding
-- no learnable params in rmsnorm
+- optional learnable scales on MLP-input and final rmsnorms
 - no bias in linear layers
 - Group-Query Attention (GQA) support for more efficient inference
 - Flash Attention 3 integration
@@ -37,10 +37,12 @@ class GPTConfig:
     # Characters: L=long (full context), S=short (quarter context)
     # Examples: "L"=all full context, "SL"=alternating, "SSL"=two short then one long
     window_pattern: str = "SSSL"
+    learnable_rmsnorm: bool = False
 
 
-def norm(x):
-    return F.rms_norm(x, (x.size(-1),)) # note that this will run in bf16, seems ok
+def norm(x, weight=None):
+    weight = None if weight is None else weight.to(dtype=x.dtype)
+    return F.rms_norm(x, (x.size(-1),), weight) # note that this will run in bf16, seems ok
 
 class Linear(nn.Linear):
     """nn.Linear that casts weights to match input dtype in forward.
@@ -146,10 +148,11 @@ class Block(nn.Module):
         super().__init__()
         self.attn = CausalSelfAttention(config, layer_idx)
         self.mlp = MLP(config)
+        self.mlp_norm_gamma = nn.Parameter(torch.ones(config.n_embd)) if config.learnable_rmsnorm else None
 
     def forward(self, x, ve, cos_sin, window_size, kv_cache):
         x = x + self.attn(norm(x), ve, cos_sin, window_size, kv_cache)
-        x = x + self.mlp(norm(x))
+        x = x + self.mlp(norm(x, self.mlp_norm_gamma))
         return x
 
 
@@ -176,6 +179,7 @@ class GPT(nn.Module):
         })
         self.lm_head = Linear(config.n_embd, padded_vocab_size, bias=False)
         self._training_loss = None
+        self.final_norm_gamma = nn.Parameter(torch.ones(config.n_embd)) if config.learnable_rmsnorm else None
         # Per-layer learnable scalars (inspired by modded-nanogpt)
         # resid_lambdas: scales the residual stream at each layer (init 1.0 = neutral)
         # x0_lambdas: blends initial embedding back in at each layer (init 0.0 = disabled)
@@ -209,6 +213,10 @@ class GPT(nn.Module):
             raise ValueError("training loss must not own parameters or buffers")
         self._training_loss = loss.to(device=self.get_device())
 
+    def _norm_scale_params(self):
+        scales = [block.mlp_norm_gamma for block in self.transformer.h if block.mlp_norm_gamma is not None]
+        return scales + ([] if self.final_norm_gamma is None else [self.final_norm_gamma])
+
     @torch.no_grad()
     def init_weights(self):
         """
@@ -239,6 +247,10 @@ class GPT(nn.Module):
             torch.nn.init.zeros_(block.attn.c_proj.weight) # projections are zero
             torch.nn.init.uniform_(block.mlp.c_fc.weight, -s * 0.4, s * 0.4)  # 0.4x init scale for c_fc
             torch.nn.init.zeros_(block.mlp.c_proj.weight)
+            if block.mlp_norm_gamma is not None:
+                torch.nn.init.ones_(block.mlp_norm_gamma)
+        if self.final_norm_gamma is not None:
+            torch.nn.init.ones_(self.final_norm_gamma)
 
         # Per-layer scalars
         # Per-layer resid init: stronger residual at early layers, weaker at deep layers
@@ -412,8 +424,8 @@ class GPT(nn.Module):
         wte = sum(p.numel() for p in self.transformer.wte.parameters())
         value_embeds = sum(p.numel() for p in self.value_embeds.parameters())
         lm_head = sum(p.numel() for p in self.lm_head.parameters())
-        transformer_matrices = sum(p.numel() for p in self.transformer.h.parameters())
-        scalars = self.resid_lambdas.numel() + self.x0_lambdas.numel() + self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel()
+        transformer_matrices = sum(p.numel() for p in self.transformer.h.parameters() if p.ndim >= 2)
+        scalars = self.resid_lambdas.numel() + self.x0_lambdas.numel() + self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel() + sum(p.numel() for p in self._norm_scale_params())
         total = wte + value_embeds + lm_head + transformer_matrices + scalars
         assert total == sum(p.numel() for p in self.parameters()), "Parameter count mismatch"
         return {
@@ -429,14 +441,15 @@ class GPT(nn.Module):
         model_dim = self.config.n_embd
 
         # Separate out all parameters into groups
-        matrix_params = list(self.transformer.h.parameters())
+        matrix_params = [p for p in self.transformer.h.parameters() if p.ndim >= 2]
         value_embeds_params = list(self.value_embeds.parameters())
         embedding_params = list(self.transformer.wte.parameters())
         lm_head_params = list(self.lm_head.parameters())
         resid_params = [self.resid_lambdas]
+        norm_scale_params = self._norm_scale_params()
         x0_params = [self.x0_lambdas]
         smear_params = [self.smear_gate.weight, self.smear_lambda, self.backout_lambda]
-        assert len(list(self.parameters())) == len(matrix_params) + len(embedding_params) + len(lm_head_params) + len(value_embeds_params) + len(resid_params) + len(x0_params) + len(smear_params)
+        assert len(list(self.parameters())) == len(matrix_params) + len(embedding_params) + len(lm_head_params) + len(value_embeds_params) + len(resid_params) + len(norm_scale_params) + len(x0_params) + len(smear_params)
 
         # Scale the LR for the AdamW parameters by ∝1/√dmodel (tuned for 768 dim model)
         dmodel_lr_scale = (model_dim / 768) ** -0.5
@@ -448,7 +461,7 @@ class GPT(nn.Module):
             dict(kind='adamw', params=lm_head_params, lr=unembedding_lr * dmodel_lr_scale, betas=(0.8, 0.96), eps=1e-10, weight_decay=0.01),
             dict(kind='adamw', params=embedding_params, lr=embedding_lr * dmodel_lr_scale, betas=(0.8, 0.995), eps=1e-10, weight_decay=0.001),
             dict(kind='adamw', params=value_embeds_params, lr=embedding_lr * dmodel_lr_scale * 0.5, betas=(0.8, 0.995), eps=1e-10, weight_decay=0.01),
-            dict(kind='adamw', params=resid_params, lr=scalar_lr * 0.01, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.05),
+            dict(kind='adamw', params=resid_params + norm_scale_params, lr=scalar_lr * 0.01, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.05),
             dict(kind='adamw', params=x0_params, lr=scalar_lr, betas=(0.96, 0.95), eps=1e-10, weight_decay=0.0),  # higher beta1 for x0
             dict(kind='adamw', params=smear_params, lr=0.2, betas=(0.8, 0.95), eps=1e-10, weight_decay=0.0),
         ]
@@ -514,7 +527,7 @@ class GPT(nn.Module):
         # Subtract mid-layer residual to remove low-level features before logit projection
         if x_backout is not None:
             x = x - self.backout_lambda.to(x.dtype) * x_backout
-        x = norm(x)
+        x = norm(x, self.final_norm_gamma)
 
         # Forward the lm_head (compute logits)
         softcap = 15 # smoothly cap the logits to the range [-softcap, softcap]

--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -245,10 +245,9 @@ class MuonAdamW(torch.optim.Optimizer):
     - Padding: if K doesn't divide evenly, we zero-pad to (ceil(K/N) * N) for comm,
       then ignore the padding when copying back.
 
-    Buffer Reuse:
-    - For Muon, we allocate stacked_grads for reduce_scatter input, then reuse the
-      same buffer as the output for all_gather (stacked_params). This saves memory
-      since we don't need both buffers simultaneously.
+    Communication buffers are reused between steps. They are derived entirely
+    from parameter shapes and live outside optimizer state, so checkpoints are
+    unchanged.
 
     Arguments:
         param_groups: List of dicts, each containing:
@@ -259,6 +258,7 @@ class MuonAdamW(torch.optim.Optimizer):
     """
     def __init__(self, param_groups: list[dict]):
         super().__init__(param_groups, defaults={})
+        self._comm_buffers: dict[tuple[int, str], Tensor] = {}
         # 0-D CPU tensors to avoid torch.compile recompilation when values change
         self._adamw_step_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
         self._adamw_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
@@ -270,6 +270,30 @@ class MuonAdamW(torch.optim.Optimizer):
         self._muon_lr_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
         self._muon_wd_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
         self._muon_beta2_t = torch.tensor(0.0, dtype=torch.float32, device="cpu")
+
+    def load_state_dict(self, state_dict):
+        result = super().load_state_dict(state_dict)
+        self._comm_buffers.clear()
+        return result
+
+    def _comm_buffer(self, owner, name: str, shape, reference: Tensor) -> Tensor:
+        """Return a shape-stable, cached communication buffer."""
+        key = (id(owner), name)
+        buffer = self._comm_buffers.get(key)
+        if (
+            buffer is None
+            or buffer.shape != torch.Size(shape)
+            or buffer.dtype != reference.dtype
+            or buffer.device != reference.device
+        ):
+            buffer = reference.new_empty(shape)
+            self._comm_buffers[key] = buffer
+        return buffer
+
+    @staticmethod
+    @torch.no_grad()
+    def _stack_into(destination: Tensor, tensors: list[Tensor]) -> None:
+        torch.stack(tensors, out=destination[:len(tensors)])
 
     def _reduce_adamw(self, group: dict, world_size: int) -> dict:
         """Launch async reduce ops for AdamW group. Returns info dict with per-param infos."""
@@ -287,7 +311,7 @@ class MuonAdamW(torch.optim.Optimizer):
                 # Large params: reduce_scatter
                 assert grad.shape[0] % world_size == 0, f"AdamW reduce_scatter requires shape[0] ({grad.shape[0]}) divisible by world_size ({world_size})"
                 rank_size = grad.shape[0] // world_size
-                grad_slice = torch.empty_like(grad[:rank_size])
+                grad_slice = self._comm_buffer(p, "adamw_grad", grad[:rank_size].shape, grad)
                 future = dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
                 param_infos[p] = dict(future=future, grad_slice=grad_slice, is_small=False)
         return dict(param_infos=param_infos)
@@ -295,24 +319,25 @@ class MuonAdamW(torch.optim.Optimizer):
     def _reduce_muon(self, group: dict, world_size: int) -> dict:
         """Launch async reduce op for Muon group. Returns info dict."""
         params = group['params']
+        p = params[0]
+        shape = p.shape
         if world_size == 1:
             # Single rank: this rank owns all params, the stacked grads are the "chunk"
-            grad_chunk = torch.stack([p.grad for p in params])
+            grad_chunk = self._comm_buffer(group, "muon_grad", (len(params), *shape), p)
+            self._stack_into(grad_chunk, [p.grad for p in params])
             return dict(future=None, grad_chunk=grad_chunk, stacked_grads=None, chunk_size=len(params))
         chunk_size = (len(params) + world_size - 1) // world_size
         padded_num_params = chunk_size * world_size
-        p = params[0]
-        shape, device, dtype = p.shape, p.device, p.dtype
 
-        # Stack grads and zero-pad to padded_num_params
-        grad_stack = torch.stack([p.grad for p in params])
-        stacked_grads = torch.empty(padded_num_params, *shape, dtype=dtype, device=device)
-        stacked_grads[:len(params)].copy_(grad_stack)
+        # Pack same-shaped grads into one collective. reduce_scatter gives every rank
+        # an equal chunk, so round up to world_size and zero the unused, reused slots.
+        stacked_grads = self._comm_buffer(group, "muon_stacked", (padded_num_params, *shape), p)
+        self._stack_into(stacked_grads, [p.grad for p in params])
         if len(params) < padded_num_params:
             stacked_grads[len(params):].zero_()
 
         # Reduce_scatter to get this rank's chunk
-        grad_chunk = torch.empty(chunk_size, *shape, dtype=dtype, device=device)
+        grad_chunk = self._comm_buffer(group, "muon_grad", (chunk_size, *shape), p)
         future = dist.reduce_scatter_tensor(grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True).get_future()
 
         return dict(future=future, grad_chunk=grad_chunk, stacked_grads=stacked_grads, chunk_size=chunk_size)
@@ -382,10 +407,11 @@ class MuonAdamW(torch.optim.Optimizer):
             state["second_momentum_buffer"] = torch.zeros(state_shape, dtype=dtype, device=device)
         red_dim = -1 if shape[-2] >= shape[-1] else -2
 
-        stacked_owned = None
+        updated_params = self._comm_buffer(group, "muon_params", (chunk_size, *shape), p)
+        stacked_owned = updated_params[:num_owned]
         if num_owned > 0:
             owned_params = [params[start_idx + i] for i in range(num_owned)]
-            stacked_owned = torch.stack(owned_params)
+            self._stack_into(updated_params, owned_params)
 
             # Fill 0-D tensors and run fused kernel
             self._muon_momentum_t.fill_(group["momentum"])
@@ -405,9 +431,6 @@ class MuonAdamW(torch.optim.Optimizer):
             return
 
         # Build the input buffer for all_gather
-        updated_params = torch.empty(chunk_size, *shape, dtype=dtype, device=device)
-        if num_owned > 0:
-            updated_params[:num_owned].copy_(stacked_owned)
         if num_owned < chunk_size:
             updated_params[num_owned:].zero_()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ cpu = [
 gpu = [
     "torch==2.9.1",
 ]
+liger = [
+    # Optional fused training losses; depends only on Torch and Triton already in the GPU stack.
+    "liger-kernel==0.8.0",
+]
 
 [tool.uv]
 default-groups = []

--- a/runs/speedrun.sh
+++ b/runs/speedrun.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # This script is configured to train your own GPT-2 grade LLM (pretraining + finetuning)
-# It is designed to run on a blank 8XH100 GPU node and takes approximately 1.5 hours to complete.
+# It is designed to run on a blank 8XH100 GPU node. Base pretraining takes
+# approximately 82 minutes; leaderboard timing excludes setup, eval, and SFT.
 
 # 1) Example launch (simplest):
 # bash runs/speedrun.sh
@@ -23,7 +24,7 @@ command -v uv &> /dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
 # create a .venv local virtual environment (if it doesn't exist)
 [ -d ".venv" ] || uv venv
 # install the repo dependencies
-uv sync --extra gpu
+uv sync --extra gpu --extra liger
 # activate venv so that `python` uses the project's venv instead of system python
 source .venv/bin/activate
 
@@ -53,8 +54,8 @@ python -m nanochat.dataset -n 8
 # The maximum total number of shards available in the entire dataset is 6542.
 python -m nanochat.dataset -n 170 &
 DATASET_DOWNLOAD_PID=$!
-# train the tokenizer with vocab size 2**15 = 32768 on ~2B characters of data
-python -m scripts.tok_train
+# Train the measured 49k tokenizer on the default ClimbMix data.
+python -m scripts.tok_train --vocab-size=49152
 # evaluate the tokenizer (report compression ratio etc.)
 python -m scripts.tok_eval
 
@@ -63,17 +64,22 @@ python -m scripts.tok_eval
 echo "Waiting for dataset download to complete..."
 wait $DATASET_DOWNLOAD_PID
 
-# d24 model (slightly undertrained to beat GPT-2 => decrease data:params ratio from compute optimal 10.5 (default) to 8)
-torchrun --standalone --nproc_per_node=8 -m scripts.base_train -- --depth=24 --target-param-data-ratio=8 --device-batch-size=16 --fp8 --run=$WANDB_RUN
+# The in-place loss makes the preferred device batch 32 fit at this vocabulary.
+torchrun --standalone --nproc_per_node=8 -m scripts.base_train -- \
+    --depth=22 --target-param-data-ratio=9.4 \
+    --device-batch-size=32 --total-batch-size=524288 \
+    --fp8 --liger-cross-entropy --learnable-rmsnorm \
+    --eval-every=999999 --core-metric-every=-1 --sample-every=-1 \
+    --run="$WANDB_RUN"
 # evaluate the model: CORE metric, BPB on train/val, and draw samples
-torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --device-batch-size=16
+torchrun --standalone --nproc_per_node=8 -m scripts.base_eval -- --model-tag=d22 --device-batch-size=16
 
 # -----------------------------------------------------------------------------
 # SFT (teach the model conversation special tokens, tool use, multiple choice)
 
-# run SFT and eval the model
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --run=$WANDB_RUN
-torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft
+# SFT is BF16, so use accumulation instead of the FP8 pretraining device batch.
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_sft -- --model-tag=d22 --device-batch-size=16 --run="$WANDB_RUN"
+torchrun --standalone --nproc_per_node=8 -m scripts.chat_eval -- -i sft --model-tag=d22
 
 # chat with the model over CLI! Leave out the -p to chat interactively
 # python -m scripts.chat_cli -p "Why is the sky blue?"

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -53,6 +53,7 @@ parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = de
 parser.add_argument("--head-dim", type=int, default=128, help="target head dimension for attention")
 parser.add_argument("--max-seq-len", type=int, default=2048, help="max context length")
 parser.add_argument("--window-pattern", type=str, default="SSSL", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
+parser.add_argument("--learnable-rmsnorm", action="store_true", help="learn gamma on MLP-input and final RMSNorms")
 # Training horizon (only one used, in order of precedence)
 parser.add_argument("--num-iterations", type=int, default=-1, help="explicit number of optimization steps (-1 = disable)")
 parser.add_argument("--target-flops", type=float, default=-1.0, help="calculate num_iterations to reach target_flops (-1 = disable)")
@@ -140,6 +141,7 @@ def build_model_meta(depth):
         sequence_len=args.max_seq_len, vocab_size=vocab_size,
         n_layer=depth, n_head=num_heads, n_kv_head=num_heads, n_embd=model_dim,
         window_pattern=args.window_pattern,
+        learnable_rmsnorm=args.learnable_rmsnorm,
     )
     with torch.device("meta"):
         model_meta = GPT(config)

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -46,6 +46,7 @@ parser.add_argument("--device-type", type=str, default="", help="cuda|cpu|mps (e
 # FP8 training
 parser.add_argument("--fp8", action="store_true", help="enable FP8 training (requires H100+ GPU)")
 parser.add_argument("--fp8-recipe", type=str, default="tensorwise", choices=["rowwise", "tensorwise"], help="FP8 scaling recipe: tensorwise (faster, recommended) or rowwise (more accurate but slower)")
+parser.add_argument("--liger-cross-entropy", action="store_true", help="use Liger's in-place softcapped cross entropy for training")
 # Model architecture
 parser.add_argument("--depth", type=int, default=20, help="depth of the Transformer model")
 parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = depth * aspect_ratio")
@@ -83,6 +84,8 @@ user_config = vars(args).copy()  # for logging
 # Compute init and wandb logging
 
 device_type = autodetect_device_type() if args.device_type == "" else args.device_type
+if args.liger_cross_entropy and device_type != "cuda":
+    parser.error("--liger-cross-entropy requires a CUDA device")
 ddp, ddp_rank, ddp_local_rank, ddp_world_size, device = compute_init(device_type)
 master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.
 synchronize = torch.cuda.synchronize if device_type == "cuda" else lambda: None
@@ -190,6 +193,16 @@ if args.fp8:
         num_fp8 = sum(1 for m in model.modules() if 'Float8' in type(m).__name__)
         num_skipped = num_linear - num_fp8
         print0(f"✓ FP8 training enabled ({args.fp8_recipe} scaling) - converted {num_fp8}/{num_linear} linear layers, skipped {num_skipped} (too small)")
+
+if args.liger_cross_entropy:
+    try:
+        from liger_kernel.transformers import LigerCrossEntropyLoss
+    except ImportError as exc:
+        raise RuntimeError("Install the optional 'liger' dependency to use --liger-cross-entropy") from exc
+    model.set_training_loss(LigerCrossEntropyLoss(
+        ignore_index=-1, reduction="mean", softcap=15, lse_square_scale=0.0,
+    ))
+    print0("✓ Liger in-place softcapped cross entropy enabled")
 
 # Context manager to temporarily disable FP8 so that model evaluation remains in BF16
 @contextmanager

--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -408,6 +408,7 @@ while True:
                     "n_kv_head": model.config.n_kv_head,
                     "n_embd": model.config.n_embd,
                     "window_pattern": model.config.window_pattern,
+                    "learnable_rmsnorm": model.config.learnable_rmsnorm,
                 },
                 "user_config": user_config, # inputs to the training script
             },

--- a/uv.lock
+++ b/uv.lock
@@ -29,10 +29,6 @@ conflicts = [[
     { package = "nanochat", extra = "gpu" },
 ]]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -921,6 +917,22 @@ wheels = [
 ]
 
 [[package]]
+name = "liger-kernel"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu') or (extra != 'extra-8-nanochat-cpu' and extra != 'extra-8-nanochat-gpu')" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-nanochat-cpu') or (extra == 'extra-8-nanochat-cpu' and extra == 'extra-8-nanochat-gpu')" },
+    { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-nanochat-gpu'" },
+    { name = "triton" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/d6/85f032b40fc30c969e817f9f3527f987b508171b46d9958befd0868855fd/liger_kernel-0.8.0.tar.gz", hash = "sha256:f98b94faf018814a0757e7b72bb8ebaaf12a78782cd09b157732acca2791e72c", size = 3989670, upload-time = "2026-04-30T23:02:15.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/6b/eb29b56f128a819e2cded552e293212c57daa949481206b82490b207deac/liger_kernel-0.8.0-py3-none-any.whl", hash = "sha256:e1f03eeb4ba6a6a413d585dacf92c4c15d164bab5844fa4ead2fede6bcac469c", size = 403120, upload-time = "2026-04-30T23:02:13.443Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1101,6 +1113,9 @@ cpu = [
 gpu = [
     { name = "torch", version = "2.9.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
+liger = [
+    { name = "liger-kernel" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1114,6 +1129,7 @@ dev = [
 requires-dist = [
     { name = "filelock", specifier = ">=3.19.0" },
     { name = "kernels", specifier = ">=0.11.7" },
+    { name = "liger-kernel", marker = "extra == 'liger'", specifier = "==0.8.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "psutil", specifier = ">=7.1.0" },
     { name = "pyarrow", specifier = ">=21.0.0" },
@@ -1125,7 +1141,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'gpu'", specifier = "==2.9.1", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "nanochat", extra = "gpu" } },
     { name = "wandb", specifier = ">=0.21.3" },
 ]
-provides-extras = ["cpu", "gpu"]
+provides-extras = ["cpu", "gpu", "liger"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Result

This is my next speedrun attempt, following the d22 + muon attempt in [nanochat #733](https://github.com/karpathy/nanochat/pull/733). It comes with a few speedups. Its main tradeoff is the new `liger-kernel` dependency. At the speedrun's 49,152-token vocabulary (the repository default remains 32,768), its efficient Triton cross-entropy cuts loss memory enough to use device batch 32 without OOMing.

| | Run 6 (current nanochat) | this PR |
|---|---:|---:|
| recipe | d24, ratio 8 | d22, ratio 9.4 + fused CE + selective RMSNorm scales |
| tokenizer vocabulary | 32,768 | 49,152 (speedrun override; default unchanged) |
| training time | 99.0 min | **81.835 +/- 0.138 min** |
| canonical val BPB | 0.71800 (N=5) | **0.718786 +/- 0.000054 (N=6)** |
| 22-task CORE | 0.262634 (N=5) | **0.261814 +/- 0.002295 (N=6)** |

Relative to Run 6, pretraining is **17.3% faster**. Val BPB differs by +0.000786 and CORE by -0.000820; CORE is within the benchmark's observed run-to-run noise, and all six runs clear the GPT-2 floor of 0.256525.

## What changed, why, and what it bought

| Change | Why | Measured effect / tradeoff |
|---|---|---|
| Restore pinned staging for `cuda:N` devices | DDP passes indexed CUDA devices, but the loader only pinned for the literal string `cuda`. | Saves **7.30 s** on average in full-recipe matches; no data-order or CPU-path change. |
| Reuse Muon communication workspaces | Shape-stable reduce-scatter/all-gather tensors were reallocated every step. | A matched 600-step screen fell from **376.96 s to 261.07 s**; long allocator stalls fell from **322 to 1**. Buffers remain outside checkpoint state. |
| Use a 49,152-token speedrun vocabulary | A larger tokenizer represents the same text with fewer tokens, so a fixed token budget covers more source text. | In an earlier controlled d22 sweep, mean CORE rose from **0.2539 to 0.2646** versus 32,768 (N=5 each); 65,536 added no CORE and was slower. The gain was not robust at d20/d26, so this remains a speedrun-only override; the repository default stays 32,768. |
| Optional Liger cross entropy | At the 49k vocabulary and device batch 32, each GPU produces ~6 GiB BF16 logits and native CE creates another ~12 GiB FP32 copy. | Device batch 32 / GA1 fits. Native CE OOMs at that shape; batch 16 / GA2 is **4.8% slower**. Evaluation and inference stay native. |
| Learn scales on MLP-input and final RMSNorms | d22 is faster per step but needs a small amount of channel-wise capacity back. Gains start at one, so initialization is unchanged. | A paired ablation improves canonical val BPB by **0.001396** for **0.98%** more time; mean CORE is unchanged. Attention-side norms remain fixed. |
| Count FP8 `Linear` subclasses in FLOPs | FP8 conversion hid converted matrix multiplies from the exact-class FLOP counter. | Corrects reported MFU from ~5% to ~56%; observability only, with no training-math or speed change. |
| Select the d22 ratio-9.4 recipe | Put the complete measured launch in `speedrun.sh`, including its 49k tokenizer and separate canonical eval. | Produces the final result above while keeping ClimbMix, Muon, scalar LR, RoPE, warmdown, final LR, and checkpoint interfaces unchanged. |

### Dependency tradeoff

The speed/memory gain requires one additional external package: pinned `liger-kernel==0.8.0` under an optional `liger` extra. Liger itself depends on Torch and Triton, which are already resolved by nanochat's GPU stack, so it is the only newly locked package.

The cost is an additional third-party compatibility. The benefit is using a maintained, tested Triton loss instead of vendoring a large custom kernel: it removes the FP32 loss copy, makes batch 32 fit, and is 4.8% faster than the native-loss batch-16 fallback. The integration is one training-only hook behind an explicit flag; installs and runs that do not request it are unchanged.

Matched d14/d20/d24 checks reduced peak allocator memory by **20.6% / 10.4% / 7.5%**; mean step time changed by **-1.7% / +0.23% / +0.39%**, with final BPB within 0.0002 at every depth.

### Why learnable RMSNorm is selective

RMSNorm still controls each activation vector's overall size. The added gains are per-channel "volume knobs" before the MLPs and output head, where the d22 ablation showed a validation benefit. Applying gains more broadly did not improve the tradeoff, so this PR leaves attention-side RMSNorms parameter-free. The setting is saved in model config so SFT reconstructs the checkpoint correctly.

### Promising directions not included

Cosmopedia was the strongest rejected data direction. A character-balanced 80/20 ClimbMix/Cosmopedia-v2 mix reached **73.917 min, 0.726888 val BPB, and 0.267123 CORE** at d22 (N=3). It did not transfer to d14: versus matched ClimbMix controls, mean val worsened by **0.004797** and CORE fell by **0.010313**, with CORE lower in every pair. A separate metadata screen that varied the college-textbook share inside a fixed 15% Cosmopedia dose also missed the CORE gate in every arm. This PR therefore stays on default ClimbMix rather than shipping a depth-specific data win. Research direction inspired by Textbooks are all you need (I'm pretty sure there's gains worth exploring further here!)

## Reproduce

```bash
torchrun --standalone --nproc_per_node=8 -m scripts.base_train -- \
    --depth=22 --target-param-data-ratio=9.4 \
    --device-batch-size=32 --total-batch-size=524288 \
    --fp8 --liger-cross-entropy --learnable-rmsnorm \
    --eval-every=999999 --core-metric-every=-1 --sample-every=-1 \
    --run="$WANDB_RUN"
```
