### PR TITLE
Stop requantizing fp8 weight; actually pin dataloader buffers

### DIFF
--- a/nanochat/dataloader.py
+++ b/nanochat/dataloader.py
@@ -108,14 +108,10 @@ def tokenizing_distributed_data_loader_with_state_bos_bestfit(
         for tokens in token_lists:
             doc_buffer.append(tokens)
 
-    # Pre-allocate buffers once: layout is [inputs (B*T) | targets (B*T)]
-    # This gives us contiguous views and a single HtoD transfer
-    use_cuda = device == "cuda"
+    # Layout is [inputs (B*T) | targets (B*T)], which gives contiguous views and a single HtoD transfer
+    use_cuda = torch.device(device).type == "cuda"
     row_buffer = torch.empty((B, row_capacity), dtype=torch.long) # for building rows without creating Python lists
-    cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=use_cuda) # staging area (CPU)
-    gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device) # on-device buffer
-    cpu_inputs = cpu_buffer[:B * T].view(B, T) # a few views into these buffers just for convenience
-    cpu_targets = cpu_buffer[B * T:].view(B, T)
+    gpu_buffer = torch.empty(2 * B * T, dtype=torch.long, device=device) # on-device buffer, reused every batch
     inputs = gpu_buffer[:B * T].view(B, T)
     targets = gpu_buffer[B * T:].view(B, T)
 
