### PR TITLE
Report a real peak memory number on CPU/MPS instead of 0.00MiB

### DIFF
--- a/nanochat/common.py
+++ b/nanochat/common.py
@@ -213,6 +213,30 @@ def compute_cleanup():
     if is_ddp_initialized():
         dist.destroy_process_group()
 
+class PeakMemoryTracker:
+    """Peak device memory allocated over a run, in bytes (0 if N/A).
+
+    cuda keeps a true high-water mark in the allocator, so update() is a no-op.
+    mps has no peak API, so we sample current_allocated_memory() once per step and
+    keep the running max. We can't use driver_allocated_memory(): that's the Metal
+    allocator's *reserved* pool (the analogue of max_memory_reserved), which reads
+    far above what's allocated and barely moves for spikes that fit inside the pool.
+    The mps number is a lower bound -- the true peak is mid-backward, which only the
+    allocator can see.
+    """
+    def __init__(self, device_type):
+        self.device_type = device_type
+        self._peak = 0
+
+    def update(self):
+        if self.device_type == "mps":
+            self._peak = max(self._peak, torch.mps.current_allocated_memory())
+
+    def peak(self):
+        if self.device_type == "cuda":
+            return torch.cuda.max_memory_allocated()
+        return self._peak
+
 class DummyWandb:
     """Useful if we wish to not use wandb but have all the same signatures"""
     def __init__(self):

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -27,7 +27,7 @@ import torch.distributed as dist
 
 from nanochat.gpt import GPT, GPTConfig, Linear
 from nanochat.dataloader import tokenizing_distributed_data_loader_bos_bestfit, tokenizing_distributed_data_loader_with_state_bos_bestfit
-from nanochat.common import compute_init, compute_cleanup, print0, DummyWandb, print_banner, get_base_dir, autodetect_device_type, get_peak_flops, COMPUTE_DTYPE, COMPUTE_DTYPE_REASON, is_ddp_initialized
+from nanochat.common import compute_init, compute_cleanup, print0, DummyWandb, print_banner, get_base_dir, autodetect_device_type, get_peak_flops, PeakMemoryTracker, COMPUTE_DTYPE, COMPUTE_DTYPE_REASON, is_ddp_initialized
 from nanochat.tokenizer import get_tokenizer, get_token_bytes
 from nanochat.checkpoint_manager import save_checkpoint, load_checkpoint
 from nanochat.loss_eval import evaluate_bpb
@@ -86,7 +86,7 @@ device_type = autodetect_device_type() if args.device_type == "" else args.devic
 ddp, ddp_rank, ddp_local_rank, ddp_world_size, device = compute_init(device_type)
 master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.
 synchronize = torch.cuda.synchronize if device_type == "cuda" else lambda: None
-get_max_memory = torch.cuda.max_memory_allocated if device_type == "cuda" else lambda: 0
+peak_memory = PeakMemoryTracker(device_type)
 if device_type == "cuda":
     gpu_device_name = torch.cuda.get_device_name(0)
     gpu_peak_flops = get_peak_flops(gpu_device_name)
@@ -537,6 +537,7 @@ while True:
         scaler.update()
     else:
         optimizer.step()
+    peak_memory.update() # params + grads + optimizer state all live here
     model.zero_grad(set_to_none=True)
     train_loss_f = train_loss.item() # .item() is a CPU-GPU sync point
     synchronize()
@@ -594,7 +595,7 @@ while True:
         gc.collect() # manually collect, just to be safe for very, very long runs
 
 # print a few more stats
-print0(f"Peak memory usage: {get_max_memory() / 1024 / 1024:.2f}MiB")
+print0(f"Peak memory usage: {peak_memory.peak() / 1024 / 1024:.2f}MiB")
 print0(f"Total training time: {total_training_time/60:.2f}m")
 if val_bpb is not None:
     print0(f"Minimum validation bpb: {min_val_bpb:.6f}")

--- a/scripts/chat_sft.py
+++ b/scripts/chat_sft.py
@@ -16,7 +16,7 @@ os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 import time
 import wandb
 import torch
