### PR TITLE
fix(sft): pass max_tokens to render_conversation so conversations fit

### DIFF
--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -205,7 +205,7 @@ def sft_data_generator_bos_bestfit(split, buffer_size=100):
         nonlocal cursor, epoch
         while len(conv_buffer) < buffer_size:
             conversation = dataset[cursor]
-            ids, mask = tokenizer.render_conversation(conversation)
+            ids, mask = tokenizer.render_conversation(conversation, max_tokens=row_capacity)
             conv_buffer.append((ids, mask))
             cursor += ddp_world_size
             if cursor >= dataset_size:


### PR DESCRIPTION
I was experimenting with nanochat using the small model for quick turn around  when I ran into this issue

### Symptom:

SFT always collapses with `loss: nan` on step 4. I've tried this on both AMD GPU and CPU, and both failed at the exact same spot.

```
Step 00000 | Validation bpb: 1.0596
step 00001 (0.13%) | loss: 1.874766 | lrm: 0.01 | dt: 1308.03ms | tok/sec: 12,525 | mfu: 0.00 | epoch: 1 | total time: 0.00m
step 00002 (0.20%) | loss: 2.581178 | lrm: 0.01 | dt: 82.70ms | tok/sec: 198,125 | mfu: 0.00 | epoch: 1 | total time: 0.00m
step 00003 (0.27%) | loss: 2.784387 | lrm: 0.01 | dt: 82.80ms | tok/sec: 197,880 | mfu: 0.00 | epoch: 1 | total time: 0.00m
step 00004 (0.33%) | loss: nan | lrm: 0.02 | dt: 85.34ms | tok/sec: 191,989 | mfu: 0.00 | epoch: 1 | total time: 0.00m
step 00005 (0.40%) | loss: nan | lrm: 0.02 | dt: 85.83ms | tok/sec: 190,889 | mfu: 0.00 | epoch: 1 | total time: 0.00m
```

### Root cause:

* Line 209 (bug): `render_conversation(conversation)` — no max_tokens passed, so it uses the default of 2048. Conversations can be up to 2048 tokens long.

* The best-fit packing loop (lines 232-239) looks for conversations where `conv_len <= remaining`. If every conversation in the buffer is longer than row_capacity (513), none of them can fit in an empty row. The code falls through to the padding branch (line 247) and fills the entire row with BOS padding tokens — every single row becomes garbage with zero training signal.

* The fix is to always pass a value for `max_tokens` instead of relying on the default (`2048`). 