@@ -150,7 +146,12 @@ def tokenizing_distributed_data_loader_with_state_bos_bestfit(
                     row_buffer[row_idx, pos:pos + remaining] = torch.tensor(doc[:remaining], dtype=torch.long)
                     pos += remaining
 
-        # Copy to pinned CPU buffer, then single HtoD transfer
+        # The staging buffer is allocated per batch rather than hoisted: the caching host
+        # allocator will not recycle a pinned block while the async copy that reads it is
+        # still outstanding.
+        cpu_buffer = torch.empty(2 * B * T, dtype=torch.long, pin_memory=use_cuda) # staging area (CPU)
+        cpu_inputs = cpu_buffer[:B * T].view(B, T)
+        cpu_targets = cpu_buffer[B * T:].view(B, T)
         cpu_inputs.copy_(row_buffer[:, :-1])
         cpu_targets.copy_(row_buffer[:, 1:])
 

--- a/nanochat/fp8.py
+++ b/nanochat/fp8.py
@@ -49,9 +49,10 @@ torch._scaled_mm behind the scenes. This is ~2000 lines of code because you need
 a handler for every tensor operation that might touch an FP8 tensor.
 
 We take a simpler approach: a single autograd.Function (_Float8Matmul) that takes
-full-precision inputs, quantizes to FP8 internally, calls _scaled_mm, and returns
-full-precision outputs. Marked @allow_in_graph so torch.compile treats it as one
-opaque node rather than trying to trace inside.
+full-precision inputs, quantizes them to FP8 (the weight may arrive already
+quantized), calls _scaled_mm, and returns full-precision outputs. Marked
+@allow_in_graph so torch.compile treats it as one opaque node rather than trying
+to trace inside.
 
 The trade-off is in how torch.compile sees the two approaches:
   - torchao: compile decomposes the tensor subclass (via __tensor_flatten__) and
@@ -107,6 +108,11 @@ def _to_fp8(x, fp8_dtype):
     return x_fp8, inv_scale
 
 
+# Compiled so the amax reduction and the cast fuse into two kernels; run eagerly
+# this chain materialises five full-size fp32 intermediates per weight.
+_to_fp8_compiled = torch.compile(_to_fp8, dynamic=False)
+
+
 def _to_col_major(x):
     """Rearrange a 2D tensor's memory to column-major layout.
 
@@ -123,17 +129,15 @@ def _to_col_major(x):
 # for how this differs from torchao's tensor subclass approach.
 @torch._dynamo.allow_in_graph
 class _Float8Matmul(torch.autograd.Function):
-    """Custom autograd for the three FP8 GEMMs of a Linear layer.
-
-    The forward quantizes input and weight to FP8 and saves
-    the quantized tensors + scales for backward.
-    """
+    """Custom autograd for the three FP8 GEMMs of a Linear layer."""
 
     @staticmethod
-    def forward(ctx, input_2d, weight):
-        # Quantize both operands to e4m3 (higher precision format)
+    def forward(ctx, input_2d, weight, weight_fp8=None, weight_inv=None):
+        # Quantize to e4m3 (higher precision format). weight is still an input even
+        # when its fp8 form is supplied, so autograd routes grad_weight to it.
         input_fp8, input_inv = _to_fp8(input_2d, torch.float8_e4m3fn)
-        weight_fp8, weight_inv = _to_fp8(weight, torch.float8_e4m3fn)
+        if weight_fp8 is None:
+            weight_fp8, weight_inv = _to_fp8(weight, torch.float8_e4m3fn)
         ctx.save_for_backward(input_fp8, input_inv, weight_fp8, weight_inv)
 
         # output = input @ weight.T
@@ -189,7 +193,7 @@ class _Float8Matmul(torch.autograd.Function):
             use_fast_accum=False,
         )
 
-        return grad_input, grad_weight
+        return grad_input, grad_weight, None, None
 
 
 class Float8Linear(nn.Linear):
@@ -197,7 +201,20 @@ class Float8Linear(nn.Linear):
 
     Weights and biases remain in their original precision (e.g. fp32/bf16).
     Only the matmul is performed in FP8 via the _Float8Matmul autograd function.
+
+    The input changes every call and is quantized inside the matmul; the weight
+    changes only per optimizer step, so its quantization is held here. A held value
+    is used as-is until quantize_weight() replaces it — while it is None the matmul
+    quantizes the weight per call.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.w_fp8 = None
+        self.w_inv_scale = None
+
+    def quantize_weight(self):
+        self.w_fp8, self.w_inv_scale = _to_fp8_compiled(self.weight, torch.float8_e4m3fn)
 
     def forward(self, input):
         # Cast input to COMPUTE_DTYPE (typically bf16) since _scaled_mm expects
@@ -206,7 +223,7 @@ class Float8Linear(nn.Linear):
         # _scaled_mm only works on 2D tensors, so flatten batch dimensions
         orig_shape = input.shape
         input_2d = input.reshape(-1, orig_shape[-1])
-        output = _Float8Matmul.apply(input_2d, self.weight)
+        output = _Float8Matmul.apply(input_2d, self.weight, self.w_fp8, self.w_inv_scale)
         output = output.reshape(*orig_shape[:-1], output.shape[-1])
         if self.bias is not None:
             output = output + self.bias.to(output.dtype)

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -164,14 +164,16 @@ if resuming:
 # -----------------------------------------------------------------------------
 # FP8 training initialization and management (this has to be done before torch.compile)
 
+fp8_modules = []
+
 # Convert Linear layers to Float8Linear if --fp8 is set
 if args.fp8:
     if device_type != "cuda":
         print0("Warning: FP8 training requires CUDA, ignoring --fp8 flag")
     else:
-        # our custom fp8 is simpler than torchao, written for exact API compatibility
-        from nanochat.fp8 import Float8LinearConfig, convert_to_float8_training
-        # from torchao.float8 import Float8LinearConfig, convert_to_float8_training
+        # our custom fp8 is simpler than torchao and mirrors its API apart from quantize_weight()
+        from nanochat.fp8 import Float8Linear, Float8LinearConfig, convert_to_float8_training
+        # from torchao.float8 import Float8Linear, Float8LinearConfig, convert_to_float8_training
         import torch.nn as nn
 
         # Filter: dims must be divisible by 16 (FP8 hardware requirement) large enough
@@ -187,6 +189,7 @@ if args.fp8:
         fp8_config = Float8LinearConfig.from_recipe_name(args.fp8_recipe)
         num_linear = sum(1 for m in model.modules() if isinstance(m, nn.Linear))
         convert_to_float8_training(model, config=fp8_config, module_filter_fn=fp8_module_filter)
+        fp8_modules = [m for m in model.modules() if isinstance(m, Float8Linear)]
         num_fp8 = sum(1 for m in model.modules() if 'Float8' in type(m).__name__)
         num_skipped = num_linear - num_fp8
         print0(f"✓ FP8 training enabled ({args.fp8_recipe} scaling) - converted {num_fp8}/{num_linear} linear layers, skipped {num_skipped} (too small)")
@@ -507,6 +510,9 @@ while True:
     # evaluate the gradient
     synchronize()
     t0 = time.time()
+    # The weight only changes once per step, so one quantization covers every micro-step
+    for m in fp8_modules:
+        m.quantize_weight()
     for micro_step in range(grad_accum_steps):
         loss = model(x, y)
         train_loss = loss.detach() # for logging

--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -1,0 +1,40 @@
+"""
+Test the FP8 quantization path: the compiled weight-quantization used once per
+optimizer step must produce byte-identical results to quantizing per call.
+
+python -m pytest tests/test_fp8.py -v
+"""
+
+import pytest
+import torch
+
+from nanochat.fp8 import _to_fp8, _to_fp8_compiled
+
+# Dims must be divisible by 16, as the FP8 gate requires.
+SHAPES = [(64, 128), (1536, 1536), (2048, 1536)]
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_compiled_quantization_is_byte_identical_to_eager(shape, dtype):
+    torch.manual_seed(0)
+    w = torch.randn(*shape, dtype=dtype)
+
+    eager_fp8, eager_inv = _to_fp8(w, torch.float8_e4m3fn)
+    compiled_fp8, compiled_inv = _to_fp8_compiled(w, torch.float8_e4m3fn)
+
+    # fp8 tensors have no equality op, so compare the raw bytes.
+    assert torch.equal(eager_fp8.view(torch.uint8), compiled_fp8.view(torch.uint8))
+    assert torch.equal(eager_inv, compiled_inv)
+
+
+def test_quantization_is_deterministic():
+    """The cache is only sound because quantizing the same weight twice agrees."""
+    torch.manual_seed(0)
+    w = torch.randn(1536, 1536, dtype=torch.bfloat16)
+
+    first_fp8, first_inv = _to_fp8_compiled(w, torch.float8_e4m3fn)
+    second_fp8, second_inv = _to_fp8_compiled(w, torch.float8_e4m3fn)
+
+    assert torch.equal(first_fp8.view(torch.uint8), second_fp8.view(torch.uint8))
+    assert torch.equal(first_inv, second_inv)


### PR DESCRIPTION
- **fp8**: the weight only changes once per optimizer step, but it was requantized on
every micro-batch. now quantized once per step and held. 
- **dataloader**: `device` is a `torch.device`, which never compares equal to a string, so
the buffer was never actually pinned. now that it is, reusing one hoisted buffer across
an async copy is unsafe — hence the per-batch alloc.

