### PR TITLE
New record: 91.7 minutes. A 300M-row hashed n-gram table in host RAM + d24 model → 0.70367 val bpb, CORE 0.2578

### DIFF
--- a/nanochat/engram.py
+++ b/nanochat/engram.py
@@ -1,0 +1,322 @@
+"""
+Engram: hashed n-gram lookup tables in host memory, injected into attention values.
+Notable features:
+- one bf16 table in /dev/shm, shared by all ranks and updated lock-free (Hogwild!)
+- each position hashes its trailing n-grams (several salted slots) into rows of the table
+- every engram layer reads its slice of the gathered rows, gates it on a few residual
+  channels, projects it up to the model dim and adds it to that layer's attention values
+- the gathered rows are a GPU autograd leaf; step() applies a row-wise RMSprop update on
+  GPU and writes the rows back to the host asynchronously (stochastic rounding to bf16)
+- the next micro-step's rows are gathered on a worker thread during the current backward
+Hashes roll across document boundaries within a packed sequence (known approximation).
+"""
+
+import concurrent.futures
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+_PRIMES = (1_000_003, 998_244_353, 911_382_323, 805_306_457)
+
+
+def _fused_update_impl(grad, vals, accum_rows, lr, n_layer, n_embd, eps, decay, accum_beta):
+    """Row-wise RMSprop + stochastic rounding to bf16, one kernel."""
+    g = grad.view(-1, n_layer, n_embd)
+    accum_rows = accum_beta * accum_rows + (1.0 - accum_beta) * g.pow(2).mean(dim=-1)
+    scale = lr / (accum_rows.sqrt() + eps)
+    x = vals.float() * (1.0 - decay) - (scale.unsqueeze(-1) * g).view(-1, n_layer * n_embd)
+    # stochastic rounding: round-to-nearest would drop every update below the bf16 ulp
+    noise = torch.randint(0, 1 << 16, x.shape, device=x.device, dtype=torch.int32)
+    out = ((x.view(torch.int32) + noise) & -65536).view(torch.float32).to(torch.bfloat16)
+    return out, accum_rows
+
+
+_FUSED_UPDATE = None
+
+
+def _fused_update(*args):
+    global _FUSED_UPDATE
+    if _FUSED_UPDATE is None:
+        try:
+            _FUSED_UPDATE = torch.compile(_fused_update_impl, dynamic=True) # row count changes every step
+        except Exception:
+            _FUSED_UPDATE = _fused_update_impl
+    try:
+        return _FUSED_UPDATE(*args)
+    except Exception:
+        _FUSED_UPDATE = _fused_update_impl
+        return _fused_update_impl(*args)
+
+
+def largest_prime_at_most(n):
+    """Prime table sizes spread multiplicative hashes much better than powers of two."""
+    def is_prime(m):
+        if m < 2 or m % 2 == 0:
+            return m == 2
+        f = 3
+        while f * f <= m:
+            if m % f == 0:
+                return False
+            f += 2
+        return True
+    n = int(n) | 1
+    while n > 2 and not is_prime(n):
+        n -= 2
+    return n
+
+
+def ngram_hash(idx, table_size, ngram, salt=0):
+    """Hash each position's trailing `ngram` token ids (B, T) into bucket ids in [0, table_size)."""
+    assert 1 <= ngram <= len(_PRIMES)
+    acc = idx * (_PRIMES[0] + salt * 2_654_435_761)
+    for j in range(1, ngram):
+        prev = torch.zeros_like(idx) # missing history (row start, single-token decode) hashes as token 0
+        if j < idx.size(1):
+            prev[:, j:] = idx[:, :-j]
+        acc = acc + prev * (_PRIMES[j] + salt * 40_503)
+    return acc.remainder(table_size)
+
+
+class EngramBank(nn.Module):
+    """The host-resident table (rows x n_layer*n_embd) and its row-wise optimizer."""
+
+    def __init__(self, table_size, n_layer, n_embd, decay, accum_beta):
+        super().__init__()
+        self.table_size = table_size
+        self.n_layer = n_layer
+        self.n_embd = n_embd
+        self.decay = decay
+        self.accum_beta = accum_beta
+        # not persistent: checkpoints hold the model only, the table stays in host memory
+        self.register_buffer("weight", torch.zeros(table_size, n_layer * n_embd, dtype=torch.bfloat16), persistent=False)
+        self.register_buffer("adagrad_accum", torch.zeros(table_size, n_layer), persistent=False)
+        self._pending = [] # (uniq_idx, leaf) per micro-step, consumed by step()
+        self._stage_in = None # pinned staging buffers, sized lazily
+        self._stage_out = None
+        self._pf_slots = [None, None] # double-buffered prefetch
+        self._pf_events = [None, None]
+        self._pf_next_slot = 0
+        self._pf_pending = None
+        self._exec = None # single worker thread => FIFO order over all host-table accesses
+        self._side = None # side CUDA stream for H2D / D2H
+        self._write_future = None
+        self._d2h_event = None
+        self.shared_path = None
+
+    def _worker(self):
+        if self._exec is None:
+            self._exec = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="engram-host")
+        return self._exec
+
+    def _side_stream(self, device):
+        if self._side is None:
+            self._side = torch.cuda.Stream(device=device)
+        return self._side
+
+    def flush(self):
+        """Block until the async host write has landed."""
+        f, self._write_future = self._write_future, None
+        if f is not None:
+            f.result()
+
+    def shutdown(self, unlink_shared=False):
+        self.flush()
+        if self._exec is not None:
+            self._exec.shutdown(wait=True)
+            self._exec = None
+        if unlink_shared and self.shared_path:
+            self.weight = torch.empty(0) # tmpfs pages are freed once the file and every mapping are gone
+            try:
+                os.unlink(self.shared_path)
+            except FileNotFoundError:
+                pass
+
+    def init_weights(self, shared_path, rank=0):
+        """Map the table from one tmpfs file shared by every rank. Zero table => no-op at step 0."""
+        self.flush()
+        need = self.table_size * self.n_layer * self.n_embd * 2
+        st = os.statvfs(os.path.dirname(shared_path) or "/")
+        avail = st.f_bavail * st.f_frsize
+        assert need < 0.9 * avail, f"engram table needs {need/2**30:.1f} GB but {shared_path} has {avail/2**30:.1f} GB free"
+        self.weight = torch.empty(0) # drop the to_empty() storage before mapping the host table
+        fresh = not os.path.exists(shared_path) or os.path.getsize(shared_path) == 0
+        n = self.table_size * self.n_layer * self.n_embd
+        self.weight = torch.from_file(shared_path, shared=True, size=n, dtype=torch.bfloat16).view(self.table_size, -1)
+        if rank == 0 and not fresh: # a freshly created file is sparse and already reads as zero
+            self.weight.zero_()
+        self.shared_path = shared_path
+        self.adagrad_accum.zero_()
+        self._stage_in = None
+        self._stage_out = None
+        self._pf_slots = [None, None]
+        self._pf_events = [None, None]
+        self._pf_pending = None
+
+    def _apply(self, fn, *args, **kwargs):
+        # keep the table out of .to()/.cuda()/to_empty(): it would otherwise be materialized in VRAM
+        saved = self.weight
+        self.weight = torch.empty(0)
+        super()._apply(fn, *args, **kwargs)
+        self.weight = saved
+        return self
+
+    def _staging(self, name, rows):
+        buf = getattr(self, name, None)
+        if buf is None or buf.shape[0] < rows:
+            buf = torch.empty(rows, self.n_layer * self.n_embd, dtype=torch.bfloat16).pin_memory()
+            setattr(self, name, buf)
+        return buf[:rows]
+
+    @torch._dynamo.disable
+    def prefetch(self, buckets):
+        """Gather the rows for a future forward on the worker thread, overlapping the current backward."""
+        if self.weight.numel() == 0 or buckets is None:
+            return
+        device = buckets.device
+        uniq, inv = torch.unique(buckets.reshape(-1), return_inverse=True)
+        uniq_cpu = uniq.to("cpu")
+        n = uniq_cpu.numel()
+        slot = self._pf_next_slot
+        self._pf_next_slot ^= 1
+        buf = self._pf_slots[slot]
+        if buf is None or buf.shape[0] < n:
+            # pin_memory() device-synchronizes, so allocate on the main thread, never in the worker
+            buf = torch.empty(n, self.n_layer * self.n_embd, dtype=torch.bfloat16).pin_memory()
+            self._pf_slots[slot] = buf
+            self._pf_events[slot] = None
+        ev = self._pf_events[slot] or torch.cuda.Event()
+        self._pf_events[slot] = ev
+        self._pf_pending = dict(buckets=buckets, uniq=uniq, uniq_cpu=uniq_cpu, inv=inv,
+                                stage=buf[:n], event=ev, device=device, future=None, gpu_rows=None)
+        self._pf_pending["future"] = self._worker().submit(self._gather_task, self._pf_pending)
+
+    def _gather_task(self, p):
+        ev, stage, device = p["event"], p["stage"], p["device"]
+        if ev.query() is False:
+            ev.synchronize() # the previous H2D that read this slot must be done before we overwrite it
+        torch.index_select(self.weight, 0, p["uniq_cpu"], out=stage)
+        torch.cuda.set_device(device) # thread-local
+        side = self._side_stream(device)
+        with torch.no_grad(), torch.cuda.stream(side):
+            gpu_rows = stage.to(device, non_blocking=True)
+            ev.record(side)
+        return gpu_rows
+
+    def _take_prefetch(self, buckets):
+        """The staged rows if they are for exactly these buckets, else None."""
+        p, self._pf_pending = self._pf_pending, None
+        if p is None:
+            return None
+        p["gpu_rows"] = p["future"].result()
+        if p["buckets"].shape != buckets.shape or not torch.equal(p["buckets"], buckets):
+            return None
+        return p
+
+    def _patch_prefetch(self, merged, new_rows):
+        """A prefetch gathered before this step's write differs from the table only in the rows just
+        updated, which are still on the GPU: patch them in rather than re-reading the host."""
+        p = self._pf_pending
+        if p is None or merged.numel() == 0:
+            return
+        if p["gpu_rows"] is None:
+            p["gpu_rows"] = p["future"].result()
+        gpu_rows = p["gpu_rows"]
+        cur = torch.cuda.current_stream()
+        cur.wait_event(p["event"])
+        gpu_rows.record_stream(cur)
+        uniq = p["uniq"]
+        pos = torch.searchsorted(merged, uniq).clamp_(max=merged.numel() - 1) # both sorted (torch.unique)
+        hit = merged[pos] == uniq
+        if bool(hit.any()):
+            gpu_rows[hit] = new_rows[pos[hit]].to(gpu_rows.dtype)
+
+    @torch._dynamo.disable
+    def _host_gather(self, uniq_gpu, device, dtype):
+        self.flush() # order every synchronous read after the outstanding async write
+        uniq_cpu = uniq_gpu.to("cpu")
+        stage = self._staging("_stage_in", uniq_cpu.numel())
+        torch.index_select(self.weight, 0, uniq_cpu, out=stage)
+        return stage.to(device=device, non_blocking=True).to(dtype)
+
+    @torch._dynamo.disable
+    def lookup(self, buckets, device, dtype):
+        """buckets (G, B, T) -> rows (G, B, T, n_layer*n_embd) on device, as a grad-tracked leaf."""
+        training = self.training and torch.is_grad_enabled()
+        p = self._take_prefetch(buckets) if training else None # eval forwards must not consume the prefetch
+        if p is not None:
+            uniq, inv = p["uniq"], p["inv"]
+            gpu_rows = p["gpu_rows"]
+            cur = torch.cuda.current_stream()
+            cur.wait_event(p["event"])
+            gpu_rows.record_stream(cur) # allocated on the side stream, consumed here
+            leaf = gpu_rows.to(dtype).requires_grad_(True)
+        else:
+            uniq, inv = torch.unique(buckets.reshape(-1), return_inverse=True)
+            leaf = self._host_gather(uniq, device, dtype).requires_grad_(True)
+        if training:
+            self._pending.append((uniq, leaf))
+        return leaf[inv].view(*buckets.shape, self.n_layer * self.n_embd)
+
+    def step(self, lr, eps=1e-8):
+        """Update the rows touched since the last step (grads summed over micro-steps) and write them back."""
+        if not self._pending:
+            return
+        device = self._pending[0][1].device
+        LD = self.n_layer * self.n_embd
+        pending, self._pending = self._pending, []
+        merged, inv = torch.unique(torch.cat([u for u, _ in pending]), return_inverse=True)
+        grad = torch.zeros(merged.numel(), LD, device=device)
+        vals = torch.empty(merged.numel(), LD, dtype=pending[0][1].dtype, device=device) # the leaves hold the current row values
+        off = 0
+        for uniq, leaf in pending:
+            sl = inv[off:off + uniq.numel()]
+            if leaf.grad is not None:
+                grad.index_add_(0, sl, leaf.grad.float())
+            vals[sl] = leaf.detach()
+            off += uniq.numel()
+        accum_rows = self.adagrad_accum[merged]
+        new_rows, accum_new = _fused_update(grad, vals, accum_rows, lr, self.n_layer, self.n_embd, eps, self.decay, self.accum_beta)
+        self.adagrad_accum[merged] = accum_new
+        # write back: D2H on the side stream, host index_copy_ on the worker (no cuda.synchronize())
+        merged_cpu = merged.to("cpu")
+        self.flush() # the previous write has landed, so _stage_out is free
+        stage = self._staging("_stage_out", merged.numel())
+        side = self._side_stream(device)
+        ev = self._d2h_event or torch.cuda.Event()
+        self._d2h_event = ev
+        side.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(side):
+            stage.copy_(new_rows, non_blocking=True)
+            ev.record(side)
+        new_rows.record_stream(side)
+
+        def _write_task(_anchor=new_rows): # the closure keeps new_rows alive until the D2H is done
+            ev.synchronize()
+            self.weight.index_copy_(0, merged_cpu, stage)
+
+        self._write_future = self._worker().submit(_write_task)
+        self._patch_prefetch(merged, new_rows)
+
+
+class EngramLayer(nn.Module):
+    """One layer's view of the bank: gate on the token's residual channels, then project the embedding up."""
+
+    def __init__(self, layer_idx, rank, n_embd, gate_channels):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.gate_channels = gate_channels
+        self.gate = nn.Linear(gate_channels, 1, bias=False)
+        self.up = nn.Linear(rank, n_embd, bias=False)
+
+    def init_weights(self):
+        torch.nn.init.uniform_(self.gate.weight, 0.0, 0.02)
+        torch.nn.init.orthogonal_(self.up.weight) # the embeddings start at zero and first learn through this basis
+
+    def forward(self, x, bank_out):
+        # x: (B, T, n_embd), bank_out: (B, T, n_layer, rank)
+        e = bank_out[:, :, self.layer_idx]
+        gin = x[..., :self.gate_channels]
+        g = torch.sigmoid(F.linear(gin, self.gate.weight.to(gin.dtype)) / self.gate_channels) # fan-in norm: step size independent of width
+        return F.linear(g * e, self.up.weight.to(e.dtype)) # gate the narrow embedding, then project

