### PR TITLE
overlap dataloader with gpu compute via background thread prefetch

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -16,6 +16,9 @@ Fallback to the original if you have very limited data AND long documents:
 https://github.com/karpathy/nanochat/blob/3c3a3d7/nanochat/dataloader.py#L78-L117
 """
 
+import threading
+from queue import Queue
+
 import torch
 import pyarrow.parquet as pq
 
@@ -71,11 +74,148 @@ def _document_batches(split, resume_state_dict, tokenizer_batch_size):
         epoch += 1
 
 
+class _BatchBuilder:
+    """
+    Stateful batch builder for the dataloader.
+
+    Owns the document buffer, tokenizer and dataset iterator, and packs one
+    batch of rows into buffer slots. Splitting this out from the generator
+    lets us run the builder in a background thread (see _PrefetchDataloader)
+    so parquet reads, tokenization and packing overlap with GPU compute
+    instead of stalling the training loop.
+    """
+
+    def __init__(self, tokenizer, B, T, split, tokenizer_threads, tokenizer_batch_size, resume_state_dict, buffer_size):
+        self.tokenizer = tokenizer
+        self.B = B
+        self.T = T
+        self.row_capacity = T + 1
+        self.tokenizer_threads = tokenizer_threads
+        self.buffer_size = buffer_size
+        self.batches = _document_batches(split, resume_state_dict, tokenizer_batch_size)
+        self.bos_token = tokenizer.get_bos_token_id()
+        self.doc_buffer = []
+        self.pq_idx, self.rg_idx, self.epoch = 0, 0, 1
+
+    def _refill_buffer(self):
+        doc_batch, (self.pq_idx, self.rg_idx, self.epoch) = next(self.batches)
+        token_lists = self.tokenizer.encode(doc_batch, prepend=self.bos_token, num_threads=self.tokenizer_threads)
+        for tokens in token_lists:
+            self.doc_buffer.append(tokens)
+
+    def _pack_rows(self, row_buffer):
+        B, row_capacity, buffer_size = self.B, self.row_capacity, self.buffer_size
+        for row_idx in range(B):
+            pos = 0
+            while pos < row_capacity:
+                # Ensure buffer has documents
+                while len(self.doc_buffer) < buffer_size:
+                    self._refill_buffer()
+
+                remaining = row_capacity - pos
+
+                # Find largest doc that fits entirely
+                best_idx = -1
+                best_len = 0
+                for i, doc in enumerate(self.doc_buffer):
+                    doc_len = len(doc)
+                    if doc_len <= remaining and doc_len > best_len:
+                        best_idx = i
+                        best_len = doc_len
+
+                if best_idx >= 0:
+                    doc = self.doc_buffer.pop(best_idx)
+                    doc_len = len(doc)
+                    row_buffer[row_idx, pos:pos + doc_len] = torch.tensor(doc, dtype=torch.long)
+                    pos += doc_len
+                else:
+                    # No doc fits - crop shortest in buffer to fill remaining and minimize waste
+                    shortest_idx = min(range(len(self.doc_buffer)), key=lambda i: len(self.doc_buffer[i]))
+                    doc = self.doc_buffer.pop(shortest_idx)
+                    row_buffer[row_idx, pos:pos + remaining] = torch.tensor(doc[:remaining], dtype=torch.long)
+                    pos += remaining
+
+    def build(self, row_buffer, cpu_buffer, gpu_buffer, stream=None):
+        """
+        Pack one batch into the given buffers and copy it to the device.
+        - row_buffer: (B, T+1) CPU tensor used to pack rows into
+        - cpu_buffer: (2*B*T,) pinned CPU staging buffer
+        - gpu_buffer: (2*B*T,) device buffer receiving [inputs|targets]
+        Returns (inputs, targets, state_dict). When stream is not None the HtoD
+        copy is enqueued on that stream (used to share the consumer's CUDA
+        stream from the producer thread so slot reuse is safely ordered).
+        """
+        B, T = self.B, self.T
+        row_buffer = row_buffer.view(B, T + 1)
+        self._pack_rows(row_buffer)
+        cpu_inputs = cpu_buffer[:B * T].view(B, T)
+        cpu_targets = cpu_buffer[B * T:].view(B, T)
+        cpu_inputs.copy_(row_buffer[:, :-1])
+        cpu_targets.copy_(row_buffer[:, 1:])
+        state_dict = {"pq_idx": self.pq_idx, "rg_idx": self.rg_idx, "epoch": self.epoch}
+        if stream is not None:
+            with torch.cuda.stream(stream):
+                gpu_buffer.copy_(cpu_buffer, non_blocking=True)
+        else:
+            gpu_buffer.copy_(cpu_buffer)
+        inputs = gpu_buffer[:B * T].view(B, T)
+        targets = gpu_buffer[B * T:].view(B, T)
+        return inputs, targets, state_dict
+
+
+class _PrefetchDataloader:
+    """
+    Background-thread dataloader for CUDA.
+
+    Runs the _BatchBuilder in a daemon thread and hands batches out through a
+    queue, so parquet reads, tokenization and row packing overlap with the
+    GPU's forward/backward passes. A small pool of preallocated buffer slots is reused;
+    a slot is only handed back to the producer once the consumer has finished with it.
+
+    The producer shares the consumer's CUDA stream, so reusing a slot is always safe.
+    """
+
+    def __init__(self, builder, n_slots, device, B, T):
+        self._ready = Queue(maxsize=n_slots)
+        self._free = Queue()
+        self._slots = []  # each slot: (row_buffer, cpu_buffer, gpu_buffer)
+        pin_memory = device == "cuda"
+        for _ in range(n_slots):
+            row_buffer = torch.empty(B * (T + 1), dtype=torch.long, pin_memory=pin_memory)
+            cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=pin_memory)
+            gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device)
+            self._slots.append((row_buffer, cpu_buffer, gpu_buffer))
+            self._free.put(len(self._slots) - 1)
+        self._error = None
+        self._stream = torch.cuda.current_stream(device) if device == "cuda" else None
+        self._thread = threading.Thread(target=self._produce, args=(builder,), daemon=True)
+        self._thread.start()
+
+    def _produce(self, builder):
+        try:
+            while True:
+                slot_idx = self._free.get()
+                row_buffer, cpu_buffer, gpu_buffer = self._slots[slot_idx]
+                inputs, targets, state_dict = builder.build(row_buffer, cpu_buffer, gpu_buffer, stream=self._stream)
+                self._ready.put((inputs, targets, state_dict, slot_idx))
+        except Exception as e:
+            self._error = e
+
+    def get(self):
+        # block until a batch is ready. Returns (inputs, targets, state_dict, slot_idx).
+        if self._error is not None:
+            raise self._error
+        return self._ready.get()
+
+    def release(self, slot_idx):
+        self._free.put(slot_idx)
+
+
 def tokenizing_distributed_data_loader_with_state_bos_bestfit(
     tokenizer, B, T, split,
     tokenizer_threads=4, tokenizer_batch_size=128,
     device="cuda", resume_state_dict=None,
-    buffer_size=1000
+    buffer_size=1000, prefetch_batches=2,
 ):
     """
     BOS-aligned dataloader with Best-Fit Cropping.
