### PR TITLE
eval: reject models with future-token leakage

### DIFF
--- a/nanochat/loss_eval.py
+++ b/nanochat/loss_eval.py
@@ -5,6 +5,26 @@ import math
 import torch
 import torch.distributed as dist
 
+
+@torch.no_grad()
+def assert_causal_logits(model, sequence_len=64):
+    """Fail if changing suffix tokens changes logits for the unchanged prefix."""
+    sequence_len = min(sequence_len, model.config.sequence_len)
+    split = sequence_len // 2
+    device = model.get_device()
+    tokens = (
+        torch.arange(sequence_len, device=device).unsqueeze(0)
+        % model.config.vocab_size
+    )
+    changed = tokens.clone()
+    changed[:, split:] = (changed[:, split:] + 1) % model.config.vocab_size
+    logits = model(tokens)
+    changed_logits = model(changed)
+    if not torch.allclose(
+        logits[:, :split], changed_logits[:, :split], atol=1e-5, rtol=1e-5
+    ):
+        raise RuntimeError("model is not causal: suffix tokens changed prefix logits")
+
 @torch.no_grad()
 def evaluate_bpb(model, batches, steps, token_bytes):
     """

--- a/nanochat/loss_eval.py
+++ b/nanochat/loss_eval.py
@@ -8,22 +8,39 @@ import torch.distributed as dist
 
 @torch.no_grad()
 def assert_causal_logits(model, sequence_len=64):
-    """Fail if changing suffix tokens changes logits for the unchanged prefix."""
+    """Fail if changing suffix tokens changes logits for any probed prefix.
+
+    Probe immediately before power-of-two boundaries in addition to the midpoint.
+    A single midpoint check can miss aligned chunk-local leaks (for example, a
+    32-token aggregation block when a 64-token probe is split at position 32).
+    """
     sequence_len = min(sequence_len, model.config.sequence_len)
-    split = sequence_len // 2
+    if sequence_len < 2:
+        return
     device = model.get_device()
     tokens = (
         torch.arange(sequence_len, device=device).unsqueeze(0)
         % model.config.vocab_size
     )
-    changed = tokens.clone()
-    changed[:, split:] = (changed[:, split:] + 1) % model.config.vocab_size
     logits = model(tokens)
-    changed_logits = model(changed)
-    if not torch.allclose(
-        logits[:, :split], changed_logits[:, :split], atol=1e-5, rtol=1e-5
-    ):
-        raise RuntimeError("model is not causal: suffix tokens changed prefix logits")
+
+    split_points = {sequence_len // 2}
+    split = 1
+    while split < sequence_len:
+        split_points.add(split)
+        split = 2 * split + 1
+
+    for split in sorted(split_points):
+        changed = tokens.clone()
+        changed[:, split:] = (changed[:, split:] + 1) % model.config.vocab_size
+        changed_logits = model(changed)
+        if not torch.allclose(
+            logits[:, :split], changed_logits[:, :split], atol=1e-5, rtol=1e-5
+        ):
+            raise RuntimeError(
+                "model is not causal: suffix tokens changed prefix logits "
+                f"at split {split}"
+            )
 
 @torch.no_grad()
 def evaluate_bpb(model, batches, steps, token_bytes):

--- a/scripts/base_eval.py
+++ b/scripts/base_eval.py
@@ -33,7 +33,7 @@ from nanochat.tokenizer import get_token_bytes
 from nanochat.checkpoint_manager import load_model
 from nanochat.core_eval import evaluate_task
 from nanochat.dataloader import tokenizing_distributed_data_loader_bos_bestfit
-from nanochat.loss_eval import evaluate_bpb
+from nanochat.loss_eval import assert_causal_logits, evaluate_bpb
 from nanochat.engine import Engine
 
 # -----------------------------------------------------------------------------
@@ -148,6 +148,8 @@ def main():
     ddp, ddp_rank, ddp_local_rank, ddp_world_size, device = compute_init(device_type)
     # Load model and tokenizer
     model, tokenizer, meta = load_model("base", device, phase="eval", model_tag=args.model_tag, step=args.step)
+    if 'bpb' in eval_modes:
+        assert_causal_logits(model)
     sequence_len = meta["model_config"]["sequence_len"]
     token_bytes = get_token_bytes(device=device)
     model_name = f"base_model (step {meta['step']})"

--- a/tests/test_loss_eval.py
+++ b/tests/test_loss_eval.py
@@ -7,21 +7,42 @@ from nanochat.loss_eval import assert_causal_logits
 
 
 class ToyModel:
-    def __init__(self, leak=False):
+    def __init__(self, leak=None, chunk_size=None):
         self.config = SimpleNamespace(sequence_len=64, vocab_size=64)
         self.leak = leak
+        self.chunk_size = chunk_size
 
     def get_device(self):
         return torch.device("cpu")
 
     def __call__(self, tokens):
         logits = tokens.float().unsqueeze(-1)
-        if self.leak:
+        if self.leak == "global":
             logits = logits + tokens.float().mean(dim=1, keepdim=True).unsqueeze(-1)
+        elif self.leak == "chunk":
+            batch_size, sequence_len = tokens.shape
+            chunks = tokens.float().view(
+                batch_size, sequence_len // self.chunk_size, self.chunk_size
+            )
+            summaries = chunks.mean(dim=2, keepdim=True).expand_as(chunks)
+            logits = logits + summaries.reshape(batch_size, sequence_len).unsqueeze(-1)
+        elif self.leak == "circular":
+            logits = logits + torch.roll(tokens.float(), shifts=-1, dims=1).unsqueeze(-1)
         return logits
 
 
 def test_causal_logits_reject_suffix_leakage():
     assert_causal_logits(ToyModel())
     with pytest.raises(RuntimeError, match="suffix tokens changed prefix logits"):
-        assert_causal_logits(ToyModel(leak=True))
+        assert_causal_logits(ToyModel(leak="global"))
+
+
+@pytest.mark.parametrize("chunk_size", [8, 16, 32, 64])
+def test_causal_logits_reject_aligned_chunk_leakage(chunk_size):
+    with pytest.raises(RuntimeError, match="suffix tokens changed prefix logits"):
+        assert_causal_logits(ToyModel(leak="chunk", chunk_size=chunk_size))
+
+
+def test_causal_logits_reject_circular_leakage():
+    with pytest.raises(RuntimeError, match="suffix tokens changed prefix logits"):
+        assert_causal_logits(ToyModel(leak="circular"))

--- a/tests/test_loss_eval.py
+++ b/tests/test_loss_eval.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from nanochat.loss_eval import assert_causal_logits
+
+
+class ToyModel:
+    def __init__(self, leak=False):
+        self.config = SimpleNamespace(sequence_len=64, vocab_size=64)
+        self.leak = leak
+
+    def get_device(self):
+        return torch.device("cpu")
+
+    def __call__(self, tokens):
+        logits = tokens.float().unsqueeze(-1)
+        if self.leak:
+            logits = logits + tokens.float().mean(dim=1, keepdim=True).unsqueeze(-1)
+        return logits
+
+
+def test_causal_logits_reject_suffix_leakage():
+    assert_causal_logits(ToyModel())
+    with pytest.raises(RuntimeError, match="suffix tokens changed prefix logits"):
+        assert_causal_logits(ToyModel(leak=True))


### PR DESCRIPTION
Fixes #844.

## What changed

- Before BPB evaluation, run a small black-box causality check on 64 tokens.
- Change suffixes after several prefix lengths (1, 3, 7, 15, 31, 32, and 63 for a 64-token probe) and require every unchanged prefix's logits to remain unchanged.
- Raise a clear error when suffix tokens affect prefix predictions.

This catches the reported intra-block aggregation leak, aligned 8/16/32/64-token chunk leaks, and circular/global mixing leaks without banning any particular architecture or changing training. The check costs eight batch-1, 64-token forwards and only runs for BPB evaluation.