--- a/nanochat/gpt.py
+++ b/nanochat/gpt.py
@@ -24,6 +24,7 @@ from nanochat.optim import MuonAdamW
 
 # Our custom Flash Attention module that automatically uses FA3 when compatible and SDPA fallback otherwise
 from nanochat.flash_attention import flash_attn
+from nanochat.engram import EngramBank, EngramLayer, ngram_hash, largest_prime_at_most
 
 @dataclass
 class GPTConfig:
@@ -37,6 +38,15 @@ class GPTConfig:
     # Characters: L=long (full context), S=short (quarter context)
     # Examples: "L"=all full context, "SL"=alternating, "SSL"=two short then one long
     window_pattern: str = "SSSL"
+    # Engram: hashed n-gram lookup table in host memory (see nanochat/engram.py)
+    engram_table_size: int = 0 # rows (0 = disabled)
+    engram_layers: str = "" # layers that read the table, e.g. "3,7,11,15"
+    engram_rank: int = 0 # embedding width per layer, split across the hash slots
+    engram_orders: str = "" # n-gram orders, e.g. "2,3"
+    engram_order_weights: str = "" # independently salted hash slots per order, e.g. "2,2"
+    engram_gate_channels: int = 12 # leading residual channels the gate reads
+    engram_decay: float = 0.0 # row decay per touch
+    engram_accum_beta: float = 0.0 # EMA coefficient of the row optimizer's second moment
 
 
 def norm(x):