-from nanochat.common import compute_init, compute_cleanup, print0, DummyWandb, get_base_dir, autodetect_device_type, get_peak_flops, COMPUTE_DTYPE, COMPUTE_DTYPE_REASON, is_ddp_initialized
+from nanochat.common import compute_init, compute_cleanup, print0, DummyWandb, get_base_dir, autodetect_device_type, get_peak_flops, PeakMemoryTracker, COMPUTE_DTYPE, COMPUTE_DTYPE_REASON, is_ddp_initialized
 from nanochat.tokenizer import get_token_bytes
 from nanochat.checkpoint_manager import save_checkpoint, load_model, load_optimizer_state
 from nanochat.loss_eval import evaluate_bpb
@@ -74,7 +74,7 @@ ddp, ddp_rank, ddp_local_rank, ddp_world_size, device = compute_init(device_type
 master_process = ddp_rank == 0
 print0(f"COMPUTE_DTYPE: {COMPUTE_DTYPE} ({COMPUTE_DTYPE_REASON})")
 synchronize = torch.cuda.synchronize if device_type == "cuda" else lambda: None
-get_max_memory = torch.cuda.max_memory_allocated if device_type == "cuda" else lambda: 0
+peak_memory = PeakMemoryTracker(device_type)
 if device_type == "cuda":
     gpu_device_name = torch.cuda.get_device_name(0)
     gpu_peak_flops = get_peak_flops(gpu_device_name)
@@ -448,6 +448,7 @@ while True:
         scaler.update()
     else:
         optimizer.step()
+    peak_memory.update() # params + grads + optimizer state all live here
     model.zero_grad(set_to_none=True)
     synchronize()
     t1 = time.time()
@@ -490,7 +491,7 @@ while True:
         gc.collect() # manually collect, just to be safe for very long runs
 
 # print a few more stats
-print0(f"Peak memory usage: {get_max_memory() / 1024 / 1024:.2f}MiB")
+print0(f"Peak memory usage: {peak_memory.peak() / 1024 / 1024:.2f}MiB")
 print0(f"Total training time: {total_training_time/60:.2f}m")
 print0(f"Minimum validation bpb: {min_val_bpb:.4f}")
 

--- a/tests/test_peak_memory.py
+++ b/tests/test_peak_memory.py
@@ -1,0 +1,73 @@
+"""
+Tests for PeakMemoryTracker, which reports "Peak memory usage" in base_train/chat_sft.
+
+The interesting case is mps, which has no peak API: the tracker samples
+current_allocated_memory() per step and keeps the running max. The tempting
+alternative, driver_allocated_memory(), reports the Metal allocator's reserved
+pool and is not comparable to the cuda number printed under the same label;
+test_mps_peak_is_allocated_not_reserved pins that distinction.
+
+The cpu case runs in CI without a GPU; the mps/cuda cases skip when absent.
+"""
+import pytest
+import torch
+
+from nanochat.common import PeakMemoryTracker
+
+
+def test_cpu_reports_zero():
+    # cpu has no device memory to report; update() must stay safe to call
+    tracker = PeakMemoryTracker("cpu")
+    assert tracker.peak() == 0
+    for _ in range(3):
+        tracker.update()
+    assert tracker.peak() == 0
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires MPS")
+def test_mps_tracks_spike():
+    tracker = PeakMemoryTracker("mps")
+    assert tracker.peak() == 0
+
+    spike_bytes = 64 * 1024 * 1024  # 64 MiB, comfortably above allocator noise
+    baseline = torch.empty(1024, 1024, dtype=torch.float32, device="mps")  # 4 MiB
+    tracker.update()
+    after_baseline = tracker.peak()
+    assert after_baseline > 0, "tracker should see a live allocation"
+
+    # a transient spike that is freed before the run ends: the whole point is that
+    # the final number remembers it
+    spike = torch.empty(spike_bytes // 4, dtype=torch.float32, device="mps")
+    tracker.update()
+    at_spike = tracker.peak()
+    assert at_spike >= after_baseline + spike_bytes, (
+        f"spike not captured: {at_spike} < {after_baseline} + {spike_bytes}"
+    )
+
+    del spike
+    torch.mps.synchronize()
+    tracker.update()
+    assert tracker.peak() == at_spike, "peak must not decay after memory is freed"
+
+    del baseline
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires MPS")
+def test_mps_peak_is_allocated_not_reserved():
+    # guards against regressing to driver_allocated_memory(), which reports the
+    # reserved pool and reads well above what the process has actually allocated
+    tracker = PeakMemoryTracker("mps")
+    t = torch.empty(1024, 1024, dtype=torch.float32, device="mps")
+    tracker.update()
+    assert tracker.peak() <= torch.mps.driver_allocated_memory()
+    del t
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_cuda_delegates_to_allocator():
+    # on cuda the allocator owns the high-water mark; update() must not interfere
+    tracker = PeakMemoryTracker("cuda")
+    t = torch.empty(1024, 1024, dtype=torch.float32, device="cuda")
+    tracker.update()
+    assert tracker.peak() == torch.cuda.max_memory_allocated()
+    del t


### PR DESCRIPTION
Fixes #838.

**CUDA behavior is unchanged by construction.** `update()` is a no-op there and `peak()` returns `torch.cuda.max_memory_allocated()`, exactly what `get_max_memory` returned before. Nothing about an 8xH100 run moves.

## The problem

```python
get_max_memory = torch.cuda.max_memory_allocated if device_type == "cuda" else lambda: 0
```

`base_train`/`chat_sft` end with `Peak memory usage: 0.00MiB` on every non-CUDA device.

## The change

`PeakMemoryTracker(device_type)` in `common.py`, 24 lines. torch exposes no peak API for MPS, so on that device it samples `current_allocated_memory()` once per step and keeps the running max. Sampled after `optimizer.step()` and before `zero_grad()`, where params, grads and optimizer state all coexist. cpu stays 0.

The per-step cost off-MPS is one attribute compare. No added syncs.

## Why not driver_allocated_memory()

It's the Metal caching allocator's **reserved** pool — the analogue of `max_memory_reserved()`, not `max_memory_allocated()`, so it isn't comparable to the CUDA number printed under the same label. Measured on an M4 Max, depth-6,
seq 512, batch 32:

```
this PR                    :  1499.78 MiB
driver_allocated_memory()  : 11322.84 MiB
```

It also barely tracks spikes, since one that fits inside the already-reserved pool doesn't grow the pool. In a controlled bench an 8x batch-size increase moved it 1050.7 -> 1050.8 MiB (0.01%) while allocated memory went 289.4 -> 305.1 MB.

## Known limitation, stated on the class

The MPS number is a **lower bound**. The true high-water is mid-backward with activations and partial grads live, and only the allocator sees that. There is no way to get the exact figure without a torch-side change. A lower bound in CUDA's units is still strictly better than `0.00`.

## Testing

`tests/test_peak_memory.py` — cpu returns 0 and `update()` is safe to call; MPS captures a transient spike and does not decay after it's freed; the reported peak stays at or below `driver_allocated_memory()`, so a future change can't quietly regress to reporting the reserved pool.

`test_cuda_delegates_to_allocator` is included but **I have no CUDA hardware to run it on** — the CUDA path is unchanged by construction rather than by measurement. Worth a second pair of eyes on that line specifically.

Full suite on macOS: 46 passed, 15 skipped, plus 1 pre-existing failure (`test_execution.py::test_memory_limit`, unrelated — `RLIMIT_AS`/`RLIMIT_DATA` don't constrain a `bytearray` allocation on Darwin, present on clean master).

## Note on overlap

This touches `base_train.py:89` and `chat_sft.py:77`. My open #792 touches line 88 of each and the same import line. Whichever lands second will conflict on those two lines; it's a one-line resolution either way. The PRs are independent otherwise.
