### PR TITLE
Fix FA3 backend selection on Blackwell GPUs

### DIFF
--- a/nanochat/flash_attention.py
+++ b/nanochat/flash_attention.py
@@ -26,8 +26,10 @@ def _load_flash_attention_3():
         return None
     try:
         major, _ = torch.cuda.get_device_capability()
-        # FA3 kernels are currently compiled for Hopper (sm90), Ada (sm89) and Ampere (sm80/sm86)
-        # Blackwell (sm100) needs SDPA fallback until FA3 is recompiled or FA4 is released
+        # Skip the current FA3 kernels on compute capability >= 10.0.
+        # Loading may succeed even when the CUDA kernels cannot run.
+        if major >= 10:
+            return None
         import os
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
         from kernels import get_kernel, has_kernel

--- a/tests/test_attention_fallback.py
+++ b/tests/test_attention_fallback.py
@@ -4,7 +4,7 @@ Test Flash Attention unified interface - verify FA3 and SDPA produce identical r
 Run: python -m pytest tests/test_attention_fallback.py -v -s
 
 Note on test structure:
-    Tests are split into two classes due to dtype/device constraints:
+    Attention execution tests are split into two classes due to dtype/device constraints:
 
     1. TestFA3VsSDPA: Comparison tests that run both FA3 and SDPA on the same inputs
        and verify they produce identical results. These require a compatible GPU (FA3 only
@@ -13,6 +13,10 @@ Note on test structure:
     2. TestSDPAOnly: Tests that only exercise the SDPA fallback path. These can run
        on any device (CUDA, CPU, MPS) with the appropriate dtype for that device.
 """
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, call, sentinel
+
 import torch
 import pytest
 import nanochat.flash_attention as fa_module
@@ -43,6 +47,43 @@ def assert_close(t1, t2, name, atol=1e-2, rtol=1e-2):
     assert torch.allclose(t1, t2, atol=atol, rtol=rtol), \
         f"{name}: max_diff={max_diff:.6f}, mean_diff={mean_diff:.6f}"
     return max_diff, mean_diff
+
+
+# =============================================================================
+# FA3 backend selection (no GPU required)
+# =============================================================================
+@pytest.mark.parametrize("cuda_available,capability_value,kernel_available,expected_repo", [
+    (True, (10, 0), True, None),
+    (True, (12, 0), True, None),
+    (True, (13, 0), True, None),
+    (True, (8, 0), True, "kernels-community/flash-attn3"),
+    (True, (8, 9), True, "kernels-community/flash-attn3"),
+    (True, (8, 0), False, None),
+    (True, (8, 9), False, None),
+    (True, (9, 0), True, "varunneal/flash-attention-3"),
+    (False, (9, 0), True, None),
+])
+def test_fa3_loading(monkeypatch, cuda_available, capability_value, kernel_available, expected_repo):
+    """Select compatible kernels without requiring a GPU or downloading kernels."""
+    kernels = SimpleNamespace(
+        has_kernel=Mock(return_value=kernel_available),
+        get_kernel=Mock(return_value=SimpleNamespace(
+            flash_attn_interface=sentinel.flash_attn_interface,
+        )),
+    )
+    capability = Mock(return_value=capability_value)
+    monkeypatch.setitem(sys.modules, "kernels", kernels)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: cuda_available)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", capability)
+
+    expected = sentinel.flash_attn_interface if expected_repo else None
+    assert fa_module._load_flash_attention_3() is expected
+    assert capability.call_args_list == ([call()] if cuda_available else [])
+    checks_community = cuda_available and capability_value[0] == 8
+    assert kernels.has_kernel.call_args_list == (
+        [call("kernels-community/flash-attn3")] if checks_community else []
+    )
+    assert kernels.get_kernel.call_args_list == ([call(expected_repo)] if expected_repo else [])
 
 
 # =============================================================================


### PR DESCRIPTION
On Blackwell GPUs such as the RTX 5090 (sm_120), the FA3 package can load successfully even though its CUDA kernels cannot execute on the device. This enables FA3 and causes the first attention call to fail with "no kernel image is available for execution on the device", instead of reaching the existing SDPA fallback. The upstream [build configuration](https://github.com/huggingface/kernels-community/blob/main/flash-attn3/build.toml) targets `8.0` and `9.0a`, with no Blackwell target.

Return `None` from `_load_flash_attention_3()` for compute capability major >= 10, before importing or loading kernels. Add mocked regression tests covering Blackwell and a future compute capability, the existing Ampere/Ada and Hopper selection paths, unavailable community kernels, and systems without CUDA.

Fixes #820

Validation:
- Hardware validation: completed depth-24 pretraining (5,568 steps), saved the checkpoint, and completed base evaluation (CORE: 0.2581) on RTX 5090 GPUs (sm_120) using SDPA.
- `python -m pytest tests/test_attention_fallback.py -v`: **14 passed, 10 skipped** on an RTX 5090 with Python 3.10.21 and PyTorch 2.9.1+cu128. FA3-dependent tests were skipped because this GPU uses the SDPA fallback.
- Regression check: replacing the loader in memory with the pre-fix implementation makes all three compute-capability >= 10 cases fail as expected; all nine loader tests pass with the fix.