@@ -81,7 +91,7 @@ class CausalSelfAttention(nn.Module):
         self.ve_gate_channels = 12
         self.ve_gate = Linear(self.ve_gate_channels, self.n_kv_head, bias=False) if has_ve(layer_idx, config.n_layer) else None
 
-    def forward(self, x, ve, cos_sin, window_size, kv_cache):
+    def forward(self, x, ve, cos_sin, window_size, kv_cache, eng_v=None):
         B, T, C = x.size()
 
         # Project the input to get queries, keys, and values
@@ -95,6 +105,9 @@ class CausalSelfAttention(nn.Module):
             ve = ve.view(B, T, self.n_kv_head, self.head_dim)
             gate = 3 * torch.sigmoid(self.ve_gate(x[..., :self.ve_gate_channels]))  # (B, T, n_kv_head), range (0, 3)
             v = v + gate.unsqueeze(-1) * ve
+        if eng_v is not None:
+            assert self.n_kv_head * self.head_dim == eng_v.size(-1), "engram value injection assumes no GQA"
+            v = v + eng_v.view(B, T, self.n_kv_head, self.head_dim)
 
         # Apply Rotary Embeddings to queries and keys to get relative positional encoding
         cos, sin = cos_sin
@@ -147,8 +160,8 @@ class Block(nn.Module):
         self.attn = CausalSelfAttention(config, layer_idx)
         self.mlp = MLP(config)
 