@@ -92,73 +232,31 @@ def tokenizing_distributed_data_loader_with_state_bos_bestfit(
     - Every row starts with BOS
     - 100% utilization (no padding, every token is trained on)
     - Approximately 35% of all tokens are discarded due to cropping
+
+    On CUDA the batch builder runs in a background thread with prefetch_batches
+    buffer slots, so data prep overlaps the GPU's forward/backward passes. On
+    CPU/MPS (or prefetch_batches=0) batches are built synchronously.
     """
     assert split in ["train", "val"], "split must be 'train' or 'val'"
 
-    row_capacity = T + 1
-    batches = _document_batches(split, resume_state_dict, tokenizer_batch_size)
-    bos_token = tokenizer.get_bos_token_id()
-    doc_buffer = []
-    pq_idx, rg_idx, epoch = 0, 0, 1
+    builder = _BatchBuilder(tokenizer, B, T, split, tokenizer_threads, tokenizer_batch_size, resume_state_dict, buffer_size)
 
-    def refill_buffer():
-        nonlocal pq_idx, rg_idx, epoch
-        doc_batch, (pq_idx, rg_idx, epoch) = next(batches)
-        token_lists = tokenizer.encode(doc_batch, prepend=bos_token, num_threads=tokenizer_threads)
-        for tokens in token_lists:
-            doc_buffer.append(tokens)
+    if device == "cuda" and prefetch_batches > 0:
+        # CUDA: background producer thread so data prep overlaps forward/backward
+        loader = _PrefetchDataloader(builder, prefetch_batches, device, B, T)
+        while True:
+            inputs, targets, state_dict, slot_idx = loader.get()
+            yield inputs, targets, state_dict
+            loader.release(slot_idx)
+    else:
+        # CPU / MPS (or prefetch disabled): build batches synchronously
+        row_buffer = torch.empty(B * (T + 1), dtype=torch.long)
+        cpu_buffer = torch.empty(2 * B * T, dtype=torch.long)
+        gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device)
+        while True:
+            inputs, targets, state_dict = builder.build(row_buffer, cpu_buffer, gpu_buffer, stream=None)
+            yield inputs, targets, state_dict
 
-    # Pre-allocate buffers once: layout is [inputs (B*T) | targets (B*T)]
-    # This gives us contiguous views and a single HtoD transfer
-    use_cuda = device == "cuda"
-    row_buffer = torch.empty((B, row_capacity), dtype=torch.long) # for building rows without creating Python lists
-    cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=use_cuda) # staging area (CPU)
-    gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device) # on-device buffer
-    cpu_inputs = cpu_buffer[:B * T].view(B, T) # a few views into these buffers just for convenience
-    cpu_targets = cpu_buffer[B * T:].view(B, T)
-    inputs = gpu_buffer[:B * T].view(B, T)
-    targets = gpu_buffer[B * T:].view(B, T)
-
-    while True:
-        for row_idx in range(B):
-            pos = 0
-            while pos < row_capacity:
-                # Ensure buffer has documents
-                while len(doc_buffer) < buffer_size:
-                    refill_buffer()
-
-                remaining = row_capacity - pos
-
-                # Find largest doc that fits entirely
-                best_idx = -1
-                best_len = 0
-                for i, doc in enumerate(doc_buffer):
-                    doc_len = len(doc)
-                    if doc_len <= remaining and doc_len > best_len:
-                        best_idx = i
-                        best_len = doc_len
-
-                if best_idx >= 0:
-                    doc = doc_buffer.pop(best_idx)
-                    doc_len = len(doc)
-                    row_buffer[row_idx, pos:pos + doc_len] = torch.tensor(doc, dtype=torch.long)
-                    pos += doc_len
-                else:
-                    # No doc fits - crop shortest in buffer to fill remaining and minimize waste
-                    shortest_idx = min(range(len(doc_buffer)), key=lambda i: len(doc_buffer[i]))
-                    doc = doc_buffer.pop(shortest_idx)
-                    row_buffer[row_idx, pos:pos + remaining] = torch.tensor(doc[:remaining], dtype=torch.long)
-                    pos += remaining
-
-        # Copy to pinned CPU buffer, then single HtoD transfer
-        cpu_inputs.copy_(row_buffer[:, :-1])
-        cpu_targets.copy_(row_buffer[:, 1:])
-
-        state_dict = {"pq_idx": pq_idx, "rg_idx": rg_idx, "epoch": epoch}
-
-        # Single HtoD copy into persistent GPU buffer and yield
-        gpu_buffer.copy_(cpu_buffer, non_blocking=use_cuda)
-        yield inputs, targets, state_dict
 
 def tokenizing_distributed_data_loader_bos_bestfit(*args, **kwargs):
     """Helper that omits state_dict from yields."""


### PR DESCRIPTION
The pretraining dataloader (**tokenizing_distributed_data_loader_with_state_bos_bestfit**) was a synchronous generator: every next() call performed parquet reads, tiktoken tokenization, and the best-fit row packing on the CPU between micro-steps. When that CPU work took as long as (or longer than) the forward/backward pass, the GPU sat idle.
This PR moves batch building into a background thread with a small pool of preallocated buffer slots, so data prep overlaps the GPU's forward/backward passes. The batches produced are byte-identical to before: same documents, same packing order, same inputs/targets shift, same resume state_dict. The packing algorithm is untouched; only where/when it runs changed.

#### What changed (nanochat/dataloader.py)
- `_BatchBuilder` the original generator's batch-building logic, moved verbatim into a stateful class with a build(row_buffer, cpu_buffer, gpu_buffer, stream=None) method.
- `_PrefetchDataloader` daemon producer thread + queue-based slot pool (prefetch_batches=2 by default). A slot is only handed back to the producer after the consumer is done with it. The producer enqueues the async HtoD copy on the consumer's CUDA stream, so slot reuse is safely ordered (no data race) without any extra synchronization.
- Public API unchanged: new trailing kwarg prefetch_batches=2 (can be set to 0 for original synchronous behavior).