### PR TITLE
Remove unused TaskSequence class

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ I've published a number of guides that might contain helpful information, most r
 │   └── tok_train.py                # Tokenizer: train it
 ├── tasks
 │   ├── arc.py                      # Multiple choice science questions
-│   ├── common.py                   # TaskMixture | TaskSequence
+│   ├── common.py                   # TaskMixture
 │   ├── gsm8k.py                    # 8K Grade School Math questions
 │   ├── humaneval.py                # Misnomer; Simple Python coding task
 │   ├── mmlu.py                     # Multiple choice questions, broad topics

--- a/tasks/common.py
+++ b/tasks/common.py
@@ -161,29 +161,6 @@ class TaskMixture(Task):
         return self.tasks[task_idx][local_idx]
 
 
-class TaskSequence(Task):
-    """
-    For SFT Training sometimes we want to sequentially train on a list of tasks.
-    This is useful for cases that require a training curriculum.
-    """
-
-    def __init__(self, tasks, **kwargs):
-        super().__init__(**kwargs)
-        self.tasks = tasks
-        self.lengths = [len(task) for task in self.tasks]
-        self.num_conversations = sum(self.lengths)
-
-    def num_examples(self):
-        return self.num_conversations
-
-    def get_example(self, index):
-        assert 0 <= index < self.num_conversations, f"Index {index} out of range for sequence with {self.num_conversations} conversations"
-        for task_idx, task_length in enumerate(self.lengths):
-            if index < task_length:
-                return self.tasks[task_idx][index]
-            index -= task_length
-
-
 def render_mc(question, letters, choices):
     """
     The common multiple choice rendering format we will use.


### PR DESCRIPTION
Closes #840.

Removes the unused `TaskSequence` class from `tasks/common.py`.

`TaskSequence` has never been referenced since the initial commit. Its only import (`scripts/chat_sft.py`) was already removed in 190d951 ("delete unused imports"), leaving the class body with no callers, tests, or dynamic construction anywhere in the repo:

- `chat_sft.py` constructs `TaskMixture` only.
- `tests/test_tasks.py` imports `Task, TaskMixture, HubDataset, render_mc` — never `TaskSequence`.
- No `getattr` / `importlib` / string-name lookup; no `tasks/__init__.py` re-export; not exported via `pyproject.toml`.

This PR removes the class and drops it from the `README.md` file-tree comment. `TaskMixture` (the mixture-based path actually used by `chat_sft.py`) is untouched.