-    def forward(self, x, ve, cos_sin, window_size, kv_cache):
-        x = x + self.attn(norm(x), ve, cos_sin, window_size, kv_cache)
+    def forward(self, x, ve, cos_sin, window_size, kv_cache, eng_v=None):
+        x = x + self.attn(norm(x), ve, cos_sin, window_size, kv_cache, eng_v)
         x = x + self.mlp(norm(x))
         return x
 
@@ -190,6 +203,26 @@ class GPT(nn.Module):
         head_dim = config.n_embd // config.n_head
         kv_dim = config.n_kv_head * head_dim
         self.value_embeds = nn.ModuleDict({str(i): nn.Embedding(padded_vocab_size, kv_dim) for i in range(config.n_layer) if has_ve(i, config.n_layer)})
+        # Engram: one host-resident table, a slice per engram layer, a gate + up-projection per layer
+        if config.engram_table_size > 0:
+            eng_layers = [int(v) for v in config.engram_layers.split(",") if v != ""]
+            assert eng_layers and all(0 <= L < config.n_layer for L in eng_layers), "engram_layers, e.g. 3,7,11,15"
+            self.engram_orders = [int(v) for v in config.engram_orders.split(",") if v != ""]
+            assert self.engram_orders, "engram_orders, e.g. 2,3"
+            w = [int(v) for v in config.engram_order_weights.split(",") if v != ""]
+            self.engram_order_weights = w or [1] * len(self.engram_orders)
+            assert len(self.engram_order_weights) == len(self.engram_orders) and min(self.engram_order_weights) >= 1
+            n_slot = sum(self.engram_order_weights)
+            rank = config.engram_rank
+            assert rank > 0 and rank % n_slot == 0, "engram rank must be a positive multiple of the slot count"
+            rows = largest_prime_at_most(config.engram_table_size)
+            self.engram_table_rows = rows
+            self.engram_bank = EngramBank(rows, len(eng_layers), rank // n_slot, config.engram_decay, config.engram_accum_beta)
+            self.engrams = nn.ModuleDict({str(L): EngramLayer(slot, rank, config.n_embd, config.engram_gate_channels) for slot, L in enumerate(eng_layers)})
+            print0(f"Engram on layers {eng_layers} | embedding {rank} -> {config.n_embd} | orders {self.engram_orders} x slots {self.engram_order_weights} | rows {rows:,}")
+        else:
+            self.engram_bank = None
+            self.engrams = nn.ModuleDict({})
         # To support meta device initialization, we init the rotary embeddings here, but it's just "fake" meta tensors only.
         # As for rotary_seq_len, these rotary embeddings are pretty small/cheap in memory,
         # so let's just over-compute them by 10X, but assert fail if we ever reach that amount.
@@ -201,7 +234,7 @@ class GPT(nn.Module):
         self.register_buffer("sin", sin, persistent=False)
 
     @torch.no_grad()
-    def init_weights(self):
+    def init_weights(self, engram_shared_path=None, engram_rank=0):
         """
         Initialize the full model in this one function for maximum clarity.
 
@@ -253,6 +286,11 @@ class GPT(nn.Module):
         for block in self.transformer.h:
             if block.attn.ve_gate is not None:
                 torch.nn.init.uniform_(block.attn.ve_gate.weight, 0.0, 0.02)
+
+        if self.engram_bank is not None:
+            self.engram_bank.init_weights(engram_shared_path, rank=engram_rank)
+        for e in self.engrams.values():
+            e.init_weights()
 
         # Rotary embeddings
         head_dim = self.config.n_embd // self.config.n_head
@@ -405,9 +443,11 @@ class GPT(nn.Module):
         lm_head = sum(p.numel() for p in self.lm_head.parameters())
         transformer_matrices = sum(p.numel() for p in self.transformer.h.parameters())
         scalars = self.resid_lambdas.numel() + self.x0_lambdas.numel() + self.smear_gate.weight.numel() + self.smear_lambda.numel() + self.backout_lambda.numel()
-        total = wte + value_embeds + lm_head + transformer_matrices + scalars
+        engram = sum(p.numel() for p in self.engrams.parameters())
+        total = wte + value_embeds + lm_head + transformer_matrices + scalars + engram
         assert total == sum(p.numel() for p in self.parameters()), "Parameter count mismatch"
         return {
+            'engram': engram,
             'wte': wte,
             'value_embeds': value_embeds,
             'lm_head': lm_head,
@@ -427,6 +467,9 @@ class GPT(nn.Module):
         resid_params = [self.resid_lambdas]
         x0_params = [self.x0_lambdas]
         smear_params = [self.smear_gate.weight, self.smear_lambda, self.backout_lambda]
+        smear_params = smear_params + [m.gate.weight for m in self.engrams.values()] # engram gates: same treatment as the smear gate
+        matrix_params = matrix_params + [m.up.weight for m in self.engrams.values()] # engram up-projections: Muon like any matrix
+        # (the engram table itself is a buffer, updated by engram_bank.step() in the training script)
         assert len(list(self.parameters())) == len(matrix_params) + len(embedding_params) + len(lm_head_params) + len(value_embeds_params) + len(resid_params) + len(x0_params) + len(smear_params)
 
         # Scale the LR for the AdamW parameters by ∝1/√dmodel (tuned for 768 dim model)
@@ -455,6 +498,24 @@ class GPT(nn.Module):
         for group in optimizer.param_groups:
             group["initial_lr"] = group["lr"]
         return optimizer
+
+    def engram_buckets(self, idx, kv_cache=None):
+        """(G, B, T) bucket ids, one hash per slot, shared by every engram layer."""
+        ngram = max(self.engram_orders)
+        hash_idx = idx
+        if kv_cache is not None: # during decoding, keep the trailing tokens the hashes need
+            hist = getattr(kv_cache, "engram_hist", None)
+            if hist is not None:
+                hash_idx = torch.cat([hist, idx], dim=1)
+            kv_cache.engram_hist = hash_idx[:, -(ngram - 1):] if ngram > 1 else None
+        hs = [ngram_hash(hash_idx, self.engram_table_rows, order, salt=1 + oi * 97 + w * 7919)
+              for oi, order in enumerate(self.engram_orders) for w in range(self.engram_order_weights[oi])]
+        return torch.stack(hs)[..., -idx.size(1):]
+
+    def engram_prefetch(self, idx):
+        """Call between a forward and its backward to gather the next batch's rows during the backward."""
+        if self.engram_bank is not None:
+            self.engram_bank.prefetch(self.engram_buckets(idx))
 
     def forward(self, idx, targets=None, kv_cache=None, loss_reduction='mean'):
         B, T = idx.size()
@@ -493,13 +554,19 @@ class GPT(nn.Module):
 
         # Forward the trunk of the Transformer
         x0 = x  # save initial normalized embedding for x0 residual
+        engram_out = None
+        if self.engram_bank is not None:
+            raw = self.engram_bank.lookup(self.engram_buckets(idx, kv_cache), x.device, x.dtype) # (G, B, T, n_layer*per_slot)
+            G, n_eng = sum(self.engram_order_weights), len(self.engrams)
+            engram_out = raw.view(G, B, T, n_eng, -1).permute(1, 2, 3, 0, 4).reshape(B, T, n_eng, -1) # (B, T, layer, rank)
         n_layer = self.config.n_layer
         backout_layer = n_layer // 2  # cache at halfway point
         x_backout = None
         for i, block in enumerate(self.transformer.h):
             x = self.resid_lambdas[i] * x + self.x0_lambdas[i] * x0
+            eng = self.engrams[str(i)](x, engram_out) if (engram_out is not None and str(i) in self.engrams) else None
             ve = self.value_embeds[str(i)](idx).to(x.dtype) if str(i) in self.value_embeds else None
-            x = block(x, ve, cos_sin, self.window_sizes[i], kv_cache)
+            x = block(x, ve, cos_sin, self.window_sizes[i], kv_cache, eng)
             if i == backout_layer:
                 x_backout = x
         # Subtract mid-layer residual to remove low-level features before logit projection

--- a/scripts/base_train.py
+++ b/scripts/base_train.py
@@ -52,6 +52,16 @@ parser.add_argument("--aspect-ratio", type=int, default=64, help="model_dim = de
 parser.add_argument("--head-dim", type=int, default=128, help="target head dimension for attention")
 parser.add_argument("--max-seq-len", type=int, default=2048, help="max context length")
 parser.add_argument("--window-pattern", type=str, default="SSSL", help="sliding window pattern tiled across layers: L=full, S=half context (e.g. 'SSL')")
+# Engram (hashed n-gram tables in host memory; 0 = disabled)
+parser.add_argument("--engram-table-size", type=int, default=0, help="rows in the engram table (0 = disabled)")
+parser.add_argument("--engram-layers", type=str, default="", help="layers that read the table, e.g. 3,7,11,15")
+parser.add_argument("--engram-rank", type=int, default=0, help="engram embedding width per layer, split across the hash slots")
+parser.add_argument("--engram-orders", type=str, default="", help="n-gram orders to combine, e.g. 2,3")
+parser.add_argument("--engram-order-weights", type=str, default="", help="hash slots per order, e.g. 2,2 (default one each)")
+parser.add_argument("--engram-gate-channels", type=int, default=12, help="leading residual-stream channels the engram gate reads")
+parser.add_argument("--engram-lr", type=float, default=0.1, help="row-wise LR for the host-resident engram table")
+parser.add_argument("--engram-decay", type=float, default=0.0, help="decay applied to a row each time it is written (0 = never forget)")
+parser.add_argument("--engram-accum-beta", type=float, default=0.0, help="EMA coefficient of the row optimizer's second-moment accumulator, e.g. 0.99")
 # Training horizon (only one used, in order of precedence)
 parser.add_argument("--num-iterations", type=int, default=-1, help="explicit number of optimization steps (-1 = disable)")
 parser.add_argument("--target-flops", type=float, default=-1.0, help="calculate num_iterations to reach target_flops (-1 = disable)")
@@ -137,6 +147,12 @@ def build_model_meta(depth):
         sequence_len=args.max_seq_len, vocab_size=vocab_size,
         n_layer=depth, n_head=num_heads, n_kv_head=num_heads, n_embd=model_dim,
         window_pattern=args.window_pattern,
+        engram_table_size=args.engram_table_size if depth == args.depth else 0, # the d12 reference model has no engram
+        engram_rank=args.engram_rank,
+        engram_layers=args.engram_layers, engram_orders=args.engram_orders,
+        engram_order_weights=args.engram_order_weights,
+        engram_gate_channels=args.engram_gate_channels,
+        engram_decay=args.engram_decay, engram_accum_beta=args.engram_accum_beta,
     )
     with torch.device("meta"):
         model_meta = GPT(config)
@@ -148,7 +164,14 @@ model_config = model.config
 model_config_kwargs = asdict(model_config)
 print0(f"Model config:\n{json.dumps(model_config_kwargs, indent=2)}")
 model.to_empty(device=device) # 2) All tensors get storage on target device but with uninitialized (garbage) data
-model.init_weights() # 3) All tensors get initialized
+# Engram: one table in tmpfs, mapped into every rank and updated lock-free (Hogwild!)
+engram_shared_path = None
+if args.engram_table_size > 0:
+    engram_shared_path = f"/dev/shm/nanochat_engram_{args.model_tag or ('d%d' % args.depth)}_{args.engram_table_size}.bin"
+model.init_weights(engram_shared_path=engram_shared_path, engram_rank=ddp_rank) # 3) All tensors get initialized
+if engram_shared_path is not None and ddp_world_size > 1:
+    dist.barrier() # rank 0 has zeroed the shared table before anyone reads it
+    print0(f"Engram: shared table at {engram_shared_path} across {ddp_world_size} ranks")
 
 # If we are resuming, overwrite the model parameters with those of the checkpoint
 base_dir = get_base_dir()
@@ -319,6 +342,12 @@ if resuming:
     optimizer.load_state_dict(optimizer_data)
     del optimizer_data
 
+engram_enabled = args.engram_table_size > 0
+if engram_enabled:
+    assert COMPUTE_DTYPE != torch.float16, "engram rows are outside the optimizer, so the fp16 GradScaler would not unscale them"
+    w = orig_model.engram_bank.weight
+    print0(f"Engram enabled: {orig_model.engram_table_rows:,} rows ({w.numel() * w.element_size() / 1e9:.2f} GB host memory), row lr={args.engram_lr}")
+
 # -----------------------------------------------------------------------------
 # GradScaler for fp16 training (bf16/fp32 don't need it — bf16 has the same exponent range as fp32)
 scaler = torch.amp.GradScaler() if COMPUTE_DTYPE == torch.float16 else None
@@ -331,6 +360,7 @@ dataloader_resume_state_dict = None if not resuming else meta_data["dataloader_s
 train_loader = tokenizing_distributed_data_loader_with_state_bos_bestfit(tokenizer, args.device_batch_size, args.max_seq_len, split="train", device=device, resume_state_dict=dataloader_resume_state_dict)
 build_val_loader = lambda: tokenizing_distributed_data_loader_bos_bestfit(tokenizer, args.device_batch_size, args.max_seq_len, split="val", device=device)
 x, y, dataloader_state_dict = next(train_loader) # kick off load of the very first batch of data
+x, y = x.clone(), y.clone() # the loader reuses its buffers; see the micro-step loop
 
 # -----------------------------------------------------------------------------
 # Calculate the number of iterations we will train for and set up the various schedulers
@@ -511,11 +541,15 @@ while True:
         loss = model(x, y)
         train_loss = loss.detach() # for logging
         loss = loss / grad_accum_steps # each .backward() is a grad sum => normalize loss here
+        # fetch the next batch before backward so its engram rows are gathered during the backward
+        x, y, dataloader_state_dict = next(train_loader)
+        x, y = x.clone(), y.clone() # the loader reuses its buffers and backward still needs the current ids
+        if engram_enabled:
+            orig_model.engram_prefetch(x)
         if scaler is not None:
             scaler.scale(loss).backward()
         else:
             loss.backward()
-        x, y, dataloader_state_dict = next(train_loader) # prefetch the next batch while the GPU is busy with forward/backward
     # step the optimizer
     lrm = get_lr_multiplier(step)
     muon_momentum = get_muon_momentum(step)
@@ -525,6 +559,8 @@ while True:
         if group['kind'] == 'muon':
             group["momentum"] = muon_momentum
             group["weight_decay"] = muon_weight_decay
+    if engram_enabled:
+        orig_model.engram_bank.step(args.engram_lr * lrm)
     if scaler is not None:
         scaler.unscale_(optimizer)
         # In distributed training, all ranks must agree on whether to skip the step.
@@ -592,6 +628,11 @@ while True:
         gc.disable() # nuclear intervention here: disable GC entirely except:
     elif step % 5000 == 0: # every 5000 steps...
         gc.collect() # manually collect, just to be safe for very, very long runs
+
+if engram_enabled: # land the last host write, stop the worker thread, release the shared table
+    if ddp_world_size > 1:
+        dist.barrier()
+    orig_model.engram_bank.shutdown(unlink_shared=master_process)
 
 # print a few more stats
 print0(f"Peak memory usage: {get_max_memory() / 1024 / 1024:.2f}MiB")


### PR DESCRIPTION
Hashed bigram/trigram lookup tables in host RAM, injected into the attention
values of four layers.

- One Engram table in `/dev/shm`, mapped by all eight ranks and updated lock-free (Hogwild!). No VRAM.
- Host IO hidden: rows for the next micro-step are prefetched and updates are written back asynchronously. +1.6% step time at d24.
- Row-wise optimiser on the GPU: state is one scalar per row and Engram layer, kept in VRAM.

| | this PR | Run 6 |
|---|---|---|
| val bpb | **0.703668** | 0.71800 |
| CORE | **0.2578** | 0.262634 |
| total_training_time | **91.74 min** | 99 mins |

Individual runs on the 8x H100 node:

| attempt | val bpb | CORE | total_training_time |
|---|---|---|---|
| 1 | 0.703674 | 0.2592 | 91.56 min |
| 2 | 0.703734 | 0.2557 | 91.63 min |
| 3 | 0.703596 | 0.2584 | 92.03 min |
| mean | 0.703668 | 0.2578 | 91.74 min |

## Launch

```bash
OMP_NUM_THREADS=1 torchrun --standalone --nproc_per_node=8 -m scripts.base_train -- \
    --depth=24 \
    --window-pattern=SSSL \
    --fp8 \
    --device-batch-size=16 \
    --num-iterations=5000 \
    --model-tag=d24-engram \
    --eval-every=500 \
    --sample-every=-1 \
    --save-every=-1 \
    --core-metric-every=999999 \
    --core-metric-max-per-task=-1 \
    --engram-table-size=300000000 \
    --engram-layers=3,7,11,15 \
    --engram-rank=128 \
    --engram-orders=2,3 \
    --engram-order-weights=2,2 \
    --engram-lr=0.2 \
    --engram-gate-channels=12 \
    --engram-accum-beta=0.99 \
    --engram-decay=0.001
```

72 GiB table in `/dev/shm`, released at the end of the run. The checkpoint
holds the model only (4.2 GB): the table is not saved, so the checkpoint is
not a runnable model on its own. Persisting the table is a 72 GB write and is
left out of this PR. Reported numbers are `Minimum validation bpb`, `CORE metric` and
`Total training time` from the log, as for the other leaderboard runs.

## What it does

Each token hashes its last two and three token ids, with two salted hashes per
order, into four rows of one bf16 table. A row is 128 values: a 32-dim slice for
each of the four engram layers. A layer takes its 32-dim slice from each of the
token's four rows and concatenates them (bigram A, bigram B, trigram A, trigram
B) into a 128-dim embedding, gates it on the first 12 residual channels,
projects it to model width and adds it to that layer's attention values. Rows
are zero at init and are trained by a row-wise RMSprop update on the GPU (second
moment EMA 0.99, per-touch decay 1e-3, stochastic rounding to bf16); the table
holds 38.4 billion bf16 values (300M rows x 128) beside 1.38B trainable
parameters.

## Table size scaling

The right table size is set by the data, not the model. What appears to matter
is how many times each row is written over the run. Adding rows keeps improving
loss until each row is written only a few dozen times on average, then the gain
flattens; downstream accuracy peaks somewhat before that point and falls off if
rows are added past it. The table should therefore grow linearly with training
tokens, up to an unknown point where the supply of new n-grams thins out and
the growth turns sublinear.

## Disclosure

Most of the code in this PR was produced by an AI coding assistant working under
my direction (Nihir Patel, nihir.patel@oriolenetworks.com, Oriole Networks). No
autoresearch or other autonomous experimentation was used. Thanks to Alessandro
Ottino (alessandro@oriolenetworks.com) and Robin Matzner
(robin.matzner@oriolenetworks.com), also at Oriole Networks, for discussion and
collaboration along the way.