### PR TITLE
optim: keep async collective inputs and Work handles alive until wait()

### DIFF
--- a/nanochat/optim.py
+++ b/nanochat/optim.py
@@ -281,15 +281,15 @@ class MuonAdamW(torch.optim.Optimizer):
                 param_infos[p] = dict(future=None, grad_slice=grad, is_small=True)
             elif p.numel() < 1024:
                 # Small params: all_reduce (no scatter/gather needed)
-                future = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
-                param_infos[p] = dict(future=future, grad_slice=grad, is_small=True)
+                work = dist.all_reduce(grad, op=dist.ReduceOp.AVG, async_op=True); future = work.get_future()
+                param_infos[p] = dict(future=future, grad_slice=grad, is_small=True, work=work)
             else:
                 # Large params: reduce_scatter
                 assert grad.shape[0] % world_size == 0, f"AdamW reduce_scatter requires shape[0] ({grad.shape[0]}) divisible by world_size ({world_size})"
                 rank_size = grad.shape[0] // world_size
                 grad_slice = torch.empty_like(grad[:rank_size])
-                future = dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True).get_future()
-                param_infos[p] = dict(future=future, grad_slice=grad_slice, is_small=False)
+                work = dist.reduce_scatter_tensor(grad_slice, grad, op=dist.ReduceOp.AVG, async_op=True); future = work.get_future()
+                param_infos[p] = dict(future=future, grad_slice=grad_slice, is_small=False, work=work)
         return dict(param_infos=param_infos)
 
     def _reduce_muon(self, group: dict, world_size: int) -> dict:
@@ -313,9 +313,9 @@ class MuonAdamW(torch.optim.Optimizer):
 
         # Reduce_scatter to get this rank's chunk
         grad_chunk = torch.empty(chunk_size, *shape, dtype=dtype, device=device)
-        future = dist.reduce_scatter_tensor(grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True).get_future()
+        work = dist.reduce_scatter_tensor(grad_chunk, stacked_grads, op=dist.ReduceOp.AVG, async_op=True); future = work.get_future()
 
-        return dict(future=future, grad_chunk=grad_chunk, stacked_grads=stacked_grads, chunk_size=chunk_size)
+        return dict(future=future, grad_chunk=grad_chunk, stacked_grads=stacked_grads, chunk_size=chunk_size, work=work, grad_stack_alive=grad_stack)
 
     def _compute_adamw(self, group: dict, info: dict, gather_list: list, rank: int, world_size: int) -> None:
         """Wait for reduce, compute AdamW updates, launch gathers for large params."""
@@ -356,8 +356,8 @@ class MuonAdamW(torch.optim.Optimizer):
 
             # Large params need all_gather
             if not pinfo['is_small']:
-                future = dist.all_gather_into_tensor(p, p_slice, async_op=True).get_future()
-                gather_list.append(dict(future=future, params=None))
+                work = dist.all_gather_into_tensor(p, p_slice, async_op=True); future = work.get_future()
+                gather_list.append(dict(future=future, params=None, work=work, gather_inputs_alive=p_slice))
 
     def _compute_muon(self, group: dict, info: dict, gather_list: list, rank: int) -> None:
         """Wait for reduce, compute Muon updates, launch gather."""
@@ -413,14 +413,15 @@ class MuonAdamW(torch.optim.Optimizer):
 
         # Reuse stacked_grads buffer for all_gather output
         stacked_params = info["stacked_grads"]
-        future = dist.all_gather_into_tensor(stacked_params, updated_params, async_op=True).get_future()
-        gather_list.append(dict(future=future, stacked_params=stacked_params, params=params))
+        work = dist.all_gather_into_tensor(stacked_params, updated_params, async_op=True); future = work.get_future()
+        gather_list.append(dict(future=future, stacked_params=stacked_params, params=params, work=work, gather_inputs_alive=updated_params))
 
     def _finish_gathers(self, gather_list: list) -> None:
         """Wait for all gathers and copy Muon params back."""
         for info in gather_list:
             if info["future"] is not None:
                 info["future"].wait()
+                if info.get("work") is not None: info["work"].wait()
             if info["params"] is not None:
                 # Muon: copy from stacked buffer back to individual params
                 torch._foreach_copy_(info["params"], list(info["stacked_params"][:len(info["params"])].unbind(0)))


### PR DESCRIPTION
I hit this while pretraining a 1.5B Persian model on nanochat (8×H100, bf16), so the Muon path has had a hard workout. Sharing a latent lifetime bug I found in it.

`MuonAdamW.step()` overlaps communication with compute by launching `reduce_scatter_tensor` / `all_gather_into_tensor` with `async_op=True`, keeping only the returned Future. Two lifetime issues:

1. In `_compute_muon`, the input of the final all_gather, `updated_params`, is a local tensor that goes out of scope as soon as the method returns — before `_finish_gathers` waits on the collective. Nothing else references it, so the CUDA caching allocator can hand its block to the next allocation (usually the next group's `updated_params`, immediately overwritten) while NCCL is still reading it.
2. The `Work` objects are dropped everywhere (`.get_future()` only). On current PyTorch (checked on 2.9.1 + NCCL 2.27.5) the NCCL backend doesn't `record_stream` collective arguments by default, so correctness relies on the caller keeping tensors referenced until `wait()`.

If the timing lines up, the gather can deliver torn data: every rank keeps its own shard of each Muon matrix correct and stale bytes for the other `world_size - 1` shards.

**Fix:** keep each async collective's input tensor and its `Work` referenced in the info dicts that already flow to the waits, and have `_finish_gathers` call `work.wait()` alongside `future.wait()` before the copy-back. No behaviour change on the happy path, no extra memory beyond what was already in flight, no extra synchronisation beyond the existing waits.

**Honest scope:** I first suspected this path when my run hit repeated loss plateaus around step 27,000, but forensics exonerated it for my actual incident — with updates frozen at a plateau, all-rank parameter checks showed 0/255 tensors differing, and the plateaus reproduced under fully synchronous collectives too. My real root cause was attention-logit growth in a custom no-QK-norm model variant, unrelated to this optimizer. Submitting anyway: the lifetime hazard is real under current PyTorch semantics and cheap to close. I'm presenting it as a hardening fix with a consistency test, not a field-failure fix — `repro_torn_gather.py` (in a comment below, not the diff) churns the allocator between steps and asserts cross-rank parameter equality, but I did not observe divergence I could attribute to this bug in production.

**Environment:** torch 2.9.1+cu128, NCCL 2.27.5, CUDA 12.8, 8×H100 (GCE a3-highgpu-8g), nanochat `92d63d4`